### PR TITLE
Fix client issue #56. App crashes when profile section name and profile label name are equal.

### DIFF
--- a/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilderEx.java
+++ b/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilderEx.java
@@ -257,19 +257,6 @@ public class BuendiaXformBuilderEx {
             String sectionName = FormUtil.getXmlToken(formField.getField().getName());
             String name = FormUtil.getNewTag(sectionName, tagList);
 
-            if (formField.getParent() != null && fieldTokens.values().contains(name)) {
-                String parentName = fieldTokens.get(formField.getParent());
-                String token = parentName + "_" + name;
-
-                if (!bindings.containsKey(token)) {
-                    token = FormUtil.getNewTag(FormUtil.getXmlToken(formField.getParent()
-                        .getField().getName()), new Vector<String>());
-                    token = token + "_" + name;
-                }
-
-                name = token;
-            }
-
             fieldTokens.put(formField, name);
 
             Field field = formField.getField();


### PR DESCRIPTION
This PR fixes [client issue #56](https://github.com/projectbuendia/client/issues/56).

Here are my thoughts about this change:

 * The condition which checks the repeated name between section and label is
````
        if (formField.getParent() != null && fieldTokens.values().contains(name)) {
```
The form (label) has to have a parent (section) and the section name matches the label name.
If so, the could would try to generate another name key, concatenating the section name and the label name (which will be the same).
```
                String parentName = fieldTokens.get(formField.getParent());
                String token = parentName + "_" + name;
```
Then the code checks if this new token was already populated in `bindings` by `BuendiaXformBuilder.parseTemplate` method. If not, it generates another different token and overwrites the field name (what for ???).

```
...
                if (!bindings.containsKey(token)) {
                    token = FormUtil.getNewTag(FormUtil.getXmlToken(formField.getParent()
                        .getField().getName()), new Vector<String>());
                    token = token + "_" + name;
                }
                name = token;
...
```
I believe the problem is here. The new name is not being added in `bindings` and it will throw `throw new IllegalArgumentException("No bind node for bindName " + bindName);` later. But we can't just add this new token into `bindings` because the output xml is not expecting this token either and client would throw a `ParseException`. But, in fact, i can't see what's the point of this code snippet. 
Pre-appending the section name before the label name would work only to avoid conflicts among labels in different sections, but the current code already does that.

Here are my test scenarios and the result, after this fix:
1. When a section name is equal to a label name (The real issue, in fact)
<img width="984" alt="nutrition-simpletest_01 spreadsheet" src="https://cloud.githubusercontent.com/assets/665045/10837965/18e19e6e-7ea7-11e5-9222-b5e09dcb3bce.png">
![nutrition-simpletest_01 android](https://cloud.githubusercontent.com/assets/665045/10837974/295a74dc-7ea7-11e5-883e-2b84fd907034.png)

2. When a section name is equal to a label name and the label is duplicated
<img width="981" alt="nutrition-simpletest_02 spreadsheet" src="https://cloud.githubusercontent.com/assets/665045/10838001/768fea52-7ea7-11e5-9a2f-8e2e9dca4675.png">
![nutrition-simpletest_02 android](https://cloud.githubusercontent.com/assets/665045/10838004/833a049a-7ea7-11e5-8fb2-cdf0d5bc0ce7.png)

3. Happy path (no duplicated names)
<img width="981" alt="nutrition-simpletest_03 spreadsheet" src="https://cloud.githubusercontent.com/assets/665045/10838013/ab0c340c-7ea7-11e5-87b0-48ae7832616b.png">
![nutrition-simpletest_03 android](https://cloud.githubusercontent.com/assets/665045/10838014/af4dbb30-7ea7-11e5-8090-ae15f9021e9e.png)

4. Duplicated label name between different sections
<img width="985" alt="nutrition-simpletest_04 spreadsheet" src="https://cloud.githubusercontent.com/assets/665045/10838033/e7c956fe-7ea7-11e5-994e-54e2cccb58b5.png">
![nutrition-simpletest_04 spreadsheet01](https://cloud.githubusercontent.com/assets/665045/10838034/eb0abdc6-7ea7-11e5-82e2-919df4f9579a.png)
![nutrition-simpletest_04 spreadsheet02](https://cloud.githubusercontent.com/assets/665045/10838035/ef4eb194-7ea7-11e5-9800-25d60a5bda80.png)

5. Duplicated label names, but different from section name.
<img width="981" alt="nutrition-simpletest_05 spreadsheet" src="https://cloud.githubusercontent.com/assets/665045/10838078/3cf82c22-7ea8-11e5-9cd1-d932f99e22bc.png">
![nutrition-simpletest_05 android](https://cloud.githubusercontent.com/assets/665045/10838079/3f8d6a92-7ea8-11e5-9cfd-586790d9250a.png)

Please, let me know if there are scenarios that i could possible be missing.
  





