### PR TITLE
Fix things so Edison can set itself up for Chad from scratch

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/LocationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/LocationResource.java
@@ -85,7 +85,7 @@ public class LocationResource implements
     public static final String ROOT_UUID = "3449f5fe-8e6b-4250-bcaa-fca5df28ddbf";
     public static final String TRIAGE_UUID = "3f75ca61-ec1a-4739-af09-25a84e3dd237";
     // TODO/generalize: The facility name should not be hardcoded here.
-    private static final String ROOT_NAME = "Facility Kailahun";
+    private static final String ROOT_NAME = "ROOT LOCATION";
     // The hard-coded zones. These are (name, UUID) pairs, and are children of
     // the root location.  TODO/generalize: Consider generalizing these zones
     // as well.  They may be common in infectious disease deployments but don't

--- a/openmrs/omod/src/main/java/org/projectbuendia/openmrs/web/controller/ProfileManager.java
+++ b/openmrs/omod/src/main/java/org/projectbuendia/openmrs/web/controller/ProfileManager.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
+import org.openmrs.projectbuendia.webservices.rest.ConfigurationException;
 import org.openmrs.projectbuendia.webservices.rest.GlobalProperties;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
@@ -51,6 +52,19 @@ public class ProfileManager {
     final File PROFILE_DIR = new File("/usr/share/buendia/profiles");
     final String VALIDATE_CMD = "buendia-profile-validate";
     final String APPLY_CMD = "buendia-profile-apply";
+
+    public ProfileManager() {
+        createProfileDirectoryIfNecessary();
+    }
+
+    private void createProfileDirectoryIfNecessary() {
+        if(!PROFILE_DIR.exists()) {
+            if(!PROFILE_DIR.mkdirs()) {
+                throw new ConfigurationException(String.format("Error creating profile dir %s. "
+                    + "Check its write permissions.", PROFILE_DIR.getAbsolutePath()));
+            }
+        }
+    }
 
     @RequestMapping(value = "/module/projectbuendia/openmrs/profiles", method = RequestMethod.GET)
     public void get(HttpServletRequest request, ModelMap model) {

--- a/packages/buendia-db-init/data/usr/share/buendia/db/site-msf-chad-bokoro.sql
+++ b/packages/buendia-db-init/data/usr/share/buendia/db/site-msf-chad-bokoro.sql
@@ -23,11 +23,11 @@ UPDATE global_property SET property_value = 'en, en_GB_client'
 -- Make sure camp and zone locations are present.
 -- ON DUPLICATE IGNORE is safe as there is a unique index on uuid.
 INSERT INTO location (name, creator, date_created, uuid) VALUES
-    ('Chad', @admin_id, NOW(), 'c149ee48-bcda-4661-a3bf-d98847dfd18c')
+    ('ROOT LOCATION', @admin_id, NOW(), '3449f5fe-8e6b-4250-bcaa-fca5df28ddbf')
     ON DUPLICATE KEY UPDATE uuid = uuid;
 
 SELECT @emc_id := location_id FROM location
-    WHERE uuid = 'c149ee48-bcda-4661-a3bf-d98847dfd18c';
+    WHERE uuid = '3449f5fe-8e6b-4250-bcaa-fca5df28ddbf';
 
 INSERT INTO location (name, creator, date_created, uuid, parent_location) VALUES
     ('Bokoro ITFC', @admin_id, NOW(), '69890fb4-49bb-4c14-a834-b1dead6a34df', @emc_id),

--- a/packages/buendia-mysql-python/Makefile
+++ b/packages/buendia-mysql-python/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.inc

--- a/packages/buendia-mysql-python/control/control.template
+++ b/packages/buendia-mysql-python/control/control.template
@@ -1,0 +1,6 @@
+Package: ${PACKAGE_NAME}
+Version: ${PACKAGE_VERSION}
+Architecture: all
+Pre-Depends: buendia-db-init (<=${PACKAGE_VERSION}) | buendia-db-init (>>${PACKAGE_VERSION}), buendia-db-migrate, buendia-utils
+Description: Install MySQLdb Python module
+Maintainer: projectbuendia.org

--- a/packages/buendia-mysql-python/control/preinst.template
+++ b/packages/buendia-mysql-python/control/preinst.template
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright 2015 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+pip install MySQL-python


### PR DESCRIPTION
The issue with locations not showing up was because it is hardcoded to use a "Facility Kailahun" location with a specific UUID as the root location.

The app looks for sub-sub-locations within that, expecting Facility Kailahun to have zones like "Suspect Zone" within it, and then tents like "S1", "S2", etc. within that.

To fix it, I set the root location for the Chad locations to be the location specified in ROOT_UUID.

I also renamed it to a generic name "ROOT LOCATION" instead of something site-specific.

TODO (later): Improve how this is done so that this stuff is defined in the site-specific config file instead of hard-coded in LocationResource.java.

The next issue is that the profile_apply Python script responsible for applying Buendia profiles in the Project Buendia OpenMRS module expects and requires the Python module MySQLdb to be present and installed on the Edison. It isn't.

I think the packages/buendia-mysql-python folder will cause the `pip install MySQL-python` command to be run when the Edison is setting itself up and that will fix that.