### PR TITLE
Changing buendia's configuration folder from '/usr/share/' to '/usr/local/opt'  

### DIFF
--- a/devices/server/setup
+++ b/devices/server/setup
@@ -66,8 +66,8 @@ echo $flashed
 rm -rf /tmp/debian
 mkdir /tmp/debian
 if [ -n "$site_id" ]; then
-    mkdir -p /tmp/debian/usr/share/buendia/site
-    echo "SITE_ID=$site_id" > /tmp/debian/usr/share/buendia/site/id
+    mkdir -p /tmp/debian/usr/local/opt/buendia/site
+    echo "SITE_ID=$site_id" > /tmp/debian/usr/local/opt/buendia/site/id
 fi
 if [ -n "$repo_url" ]; then
     mkdir -p /tmp/debian/etc/apt/sources.list.d

--- a/devices/server/yocto/usr/local/bin/install-buendia-base
+++ b/devices/server/yocto/usr/local/bin/install-buendia-base
@@ -115,7 +115,7 @@ apt-get update
 apt-get -y --allow-unauthenticated install buendia-update
 
 # If a site has been selected, install the site settings package.
-. /usr/share/buendia/site/id || true
+. /usr/local/opt/buendia/site/id || true
 if [ -n "$SITE_ID" ]; then
     apt-get -y --allow-unauthenticated install buendia-site-$SITE_ID
     echo "Buendia site ID configured: $SITE_ID"

--- a/openmrs/omod/src/main/java/org/projectbuendia/openmrs/web/controller/ProfileManager.java
+++ b/openmrs/omod/src/main/java/org/projectbuendia/openmrs/web/controller/ProfileManager.java
@@ -49,7 +49,7 @@ import javax.servlet.http.HttpServletResponse;
 @Controller
 public class ProfileManager {
     static Log log = LogFactory.getLog(ProfileManager.class);
-    final File PROFILE_DIR = new File("/usr/share/buendia/profiles");
+    final File PROFILE_DIR = new File("/usr/local/opt/buendia/profiles");
     final String VALIDATE_CMD = "buendia-profile-validate";
     final String APPLY_CMD = "buendia-profile-apply";
 

--- a/openmrs/omod/src/main/resources/config.xml
+++ b/openmrs/omod/src/main/resources/config.xml
@@ -44,7 +44,7 @@
     <description>
       Name of the currently active profile, which defines the forms and UI customizations for the
       Buendia app.
-      This should be the name of a file in /usr/share/buendia/profiles (including the .csv
+      This should be the name of a file in /usr/local/opt/buendia/profiles (including the .csv
       extension).
     </description>
   </globalProperty>
@@ -87,4 +87,3 @@
   </servlet>
 
 </module>
-

--- a/packages/Makefile.inc
+++ b/packages/Makefile.inc
@@ -43,6 +43,6 @@ $(PACKAGE): tests control/* $(DATA_FILES) $(EXTRA_DATA)
 	$(TOOLS)/mkdeb $@ control $(DATA) $(EXTRA_DATA)
 
 # Site packages can just declare a need for this file and it will be made.
-$(EXTRA_DATA)/usr/share/buendia/site/id:
+$(EXTRA_DATA)/usr/local/opt/buendia/site/id:
 	mkdir -p $$(dirname $@)
 	name=$(PACKAGE_NAME); echo "SITE_ID=$${name#buendia-site-}" > $@

--- a/packages/README.md
+++ b/packages/README.md
@@ -23,21 +23,21 @@ for details.
 If your package adjusts the configuration of another package,
 use `buendia-divert` to move the original configuration file aside.
 Your package should provide the alternate configuration file at
-`/usr/share/buendia/diversions/`*original-path* and call `buendia-divert`
+`/usr/local/opt/buendia/diversions/`*original-path* and call `buendia-divert`
 on the original configuration file in both `postinst` and `prerm`.
 See [`buendia-sshd/control`](buendia-sshd/control) for an example.
 
 If your package uses site-specific settings, they should be defined
-as shell variables in a file in `/usr/share/buendia/site`
-and your package must provide a config script in `/usr/share/buendia/config.d`
+as shell variables in a file in `/usr/local/opt/buendia/site`
+and your package must provide a config script in `/usr/local/opt/buendia/config.d`
 that reads the settings and applies them to the actual service or application
 (e.g. by editing its configuration files and restarting the service).
-Default values should be placed in `/usr/share/buendia/site/10-[name]`;
-these can be overriden by higher-numbered files (for more about settings
-files, see buendia-utils/data/usr/share/buendia/site/README).
+Default values should be placed in `/usr/local/opt/buendia/site/10-[name]`;
+these can be overridden by higher-numbered files (for more about settings
+files, see buendia-utils/data/usr/local/opt/buendia/site/README).
 
 The shell variables and config script should be named after the package;
 for example, a package named `buendia-foo` should have variables with
 names like `FOO_USER` and `FOO_PASSWORD`, default settings in
-/usr/share/buendia/site/10-foo, and a config script at
-`/usr/share/buendia/config.d/foo`.
+/usr/local/opt/buendia/site/10-foo, and a config script at
+`/usr/local/opt/buendia/config.d/foo`.

--- a/packages/buendia-backup/control/postinst
+++ b/packages/buendia-backup/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-backup/control/preinst
+++ b/packages/buendia-backup/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade) service_if_exists cron stop ;;

--- a/packages/buendia-backup/data/etc/cron.d/buendia-backup
+++ b/packages/buendia-backup/data/etc/cron.d/buendia-backup
@@ -2,10 +2,10 @@ SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # Back up to the first /dev/sd* partition we can find.
-0 * * * * root . /usr/share/buendia/utils.sh; if bool "$BACKUP_EXTERNAL"; then for dev in /dev/sd?[0-9]*; do [ -e $dev ] && buendia-log buendia-backup $dev $BACKUP_EXTERNAL_LIMIT_PERCENT && break; done; fi
+0 * * * * root . /usr/local/opt/buendia/utils.sh; if bool "$BACKUP_EXTERNAL"; then for dev in /dev/sd?[0-9]*; do [ -e $dev ] && buendia-log buendia-backup $dev $BACKUP_EXTERNAL_LIMIT_PERCENT && break; done; fi
 
 # Back up to the internal directory.
-10 * * * * root . /usr/share/buendia/utils.sh; [ -n "$BACKUP_INTERNAL_DIR" ] && buendia-log buendia-backup $BACKUP_INTERNAL_DIR $BACKUP_INTERNAL_LIMIT_KB
+10 * * * * root . /usr/local/opt/buendia/utils.sh; [ -n "$BACKUP_INTERNAL_DIR" ] && buendia-log buendia-backup $BACKUP_INTERNAL_DIR $BACKUP_INTERNAL_LIMIT_KB
 
 # Restore from a USB drive
 * * * * * root for dev in /dev/sd?[0-9]*; do [ -e $dev ] && buendia-log buendia-restore $dev && break; done;

--- a/packages/buendia-backup/data/usr/bin/buendia-backup
+++ b/packages/buendia-backup/data/usr/bin/buendia-backup
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 export MYSQL_USER=$OPENMRS_MYSQL_USER
 export MYSQL_PASSWORD=$OPENMRS_MYSQL_PASSWORD
 name=$(basename $0)
@@ -94,12 +94,12 @@ sleep 1  # ensure that keep has the uniquely lowest timestamp in the directory
 
 echo "Saving Buendia configuration..."
 tar cfz "$new_dir/buendia.tar.gz" \
-    /usr/share/buendia \
-    --exclude /usr/share/buendia/config.d \
-    --exclude /usr/share/buendia/db \
-    --exclude /usr/share/buendia/diversions \
-    --exclude /usr/share/buendia/openmrs/modules \
-    --exclude /usr/share/buendia/packages
+    /usr/local/opt/buendia \
+    --exclude /usr/local/opt/buendia/config.d \
+    --exclude /usr/local/opt/buendia/db \
+    --exclude /usr/local/opt/buendia/diversions \
+    --exclude /usr/local/opt/buendia/openmrs/modules \
+    --exclude /usr/local/opt/buendia/packages
 ls -l "$new_dir/buendia.tar.gz"
 
 # ---- Back up the MySQL database.

--- a/packages/buendia-backup/data/usr/bin/buendia-restore
+++ b/packages/buendia-backup/data/usr/bin/buendia-restore
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 export MYSQL_USER=$OPENMRS_MYSQL_USER
 export MYSQL_PASSWORD=$OPENMRS_MYSQL_PASSWORD
 root=$1
@@ -120,27 +120,27 @@ if [ $progress_state -le $PROGRESS_SETTINGS_NEXT ]; then
   # ---- Restore the buendia settings
   echo "Restoring buendia-settings"
   # Restore the nameserver settings
-  mv /usr/share/buendia/names.d /usr/share/buendia/names.$$.d
+  mv /usr/local/opt/buendia/names.d /usr/local/opt/buendia/names.$$.d
   # TODO(nfortescue): investigate tar then move rather than straight tar
   # to reduce time directory is empty
-  if tar -xzf $root/buendia.tar.gz -C / usr/share/buendia/names.d; then
-    rm -rf /usr/share/buendia/names.$$.d
+  if tar -xzf $root/buendia.tar.gz -C / usr/local/opt/buendia/names.d; then
+    rm -rf /usr/local/opt/buendia/names.$$.d
   else # restore the old settings in the event of failure
-    rm -rf /usr/share/buendia/names.d
-    mv /usr/share/buendia/names.$$.d /usr/share/buendia/names.d
+    rm -rf /usr/local/opt/buendia/names.d
+    mv /usr/local/opt/buendia/names.$$.d /usr/local/opt/buendia/names.d
     echo "Failed to extract new settings"
     exit 1
   fi
 
   # Restore backed up site settings
-  mv /usr/share/buendia/site /usr/share/buendia/site.$$
+  mv /usr/local/opt/buendia/site /usr/local/opt/buendia/site.$$
   # TODO(nfortescue): investigate tar then move rather than straight tar
   # to reduce time directory is empty
-  if tar -xzf $root/buendia.tar.gz -C / usr/share/buendia/site; then
-    rm -rf /usr/share/buendia/site.$$
+  if tar -xzf $root/buendia.tar.gz -C / usr/local/opt/buendia/site; then
+    rm -rf /usr/local/opt/buendia/site.$$
   else
-    rm -rf /usr/share/buendia/site
-    mv /usr/share/buendia/site.$$ /usr/share/buendia/site
+    rm -rf /usr/local/opt/buendia/site
+    mv /usr/local/opt/buendia/site.$$ /usr/local/opt/buendia/site
     echo "Failed to extract new site settings"
     exit 1
   fi
@@ -156,7 +156,7 @@ if [ $progress_state -le $PROGRESS_SETTINGS_NEXT ]; then
 
   # As we have changed the settings, we need to source them again. Otherwise
   # usernames and passwords may be wrong for database restore.
-  . /usr/share/buendia/utils.sh
+  . /usr/local/opt/buendia/utils.sh
   export MYSQL_USER=$OPENMRS_MYSQL_USER
   export MYSQL_PASSWORD=$OPENMRS_MYSQL_PASSWORD
 fi

--- a/packages/buendia-dashboard/control/postinst
+++ b/packages/buendia-dashboard/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-dashboard/control/postrm
+++ b/packages/buendia-dashboard/control/postrm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|purge|upgrade|disappear) service_if_exists nginx start ;;

--- a/packages/buendia-dashboard/control/preinst
+++ b/packages/buendia-dashboard/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade) service nginx stop ;;

--- a/packages/buendia-dashboard/control/prerm
+++ b/packages/buendia-dashboard/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|upgrade|deconfigure) service nginx stop ;;

--- a/packages/buendia-dashboard/data/etc/cron.d/buendia-dashboard
+++ b/packages/buendia-dashboard/data/etc/cron.d/buendia-dashboard
@@ -1,11 +1,11 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-*/10 * * * * root /usr/bin/buendia-distill /var/log/large/requests /usr/share/buendia/distilled /var/log/requests
+*/10 * * * * root /usr/bin/buendia-distill /var/log/large/requests /usr/local/opt/buendia/distilled /var/log/requests
 
-*/10 * * * * root /usr/bin/buendia-count /usr/share/buendia/counts
+*/10 * * * * root /usr/bin/buendia-count /usr/local/opt/buendia/counts
 
-5,25,45 * * * * root cd /usr/share/buendia; zip -r dashboard/stats.zip counts distilled
+5,25,45 * * * * root cd /usr/local/opt/buendia; zip -r dashboard/stats.zip counts distilled
 
 # logrotate regularly runs once a day, but we need to run it more often on
 # the /var/log/requests directory as the request logs can grow quickly.

--- a/packages/buendia-dashboard/data/etc/logrotate.d/buendia-dashboard
+++ b/packages/buendia-dashboard/data/etc/logrotate.d/buendia-dashboard
@@ -4,7 +4,7 @@
 # that directory is maintained in the buendia-monitoring package.  With
 # buendia-dashboard installed, however, buendia-distill will frequently
 # empty out /var/log/large/requests -- it processes the request logs, writes
-# out the distilled log information to /usr/share/buendia/distilled, then
+# out the distilled log information to /usr/local/opt/buendia/distilled, then
 # moves the log files away to prevent them from being processed twice.
 # The original logs are placed in /var/log/requests so that they remain
 # available for a while; we need logrotate to clean up /var/log/requests

--- a/packages/buendia-dashboard/data/etc/nginx/sites-available/buendia-dashboard
+++ b/packages/buendia-dashboard/data/etc/nginx/sites-available/buendia-dashboard
@@ -2,13 +2,13 @@ server {
     listen 80;
     listen 9999;
     server_name _;
-    root /usr/share/buendia/dashboard;
+    root /usr/local/opt/buendia/dashboard;
     index index;
 
     location /index {
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_NAME index;
-        fastcgi_param SCRIPT_FILENAME /usr/share/buendia/dashboard/index;
+        fastcgi_param SCRIPT_FILENAME /usr/local/opt/buendia/dashboard/index;
         fastcgi_param REQUEST_METHOD $request_method;
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param QUERY_STRING $query_string;
@@ -16,7 +16,7 @@ server {
     location /client {
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_NAME client;
-        fastcgi_param SCRIPT_FILENAME /usr/share/buendia/dashboard/client;
+        fastcgi_param SCRIPT_FILENAME /usr/local/opt/buendia/dashboard/client;
         fastcgi_param REQUEST_METHOD $request_method;
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param QUERY_STRING $query_string;
@@ -24,7 +24,7 @@ server {
     location /status {
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_NAME status;
-        fastcgi_param SCRIPT_FILENAME /usr/share/buendia/dashboard/status;
+        fastcgi_param SCRIPT_FILENAME /usr/local/opt/buendia/dashboard/status;
         fastcgi_param REQUEST_METHOD $request_method;
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param QUERY_STRING $query_string;
@@ -32,7 +32,7 @@ server {
     location /reboot {
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_NAME reboot;
-        fastcgi_param SCRIPT_FILENAME /usr/share/buendia/dashboard/reboot;
+        fastcgi_param SCRIPT_FILENAME /usr/local/opt/buendia/dashboard/reboot;
         fastcgi_param REQUEST_METHOD $request_method;
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param QUERY_STRING $query_string;
@@ -40,7 +40,7 @@ server {
     location /clock {
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_NAME clock;
-        fastcgi_param SCRIPT_FILENAME /usr/share/buendia/dashboard/clock;
+        fastcgi_param SCRIPT_FILENAME /usr/local/opt/buendia/dashboard/clock;
         fastcgi_param REQUEST_METHOD $request_method;
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param QUERY_STRING $query_string;

--- a/packages/buendia-dashboard/data/usr/bin/buendia-count
+++ b/packages/buendia-dashboard/data/usr/bin/buendia-count
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-. /usr/share/buendia/utils.sh
+. /usr/local/opt/buendia/utils.sh
 
 out_dir="$1"
 if [ -z "$out_dir" ]; then

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/client
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/client
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-cd /usr/share/buendia/packages
+cd /usr/local/opt/buendia/packages
 latest=$(ls -t buendia-client*.apk | head -1)
 
 cat <<EOF

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
@@ -14,7 +14,7 @@ tail -5 /var/log/buendia/buendia-warmup.log | grep -q Success && updown=SERVING 
 
 uptime=$(uptime | sed -e 's/.* up//' -e 's/, *[0-9][0-9]* *user.*//')
 
-cd /usr/share/buendia/counts
+cd /usr/local/opt/buendia/counts
 latest=$(ls -t *.count | head -1)
 cdot='&#xb7;'
 if [ -f "$latest" ]; then

--- a/packages/buendia-db-init/Makefile
+++ b/packages/buendia-db-init/Makefile
@@ -1,11 +1,11 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/db/init.zip
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/db/init.zip
 
 $(TOP)/db-snapshot/ID $(TOP)/db-snapshot/*.sql $(TOP)/db-snapshot/*.txt:
 	cd $(TOP); git submodule update --init db-snapshot
 
-$(EXTRA_DATA)/usr/share/buendia/db/init.zip: $(TOP)/db-snapshot/ID $(TOP)/db-snapshot/*.sql $(TOP)/db-snapshot/*.txt
+$(EXTRA_DATA)/usr/local/opt/buendia/db/init.zip: $(TOP)/db-snapshot/ID $(TOP)/db-snapshot/*.sql $(TOP)/db-snapshot/*.txt
 	@mkdir -p $$(dirname $@)
 	@echo Packing up init.zip...
 	@zip -qj $@ $^

--- a/packages/buendia-db-init/control/postinst
+++ b/packages/buendia-db-init/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-remove|abort-deconfigure)
@@ -27,10 +27,10 @@ case $1 in
         export MYSQL_PASSWORD=$MYSQL_ROOT_PASSWORD
         service mysql start
         echo "Loading initial OpenMRS database..."
-        buendia-mysql-load -f openmrs /usr/share/buendia/db/init.zip
+        buendia-mysql-load -f openmrs /usr/local/opt/buendia/db/init.zip
 
         # Add site-specific initial data.
-        site_sql=/usr/share/buendia/db/site-${SITE_ID}.sql
+        site_sql=/usr/local/opt/buendia/db/site-${SITE_ID}.sql
         if [ -f $site_sql ]; then
             echo "Applying data initialization for site ${SITE_ID}..."
             mysql -uroot -p$MYSQL_ROOT_PASSWORD openmrs < $site_sql

--- a/packages/buendia-db-init/control/preinst
+++ b/packages/buendia-db-init/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade)

--- a/packages/buendia-db/control/preinst.template
+++ b/packages/buendia-db/control/preinst.template
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case \$1 in
     install)

--- a/packages/buendia-monitoring/control/postinst
+++ b/packages/buendia-monitoring/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/logrotate.conf
 

--- a/packages/buendia-monitoring/control/prerm
+++ b/packages/buendia-monitoring/control/prerm
@@ -10,6 +10,6 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/logrotate.conf

--- a/packages/buendia-monitoring/data/usr/bin/buendia-apply-limits
+++ b/packages/buendia-monitoring/data/usr/bin/buendia-apply-limits
@@ -1,6 +1,6 @@
 #/bin/bash
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 if [ "$1" = "-h" ]; then
     echo "Usage: $0"

--- a/packages/buendia-monitoring/data/usr/bin/buendia-log
+++ b/packages/buendia-monitoring/data/usr/bin/buendia-log
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 if [ "$1" = "" -o "$1" = "-h" ]; then
     echo "Usage: $0 [-y] <command>"

--- a/packages/buendia-monitoring/data/usr/share/buendia/diversions/etc/logrotate.conf
+++ b/packages/buendia-monitoring/data/usr/share/buendia/diversions/etc/logrotate.conf
@@ -99,7 +99,7 @@ missingok
 # Keep 5 MB for everything else.  Total: ~60 MB.
 /var/log/*.log
 /var/log/buendia/*.log
-/usr/share/buendia/openmrs/*.log
+/usr/local/opt/buendia/openmrs/*.log
 {
     olddir old
 }

--- a/packages/buendia-mysql/control/postinst
+++ b/packages/buendia-mysql/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure)
@@ -23,4 +23,3 @@ case $1 in
 
     *) exit 1
 esac
-

--- a/packages/buendia-mysql/control/preinst
+++ b/packages/buendia-mysql/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade) service_if_exists cron stop ;;

--- a/packages/buendia-mysql/data/usr/share/buendia/config.d/mysql
+++ b/packages/buendia-mysql/data/usr/share/buendia/config.d/mysql
@@ -10,13 +10,13 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 # Provide a randomly generated MySQL root password.
-generated=/usr/share/buendia/site/20-mysql
+generated=/usr/local/opt/buendia/site/20-mysql
 if [ ! -e $generated ]; then
     echo "MYSQL_ROOT_PASSWORD=$(buendia-mkpass)" > $generated
-    . /usr/share/buendia/utils.sh  # reload settings
+    . /usr/local/opt/buendia/utils.sh  # reload settings
 fi
 
 # Check if MySQL is already configured with the desired root password.

--- a/packages/buendia-networking/control/postinst
+++ b/packages/buendia-networking/control/postinst
@@ -15,7 +15,7 @@
 # at the provided ip addres of this machine after the access point is up.
 # Finally it signals apt that it requires a boot.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/dnsmasq.conf
 
@@ -65,4 +65,3 @@ EOF
 
     *) exit 1
 esac
-

--- a/packages/buendia-networking/control/prerm
+++ b/packages/buendia-networking/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/dnsmasq.conf
 

--- a/packages/buendia-networking/data/etc/init.d/buendia-networking
+++ b/packages/buendia-networking/data/etc/init.d/buendia-networking
@@ -18,7 +18,7 @@
 # Default-Start: 2 3 4 5
 # Default-Stop: 0 1 6
 # Short-Description: Applies the Buendia network configuration.
-# Description: Configures networking according to the settings in /usr/share/buendia/site.
+# Description: Configures networking according to the settings in /usr/local/opt/buendia/site.
 ### END INIT INFO
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin

--- a/packages/buendia-networking/data/usr/bin/buendia-update-hosts
+++ b/packages/buendia-networking/data/usr/bin/buendia-update-hosts
@@ -26,7 +26,7 @@ unset CLICOLOR
 unset CLICOLOR_FORCE
 unset LSCOLORS
 unset LS_COLORS
-names=$(echo $(hostname) $(cat /usr/share/buendia/names.d/* | sed -e 's/#.*//'))
+names=$(echo $(hostname) $(cat /usr/local/opt/buendia/names.d/* | sed -e 's/#.*//'))
 
 # Add a line for each of the machine's IP addresses.
 for ip in $(ifconfig | grep -o 'inet addr:[0-9.]\+' | sed -e 's/.*://'); do

--- a/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
+++ b/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
@@ -19,7 +19,7 @@
 # fallen off the wifi network, and kicks wpa_supplicant to make it rejoin.
 
 set -e
-. /usr/share/buendia/utils.sh
+. /usr/local/opt/buendia/utils.sh
 
 # If a software update is in progress, we don't want to interfere with it.
 exec 9> /var/run/lock/buendia-update

--- a/packages/buendia-networking/data/usr/share/buendia/config.d/networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/networking
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 # Update the /etc/hosts file with mappings for this machine's IP addresses.
 buendia-update-hosts
@@ -72,7 +72,7 @@ if $(bool $NETWORKING_DHCP_DNS_SERVER); then
     buendia-enter-yocto <<< "ifconfig wlan0 up $NETWORKING_IP_ADDRESS"
 
     # Enable dnsmasq now, and also for future boots.  dnsmasq.conf is
-    # managed in /usr/share/buendia/diversions, so we only need to turn it on.
+    # managed in /usr/local/opt/buendia/diversions, so we only need to turn it on.
     service dnsmasq restart
     update-rc.d dnsmasq enable
 

--- a/packages/buendia-ntpserver/control/postinst
+++ b/packages/buendia-ntpserver/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/ntp.conf
 
@@ -21,4 +21,3 @@ case $1 in
 
     *) exit 1
 esac
-

--- a/packages/buendia-ntpserver/control/preinst
+++ b/packages/buendia-ntpserver/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade) service_if_exists ntp stop ;;

--- a/packages/buendia-ntpserver/control/prerm
+++ b/packages/buendia-ntpserver/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/ntp.conf
 

--- a/packages/buendia-ntpserver/data/usr/share/buendia/diversions/etc/ntp.conf
+++ b/packages/buendia-ntpserver/data/usr/share/buendia/diversions/etc/ntp.conf
@@ -12,7 +12,7 @@ server 1.debian.pool.ntp.org iburst
 server 2.debian.pool.ntp.org iburst
 server 3.debian.pool.ntp.org iburst
 
-# Access control configuration: see /usr/share/doc/ntp-doc/html/accopt.html
+# Access control configuration: see /usr/local/opt/doc/ntp-doc/html/accopt.html
 # or http://support.ntp.org/bin/view/Support/AccessRestrictions for details.
 # Note that "restrict" applies to both servers and clients, so a configuration
 # that might be intended to block requests from certain clients could also end

--- a/packages/buendia-openmrs/control/postinst
+++ b/packages/buendia-openmrs/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)
@@ -47,8 +47,8 @@ case $1 in
         fi
 
         # Point tomcat7 at our openmrs directory.
-        chown -R tomcat7:root /usr/share/buendia/openmrs
-        ln -sf /usr/share/buendia/openmrs /usr/share/tomcat7/.OpenMRS
+        chown -R tomcat7:root /usr/local/opt/buendia/openmrs
+        ln -sf /usr/local/opt/buendia/openmrs /usr/share/tomcat7/.OpenMRS
 
         # Bring tomcat7 back up.
         service tomcat7 start

--- a/packages/buendia-openmrs/control/postrm
+++ b/packages/buendia-openmrs/control/postrm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|purge|upgrade|disappear)

--- a/packages/buendia-openmrs/control/preinst
+++ b/packages/buendia-openmrs/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade) service_if_exists tomcat7 stop ;;

--- a/packages/buendia-openmrs/control/prerm
+++ b/packages/buendia-openmrs/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|upgrade|deconfigure) service tomcat7 stop ;;

--- a/packages/buendia-openmrs/data/usr/share/buendia/config.d/openmrs
+++ b/packages/buendia-openmrs/data/usr/share/buendia/config.d/openmrs
@@ -10,14 +10,14 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
-properties=/usr/share/buendia/openmrs/openmrs-runtime.properties
+set -e; . /usr/local/opt/buendia/utils.sh
+properties=/usr/local/opt/buendia/openmrs/openmrs-runtime.properties
 
 # Provide a randomly generated password for openmrs_user.
-generated=/usr/share/buendia/site/20-openmrs
+generated=/usr/local/opt/buendia/site/20-openmrs
 if [ ! -e $generated ]; then
     echo "OPENMRS_MYSQL_PASSWORD=$(buendia-mkpass)" > $generated
-    . /usr/share/buendia/utils.sh  # reload settings
+    . /usr/local/opt/buendia/utils.sh  # reload settings
 fi
 
 # Check if the MySQL server is already configured with this user and password.

--- a/packages/buendia-pkgserver/control/postinst
+++ b/packages/buendia-pkgserver/control/postinst
@@ -10,12 +10,12 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)
         # Make all subdirectories executable and readable
-        chmod -R +rX /usr/share/buendia/packages
+        chmod -R +rX /usr/local/opt/buendia/packages
 
         # Disable the default nginx website
         rm -f /etc/nginx/sites-enabled/default

--- a/packages/buendia-pkgserver/control/postrm
+++ b/packages/buendia-pkgserver/control/postrm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|purge|upgrade|disappear)

--- a/packages/buendia-pkgserver/control/preinst
+++ b/packages/buendia-pkgserver/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade)

--- a/packages/buendia-pkgserver/control/prerm
+++ b/packages/buendia-pkgserver/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|upgrade|deconfigure)

--- a/packages/buendia-pkgserver/data/etc/nginx/sites-available/buendia-packages
+++ b/packages/buendia-pkgserver/data/etc/nginx/sites-available/buendia-packages
@@ -1,6 +1,6 @@
 server {
     listen 9001;
-    root /usr/share/buendia/packages;
+    root /usr/local/opt/buendia/packages;
     autoindex on;
     server_name _;
 }

--- a/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-import
+++ b/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-import
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 name=$(basename $0)
 source="$1"
 
@@ -25,9 +25,9 @@ if [ "$1" = "-h" -o "$source" = "" ]; then
     echo
     echo "A bundle file is a zip file containing:"
     echo "  - .deb or .apk files, which will be placed at"
-    echo "    /usr/share/buendia/packages and served by the package server"
+    echo "    /usr/local/opt/buendia/packages and served by the package server"
     echo "  - settings files with names of the form NN-anything (where NN is"
-    echo "    a number), which will be copied into /usr/share/buendia/site"
+    echo "    a number), which will be copied into /usr/local/opt/buendia/site"
     echo "  - a file named commands.sh, which will be executed as a bash"
     echo "    script by root with the unpacked bundle as the current directory"
     echo
@@ -67,11 +67,11 @@ function adjust_filename() {
 }
 
 # Create temporary directories for mounting and extraction. $pkgdir should be
-# located on the same filesystem as /usr/share/buendia/packages so that any
+# located on the same filesystem as /usr/local/opt/buendia/packages so that any
 # packages dropped there can be moved into the repo instantaneously.
 name=$(basename $0)
 exdir=/tmp/$name.ex.$$
-pkgdir=/usr/share/buendia/packages.import.$$
+pkgdir=/usr/local/opt/buendia/packages.import.$$
 rm -rf $exdir $pkgdir
 mkdir -p $exdir $pkgdir
 
@@ -143,7 +143,7 @@ if [ -n "$unpacked" ]; then
             buendia-led red on || true
             buendia-led yellow on || true
             s=s; [ "$count" == 1 ] && s= || true
-            if mv $pkgdir/* /usr/share/buendia/packages; then
+            if mv $pkgdir/* /usr/local/opt/buendia/packages; then
                 echo "Imported $count package$s."
             else
                 echo "Error trying to import $count package$s; continuing."
@@ -152,7 +152,7 @@ if [ -n "$unpacked" ]; then
             # Regenerate indexes.
             buendia-pkgserver-index-debs || true
             buendia-pkgserver-index-apks || true
-            chmod -R a+rX /usr/share/buendia/packages || true
+            chmod -R a+rX /usr/local/opt/buendia/packages || true
         fi
 
         # Copy over site settings files.
@@ -161,7 +161,7 @@ if [ -n "$unpacked" ]; then
                 # Installing update: red and yellow
                 buendia-led red on || true
                 buendia-led yellow on || true
-                target=/usr/share/buendia/site/"$file"
+                target=/usr/local/opt/buendia/site/"$file"
                 if cp "$file" "$target"; then
                     echo "Installed $target."
                 else
@@ -183,7 +183,7 @@ if [ -n "$unpacked" ]; then
         cd "$source"
         if [ -n "$settings_changed" ]; then
             echo "Settings changed.  Files:"
-            ls -l /usr/share/buendia/site
+            ls -l /usr/local/opt/buendia/site
             echo "Applying new settings:"
             buendia-settings || true
             # Applying changes: red and yellow
@@ -205,4 +205,3 @@ if [ -n "$unpacked" ]; then
 else
     echo "No bundles found."
 fi
-

--- a/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-index-apks
+++ b/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-index-apks
@@ -13,10 +13,10 @@
 import sys, os, subprocess, json
 
 def get_setting(name, default=None):
-    """Get the value for a Buendia setting from /usr/share/buendia/site."""
+    """Get the value for a Buendia setting from /usr/local/opt/buendia/site."""
     try:
         value = subprocess.check_output("""
-            /bin/bash -c 'source /usr/share/buendia/utils.sh; echo -n "$%s"'
+            /bin/bash -c 'source /usr/local/opt/buendia/utils.sh; echo -n "$%s"'
         """ % name, shell=True)
     except subprocess.CalledProcessError:
         return default
@@ -71,5 +71,4 @@ if __name__ == '__main__':
         print("Requires $PKGSERVER_URL to be set to the base url.")
         exit(1)
     # Create the index of the default location for buendia packages
-    create_index('/usr/share/buendia/packages', base_url)
-
+    create_index('/usr/local/opt/buendia/packages', base_url)

--- a/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-index-debs
+++ b/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-index-debs
@@ -17,11 +17,11 @@ if [ "$1" = "-h" ]; then
     echo
     echo "Creates or updates the Release and Package indexes for the pool"
     echo "of .deb files located at the given directory.  If unspecified,"
-    echo "the repository directory defaults to /usr/share/buendia/packages."
+    echo "the repository directory defaults to /usr/local/opt/buendia/packages."
     exit 1
 fi
 
-repo=${1:-/usr/share/buendia/packages}
+repo=${1:-/usr/local/opt/buendia/packages}
 
 tmp=$repo.new.$$
 rm -rf $tmp

--- a/packages/buendia-pushclock/control/postinst
+++ b/packages/buendia-pushclock/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure)

--- a/packages/buendia-server/Makefile
+++ b/packages/buendia-server/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.inc
 
 SOURCE_DIR=$(HOME)/openmrs/server/modules
-TARGET_DIR=$(EXTRA_DATA)/usr/share/buendia/openmrs/modules
+TARGET_DIR=$(EXTRA_DATA)/usr/local/opt/buendia/openmrs/modules
 MAIN_MODULE=$(TARGET_DIR)/buendia-server.omod
 OTHER_MODULES=$(TARGET_DIR)/xforms-4.3.5.omod $(TARGET_DIR)/webservices.rest-2.6.omod
 

--- a/packages/buendia-server/control/postinst
+++ b/packages/buendia-server/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)
@@ -18,9 +18,9 @@ case $1 in
         buendia-reconfigure server
 
         # Make sure the profiles directory exists and is writeable by the tomcat7 group
-        mkdir -p /usr/share/buendia/profiles
-        chgrp tomcat7 /usr/share/buendia/profiles
-        chmod g+w /usr/share/buendia/profiles
+        mkdir -p /usr/local/opt/buendia/profiles
+        chgrp tomcat7 /usr/local/opt/buendia/profiles
+        chmod g+w /usr/local/opt/buendia/profiles
 
         # Make the warmup script run once on startup
         update-rc.d buendia-server defaults

--- a/packages/buendia-server/control/postrm
+++ b/packages/buendia-server/control/postrm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|purge|upgrade|disappear) service_if_exists tomcat7 start ;;

--- a/packages/buendia-server/control/preinst
+++ b/packages/buendia-server/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade) service_if_exists tomcat7 stop ;;

--- a/packages/buendia-server/control/prerm
+++ b/packages/buendia-server/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|upgrade|deconfigure) service tomcat7 stop ;;

--- a/packages/buendia-server/data/usr/share/buendia/config.d/server
+++ b/packages/buendia-server/data/usr/share/buendia/config.d/server
@@ -10,13 +10,13 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 # Provide a randomly generated password for the Buendia user, if necessary.
-generated=/usr/share/buendia/site/20-server
+generated=/usr/local/opt/buendia/site/20-server
 if [ ! -e $generated -o -z "$SERVER_OPENMRS_PASSWORD" ]; then
     echo "SERVER_OPENMRS_PASSWORD=$(buendia-mkpass)" > $generated
-    . /usr/share/buendia/utils.sh  # reload settings
+    . /usr/local/opt/buendia/utils.sh  # reload settings
 fi
 
 # Set up the Buendia user account.

--- a/packages/buendia-setclock/control/postinst
+++ b/packages/buendia-setclock/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure)

--- a/packages/buendia-site-demo/Makefile
+++ b/packages/buendia-site-demo/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/site/id

--- a/packages/buendia-site-demo/control/postinst
+++ b/packages/buendia-site-demo/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-site-demo/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-demo/data/usr/share/buendia/site/40-site
@@ -15,9 +15,9 @@ MONITORING_LIMITS='
 50000 /var/backups/buendia/backup*
 100000 /var/backups/buendia
 
-100000 /usr/share/buendia/packages
+100000 /usr/local/opt/buendia/packages
 
-20000 /usr/share/buendia/openmrs/openmrs.log /usr/share/buendia/openmrs/formentry /usr/share/buendia/openmrs/xforms
+20000 /usr/local/opt/buendia/openmrs/openmrs.log /usr/local/opt/buendia/openmrs/formentry /usr/local/opt/buendia/openmrs/xforms
 '
 
 # Create the buendia-demo wifi network and provide DHCP/DNS.

--- a/packages/buendia-site-dev/Makefile
+++ b/packages/buendia-site-dev/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/site/id

--- a/packages/buendia-site-dev/control/postinst
+++ b/packages/buendia-site-dev/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-site-dev/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-dev/data/usr/share/buendia/site/40-site
@@ -15,9 +15,9 @@ MONITORING_LIMITS='
 500000 /var/backups/buendia/backup*
 1000000 /var/backups/buendia
 
-100000 /usr/share/buendia/packages
+100000 /usr/local/opt/buendia/packages
 
-100000 /usr/share/buendia/openmrs/openmrs.log /usr/share/buendia/openmrs/formentry /usr/share/buendia/openmrs/xforms
+100000 /usr/local/opt/buendia/openmrs/openmrs.log /usr/local/opt/buendia/openmrs/formentry /usr/local/opt/buendia/openmrs/xforms
 '
 
 # dev site does not run buendia-pkgserver.

--- a/packages/buendia-site-integration/Makefile
+++ b/packages/buendia-site-integration/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/site/id

--- a/packages/buendia-site-integration/control/postinst
+++ b/packages/buendia-site-integration/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-site-integration/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-integration/data/usr/share/buendia/site/40-site
@@ -15,9 +15,9 @@ MONITORING_LIMITS='
 500000 /var/backups/buendia/backup*
 1000000 /var/backups/buendia
 
-100000 /usr/share/buendia/packages
+100000 /usr/local/opt/buendia/packages
 
-100000 /usr/share/buendia/openmrs/openmrs.log /usr/share/buendia/openmrs/formentry /usr/share/buendia/openmrs/xforms
+100000 /usr/local/opt/buendia/openmrs/openmrs.log /usr/local/opt/buendia/openmrs/formentry /usr/local/opt/buendia/openmrs/xforms
 '
 
 PKGSERVER_URL=http://integration.projectbuendia.org:9001

--- a/packages/buendia-site-lon/Makefile
+++ b/packages/buendia-site-lon/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/site/id

--- a/packages/buendia-site-lon/control/postinst
+++ b/packages/buendia-site-lon/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-site-lon/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-lon/data/usr/share/buendia/site/40-site
@@ -15,9 +15,9 @@ MONITORING_LIMITS='
 50000 /var/backups/buendia/backup*
 100000 /var/backups/buendia
 
-100000 /usr/share/buendia/packages
+100000 /usr/local/opt/buendia/packages
 
-5000 /usr/share/buendia/openmrs/openmrs.log /usr/share/buendia/openmrs/formentry /usr/share/buendia/openmrs/xforms
+5000 /usr/local/opt/buendia/openmrs/openmrs.log /usr/local/opt/buendia/openmrs/formentry /usr/local/opt/buendia/openmrs/xforms
 '
 
 # Create the buendia-lon wifi network and provide DHCP/DNS.

--- a/packages/buendia-site-msf-chad-bokoro/Makefile
+++ b/packages/buendia-site-msf-chad-bokoro/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/site/id

--- a/packages/buendia-site-msf-chad-bokoro/control/postinst
+++ b/packages/buendia-site-msf-chad-bokoro/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-site-msf-chad-bokoro/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-msf-chad-bokoro/data/usr/share/buendia/site/40-site
@@ -15,9 +15,9 @@ MONITORING_LIMITS='
 50000 /var/backups/buendia/backup*
 100000 /var/backups/buendia
 
-100000 /usr/share/buendia/packages
+100000 /usr/local/opt/buendia/packages
 
-20000 /usr/share/buendia/openmrs/openmrs.log /usr/share/buendia/openmrs/formentry /usr/share/buendia/openmrs/xforms
+20000 /usr/local/opt/buendia/openmrs/openmrs.log /usr/local/opt/buendia/openmrs/formentry /usr/local/opt/buendia/openmrs/xforms
 '
 
 # Join and provide DHCP/DNS to the buendia wifi network.

--- a/packages/buendia-site-msf-ks/Makefile
+++ b/packages/buendia-site-msf-ks/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/site/id

--- a/packages/buendia-site-msf-ks/control/postinst
+++ b/packages/buendia-site-msf-ks/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-site-msf-ks/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-msf-ks/data/usr/share/buendia/site/40-site
@@ -15,9 +15,9 @@ MONITORING_LIMITS='
 50000 /var/backups/buendia/backup*
 100000 /var/backups/buendia
 
-100000 /usr/share/buendia/packages
+100000 /usr/local/opt/buendia/packages
 
-20000 /usr/share/buendia/openmrs/openmrs.log /usr/share/buendia/openmrs/formentry /usr/share/buendia/openmrs/xforms
+20000 /usr/local/opt/buendia/openmrs/openmrs.log /usr/local/opt/buendia/openmrs/formentry /usr/local/opt/buendia/openmrs/xforms
 '
 
 # Join and provide DHCP/DNS to the buendia wifi network.
@@ -27,4 +27,3 @@ NETWORKING_DHCP_DNS_SERVER=1
 
 # Keep the Edison up to date.
 UPDATE_AUTOUPDATE=1
-

--- a/packages/buendia-site-msf-mg/Makefile
+++ b/packages/buendia-site-msf-mg/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/site/id

--- a/packages/buendia-site-msf-mg/control/postinst
+++ b/packages/buendia-site-msf-mg/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-site-msf-mg/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-msf-mg/data/usr/share/buendia/site/40-site
@@ -15,9 +15,9 @@ MONITORING_LIMITS='
 50000 /var/backups/buendia/backup*
 100000 /var/backups/buendia
 
-100000 /usr/share/buendia/packages
+100000 /usr/local/opt/buendia/packages
 
-20000 /usr/share/buendia/openmrs/openmrs.log /usr/share/buendia/openmrs/formentry /usr/share/buendia/openmrs/xforms
+20000 /usr/local/opt/buendia/openmrs/openmrs.log /usr/local/opt/buendia/openmrs/formentry /usr/local/opt/buendia/openmrs/xforms
 '
 
 # Join and provide DHCP/DNS to the buendia wifi network.

--- a/packages/buendia-site-test/Makefile
+++ b/packages/buendia-site-test/Makefile
@@ -1,3 +1,3 @@
 include ../Makefile.inc
 
-$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/local/opt/buendia/site/id

--- a/packages/buendia-site-test/control/postinst
+++ b/packages/buendia-site-test/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-site-test/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-test/data/usr/share/buendia/site/40-site
@@ -13,7 +13,7 @@ MONITORING_LIMITS='
 50000 /var/backups/buendia/backup*
 100000 /var/backups/buendia
 
-100000 /usr/share/buendia/packages
+100000 /usr/local/opt/buendia/packages
 '
 
 # Creates the buendia-test wifi network and provides DHCP/DNS.

--- a/packages/buendia-sshd/control/postinst
+++ b/packages/buendia-sshd/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/ssh/sshd_config
 

--- a/packages/buendia-sshd/control/postrm
+++ b/packages/buendia-sshd/control/postrm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|purge|upgrade|disappear) service_if_exists ssh start ;;

--- a/packages/buendia-sshd/control/preinst
+++ b/packages/buendia-sshd/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade) service_if_exists ssh stop ;;

--- a/packages/buendia-sshd/control/prerm
+++ b/packages/buendia-sshd/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/ssh/sshd_config
 

--- a/packages/buendia-tomcat7/control/postinst
+++ b/packages/buendia-tomcat7/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/default/tomcat7
 buendia-divert $1 /etc/tomcat7/server.xml

--- a/packages/buendia-tomcat7/control/postrm
+++ b/packages/buendia-tomcat7/control/postrm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     remove|purge|upgrade|disappear) service_if_exists tomcat7 start ;;

--- a/packages/buendia-tomcat7/control/preinst
+++ b/packages/buendia-tomcat7/control/preinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     install|upgrade) service_if_exists tomcat7 stop ;;

--- a/packages/buendia-tomcat7/control/prerm
+++ b/packages/buendia-tomcat7/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /etc/default/tomcat7
 buendia-divert $1 /etc/tomcat7/server.xml

--- a/packages/buendia-tomcat7/data/usr/share/buendia/config.d/tomcat7
+++ b/packages/buendia-tomcat7/data/usr/share/buendia/config.d/tomcat7
@@ -10,13 +10,13 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 # Provide a randomly generated Tomcat admin password.
-generated=/usr/share/buendia/site/20-tomcat7
+generated=/usr/local/opt/buendia/site/20-tomcat7
 if [ ! -e $generated ]; then
     echo "TOMCAT7_ADMIN_PASSWORD=$(buendia-mkpass)" > $generated
-    . /usr/share/buendia/utils.sh  # reload settings
+    . /usr/local/opt/buendia/utils.sh  # reload settings
 fi
 
 # Apply the settings to the Tomcat configuration.
@@ -26,4 +26,4 @@ unindent <<< "
         <user username='admin' password='$TOMCAT7_ADMIN_PASSWORD'
             roles='manager-gui' />
     </tomcat-users>
-" | create /usr/share/buendia/diversions/etc/tomcat7/tomcat-users.xml
+" | create /usr/local/opt/buendia/diversions/etc/tomcat7/tomcat-users.xml

--- a/packages/buendia-update/control/postinst
+++ b/packages/buendia-update/control/postinst
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-update/data/usr/bin/buendia-autoupdate
+++ b/packages/buendia-update/data/usr/bin/buendia-autoupdate
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 if [ "$1" = "-h" ]; then
     echo "Usage: $0 [-u <seconds>]"
@@ -24,7 +24,7 @@ if [ "$1" = "-h" ]; then
     echo "changed in the local repository since the last run."
     echo
     echo "Performs the update only if UPDATE_AUTOUPDATE is set to 1 in"
-    echo "/usr/share/buendia/site."
+    echo "/usr/local/opt/buendia/site."
     echo
     echo "Specify -u <n> to perform the update only if the machine has been"
     echo "up for at least <n> seconds.  Use this option to avoid running"
@@ -47,8 +47,8 @@ if ! bool $UPDATE_AUTOUPDATE; then
 fi
 
 # Tracks the last successfully completed update triggered by this script.
-success=/usr/share/buendia/autoupdate.success
-packages=/usr/share/buendia/packages
+success=/usr/local/opt/buendia/autoupdate.success
+packages=/usr/local/opt/buendia/packages
 
 # To keep from locking the package cache too often, skip out if we can
 # determine that there are no reachable servers with updates available.

--- a/packages/buendia-update/data/usr/bin/buendia-update
+++ b/packages/buendia-update/data/usr/bin/buendia-update
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 name=$(basename $0)
 
 if [ "$1" = "-h" ]; then
@@ -50,7 +50,7 @@ apt-get -V -y -f install || true
 if [ -n "$1" ]; then
     packages=$*
 else
-    packages=$(echo $(sed -e 's/#.*//' /usr/share/buendia/packages.list.d/*))
+    packages=$(echo $(sed -e 's/#.*//' /usr/local/opt/buendia/packages.list.d/*))
 fi
 echo
 echo "--- Updating packages: $packages"

--- a/packages/buendia-utils/control/postinst
+++ b/packages/buendia-utils/control/postinst
@@ -10,13 +10,13 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 case $1 in
     configure)
         cat <<EOF | buendia-enter-yocto
-        if [ -d /debian/usr/share/buendia/systemd ]; then
-            cp /debian/usr/share/buendia/systemd/* /lib/systemd/system
+        if [ -d /debian/usr/local/opt/buendia/systemd ]; then
+            cp /debian/usr/local/opt/buendia/systemd/* /lib/systemd/system
             systemctl enable reboot-check.timer
             systemctl start reboot-check.timer
         fi

--- a/packages/buendia-utils/control/prerm
+++ b/packages/buendia-utils/control/prerm
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 buendia-divert $1 /sbin/reboot
 update-rc.d buendia-utils remove

--- a/packages/buendia-utils/data/usr/bin/buendia-divert
+++ b/packages/buendia-utils/data/usr/bin/buendia-divert
@@ -12,7 +12,7 @@
 
 verb=$1
 original=$2
-replacement=${3-/usr/share/buendia/diversions$original}
+replacement=${3-/usr/local/opt/buendia/diversions$original}
 package=${4-$DPKG_MAINTSCRIPT_PACKAGE}
 
 if [ "$original" = "" ]; then
@@ -24,7 +24,7 @@ if [ "$original" = "" ]; then
     echo "  - <original> is the absolute path to the original file to divert;"
     echo "    it will be moved aside and replaced by a symlink."
     echo "  - <replacement> is the path to a file provided by your package;"
-    echo "    optional, defaults to /usr/share/buendia/diversions/<original>."
+    echo "    optional, defaults to /usr/local/opt/buendia/diversions/<original>."
     echo "  - <package> is the name of your package (the package performing"
     echo "    the diversion); optional, defaults to \$DPKG_MAINTSCRIPT_PACKAGE."
     exit 1

--- a/packages/buendia-utils/data/usr/bin/buendia-reconfigure
+++ b/packages/buendia-utils/data/usr/bin/buendia-reconfigure
@@ -10,12 +10,12 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+set -e; . /usr/local/opt/buendia/utils.sh
 
 if [ "$1" = "-h" ]; then
     echo "Usage: $0 [-f] [<package-name>...]"
     echo
-    echo "Re-applies settings in /usr/share/buendia/site/* to the services"
+    echo "Re-applies settings in /usr/local/opt/buendia/site/* to the services"
     echo "managed by Buendia packages.  If no package names are specified,"
     echo "all Buendia packages are reconfigured."
     echo
@@ -33,7 +33,7 @@ fi
 
 function reconfigure_package() {
     package=$1
-    config=/usr/share/buendia/config.d/$package
+    config=/usr/local/opt/buendia/config.d/$package
     if [ -f $config ]; then
         if [ -n "$force" ]; then
             echo "Force-reconfiguring buendia-$package..."
@@ -61,7 +61,7 @@ if [ -n "$1" ]; then
         reconfigure_package $package
     done
 else
-    for config in /usr/share/buendia/config.d/*; do
+    for config in /usr/local/opt/buendia/config.d/*; do
         if [ -f $config -a -x $config ]; then
             reconfigure_package $(basename $config)
         fi

--- a/packages/buendia-utils/data/usr/bin/buendia-settings
+++ b/packages/buendia-utils/data/usr/bin/buendia-settings
@@ -11,7 +11,7 @@
 # specific language governing permissions and limitations under the License.
 
 # Prints out all the settings.  The settings are determined by the files
-# in /usr/share/buendia/site, which are evaluated in order.  Files that
+# in /usr/local/opt/buendia/site, which are evaluated in order.  Files that
 # come later in the order (higher number) can override settings that were
 # set earlier in the order.  This script evaluates all the files and then
 # prints out the final values of all the variables.
@@ -26,7 +26,7 @@ old_vars=$(set | cut -f1 -d=)  # run once
 
 old_vars=$(set | cut -f1 -d=)  # collect the list of old variables
 
-for file in /usr/share/buendia/site/*; do [ -f $file ] && . $file || true; done
+for file in /usr/local/opt/buendia/site/*; do [ -f $file ] && . $file || true; done
 new_vars=$(set | cut -f1 -d=)  # collect ths list of new variables
 
 old_list=$(echo . $old_vars .)

--- a/packages/buendia-utils/data/usr/bin/buendia-status
+++ b/packages/buendia-utils/data/usr/bin/buendia-status
@@ -11,7 +11,7 @@
 # specific language governing permissions and limitations under the License.
 
 # Print as much status information as possible, rather than quitting on error.
-. /usr/share/buendia/utils.sh; set +e
+. /usr/local/opt/buendia/utils.sh; set +e
 
 if [ "$1" = "-a" ]; then
     all=1
@@ -35,7 +35,7 @@ case "$UPDATE_AUTOUPDATE" in
     *) echo "UPDATE_AUTOUPDATE is currently enabled." ;;
 esac
 
-packages=$(echo $(sed -e 's/#.*//' /usr/share/buendia/packages.list.d/* | sort))
+packages=$(echo $(sed -e 's/#.*//' /usr/local/opt/buendia/packages.list.d/* | sort))
 echo -e "Keeping updated:\n    $packages" | fmt -w 79 -c -t
 
 if [ -n "$all" ]; then
@@ -57,8 +57,8 @@ if [ -n "$all" ]; then
         echo -e '\n---- ifconfig wlan0'
         ifconfig wlan0
 
-        echo -e '\n---- ls -l /usr/share/buendia/site'
-        ls -l /usr/share/buendia/site
+        echo -e '\n---- ls -l /usr/local/opt/buendia/site'
+        ls -l /usr/local/opt/buendia/site
 
         echo -e '\n---- netstat -ln'
         netstat -ln
@@ -92,4 +92,3 @@ if [ -n "$all" ]; then
         ps -e -w -w -o pid,ppid,time,start,rss,pmem,pcpu,command --sort -pmem | grep -F "$(echo $procs | tr ' ' '\n')"
     ) 2>&1
 fi
-

--- a/packages/buendia-utils/data/usr/share/buendia/config.d/README
+++ b/packages/buendia-utils/data/usr/share/buendia/config.d/README
@@ -1,6 +1,6 @@
 # Configuration scripts for each package go in this directory.  The job
-# of configuration scripts is to apply the settings in /usr/share/buendia/site
+# of configuration scripts is to apply the settings in /usr/local/opt/buendia/site
 # to the rest of the system.  For example, if the buendia-foo package has a
-# web page with a colour that is configured by the FOO_COLOR setting, the
-# package should provide a script at /usr/share/buendia/config.d/foo that reads
-# the FOO_COLOR setting and updates the web page to have the desired colour.
+# web page with a color that is configured by the FOO_COLOR setting, the
+# package should provide a script at /usr/local/opt/buendia/config.d/foo that reads
+# the FOO_COLOR setting and updates the web page to have the desired color.

--- a/packages/buendia-utils/data/usr/share/buendia/diversions/README
+++ b/packages/buendia-utils/data/usr/share/buendia/diversions/README
@@ -1,5 +1,5 @@
 # Diversions of existing files owned by other packages go in this directory.
 # If the file to replaced is at $path, then its replacement should be at
-# /usr/share/buendia/diversions/$path.  For example, if a package wants to
-# replace /etc/motd, it should include /usr/share/buendia/diversions/etc/motd
+# /usr/local/opt/buendia/diversions/$path.  For example, if a package wants to
+# replace /etc/motd, it should include /usr/local/opt/buendia/diversions/etc/motd
 # and invoke "buendia-divert $1 /etc/motd" in its postinst and prerm scripts.

--- a/packages/buendia-utils/data/usr/share/buendia/utils.sh
+++ b/packages/buendia-utils/data/usr/share/buendia/utils.sh
@@ -9,10 +9,10 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-# Buendia shell scripts should all do ". /usr/share/buendia/utils.sh"
+# Buendia shell scripts should all do ". /usr/local/opt/buendia/utils.sh"
 
 # Read all the settings.
-for file in /usr/share/buendia/site/*; do [ -f $file ] && . $file || true; done
+for file in /usr/local/opt/buendia/site/*; do [ -f $file ] && . $file || true; done
 
 # Writes stdin to a file, creating any parent directories as needed.
 function create() {
@@ -39,4 +39,4 @@ function service_if_exists() {
 }
 
 # A handy shortcut, just for typing convenience.
-usb=usr/share/buendia
+usb=usr/local/opt/buendia

--- a/packages/tests/check-config-syntax
+++ b/packages/tests/check-config-syntax
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-for config in data/usr/share/buendia/config.d/*; do
+for config in data/usr/local/opt/buendia/config.d/*; do
     base=$(basename "$config")
     if [ -e $config -a "$base" != README ]; then
         if [ ! -x $config ]; then

--- a/packages/tests/check-filenames
+++ b/packages/tests/check-filenames
@@ -13,15 +13,15 @@
 PACKAGE_NAME=$(basename $(pwd))
 
 # Check that Buendia files in *.d directories are named after the Buendia
-# package that owns them.  Within /usr/share/buendia the "buendia-" prefix
+# package that owns them.  Within /usr/local/opt/buendia the "buendia-" prefix
 # is redundant and therefore omitted.
 
 for dir in $(find data -name '*.d'); do
     case $dir:$PACKAGE_NAME in
         data/etc/apt/sources.list.d:*) name=buendia.list ;;
         data/etc/udev/rules.d:*) continue ;;
-        data/usr/share/buendia/*:buendia-site-*) name=site ;;
-        data/usr/share/buendia/*:*) name=${PACKAGE_NAME#buendia-} ;;
+        data/usr/local/opt/buendia/*:buendia-site-*) name=site ;;
+        data/usr/local/opt/buendia/*:*) name=${PACKAGE_NAME#buendia-} ;;
         *) name=$PACKAGE_NAME
     esac
 
@@ -38,13 +38,13 @@ done
 
 # Check that settings files in the site/ directory are named after the package.
 
-if [ -e data/usr/share/buendia/site ]; then
+if [ -e data/usr/local/opt/buendia/site ]; then
     case $PACKAGE_NAME in
         buendia-site-*) name=site ;;
         *) name=${PACKAGE_NAME#buendia-} ;;
     esac
 
-    for file in data/usr/share/buendia/site/*; do
+    for file in data/usr/local/opt/buendia/site/*; do
         base=$(basename $file)
         if [ -e "$file" -a "$base" != README ]; then
             case $base in

--- a/packages/tests/check-package-list
+++ b/packages/tests/check-package-list
@@ -12,7 +12,7 @@
 
 PACKAGE_NAME=$(basename $(pwd))
 
-for file in data/usr/share/buendia/packages.list.d/*; do
+for file in data/usr/local/opt/buendia/packages.list.d/*; do
     if [ -e $file ]; then
         if [ -x $file ]; then
             echo "$file should not be executable.  Please chmod a-x all files in packages.list.d/ before building."
@@ -31,7 +31,7 @@ for file in data/usr/share/buendia/packages.list.d/*; do
 done
 
 if [[ $PACKAGE_NAME = buendia-site-* ]]; then
-    file=data/usr/share/buendia/packages.list.d/site
+    file=data/usr/local/opt/buendia/packages.list.d/site
     if [ ! -e $file ]; then
         # Site packages should contain a package list.
         echo "Missing package list: $file."

--- a/packages/tests/check-site-syntax
+++ b/packages/tests/check-site-syntax
@@ -11,7 +11,7 @@
 # specific language governing permissions and limitations under the License.
 
 result=0
-for file in data/usr/share/buendia/site/*; do
+for file in data/usr/local/opt/buendia/site/*; do
     if [ -e $file ]; then
         if [ -x $file ]; then
             echo "$file should not be executable.  Please chmod a-x all files in site/ before building."

--- a/tools/make_fresh_dump.sh
+++ b/tools/make_fresh_dump.sh
@@ -35,7 +35,7 @@ fi
 
 # Dump the database on SRC_HOST.
 cat <<EOF | ssh -p $SRC_PORT $SRC bash
-. /usr/share/buendia/utils.sh
+. /usr/local/opt/buendia/utils.sh
 export MYSQL_USER=root MYSQL_PASSWORD=\$MYSQL_ROOT_PASSWORD
 buendia-mysql-dump $SRC_DATABASE dump.zip
 EOF
@@ -51,7 +51,7 @@ SRC_HOST= SRC_PORT= SRC_USER= SRC_DATABASE= SRC=
 
 # Load the dump into the scratch area.
 cat <<EOF | ssh -p $WORK_PORT $WORK bash
-. /usr/share/buendia/utils.sh
+. /usr/local/opt/buendia/utils.sh
 export MYSQL_USER=root MYSQL_PASSWORD=\$MYSQL_ROOT_PASSWORD
 buendia-mysql-load -f $WORK_DATABASE dump.zip
 EOF
@@ -60,13 +60,13 @@ EOF
 # back in a starting state.
 scp -P $WORK_PORT clear_server.sql $WORK:
 cat <<EOF | ssh -p $WORK_PORT $WORK bash
-. /usr/share/buendia/utils.sh
+. /usr/local/opt/buendia/utils.sh
 mysql -uroot -p\$MYSQL_ROOT_PASSWORD $WORK_DATABASE < clear_server.sql
 EOF
 
 # Dump the cleaned database.
 cat <<EOF | ssh -p $WORK_PORT $WORK bash
-. /usr/share/buendia/utils.sh
+. /usr/local/opt/buendia/utils.sh
 export MYSQL_USER=root MYSQL_PASSWORD=\$MYSQL_ROOT_PASSWORD
 buendia-mysql-dump $WORK_DATABASE clean-dump.zip
 EOF


### PR DESCRIPTION
The buendia's configuration file under `/usr/share/` folder should conflict with Security policies like Apple's System Integrity Protection on 'OS X El Capitan' which prevents even users with root privilege from creating folders under `/usr`(except under `/usr/local`).