### PR TITLE
Cleanup some API method names for better consistency

### DIFF
--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/ProjectBuendiaService.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/ProjectBuendiaService.java
@@ -16,6 +16,7 @@ import org.openmrs.api.OpenmrsService;
 import org.projectbuendia.openmrs.api.db.ProjectBuendiaDAO;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.List;
 
@@ -39,5 +40,5 @@ public interface ProjectBuendiaService extends OpenmrsService {
      * Returns all encounters modified on or after the given {code date}.
      * @param date if {@code null}, returns all encounters since the beginning of time.
      */
-    List<Encounter> getEncountersModifiedOnOrAfter(Date date);
+    List<Encounter> getEncountersCreatedAtOrAfter(@Nullable Date date);
 }

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/ProjectBuendiaDAO.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/ProjectBuendiaDAO.java
@@ -14,11 +14,12 @@ package org.projectbuendia.openmrs.api.db;
 import org.openmrs.Encounter;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
 
+import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.List;
 
 /** Database methods for {@link ProjectBuendiaService}. */
 public interface ProjectBuendiaDAO {
-    List<Encounter> getEncountersCreatedAtOrAfter(Date date);
+    List<Encounter> getEncountersCreatedAtOrAfter(@Nullable Date date);
 
 }

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/hibernate/HibernateProjectBuendiaDAO.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/hibernate/HibernateProjectBuendiaDAO.java
@@ -19,6 +19,7 @@ import org.hibernate.criterion.Restrictions;
 import org.openmrs.Encounter;
 import org.projectbuendia.openmrs.api.db.ProjectBuendiaDAO;
 
+import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class HibernateProjectBuendiaDAO implements ProjectBuendiaDAO {
     }
 
     @Override
-    public List<Encounter> getEncountersCreatedAtOrAfter(Date date) {
+    public List<Encounter> getEncountersCreatedAtOrAfter(@Nullable Date date) {
         // NOTES:
         // - this code relies on the assumption that observations can't be modified independently of
         // encounters.

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/impl/ProjectBuendiaServiceImpl.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/impl/ProjectBuendiaServiceImpl.java
@@ -34,7 +34,7 @@ public class ProjectBuendiaServiceImpl extends BaseOpenmrsService implements Pro
     }
 
     @Override
-    public List<Encounter> getEncountersModifiedOnOrAfter(@Nullable Date date) {
+    public List<Encounter> getEncountersCreatedAtOrAfter(@Nullable Date date) {
         return dao.getEncountersCreatedAtOrAfter(date);
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
@@ -15,7 +15,6 @@ import org.openmrs.Concept;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
-import org.openmrs.api.EncounterService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -67,7 +66,7 @@ public class EncounterResource
         } catch (ParseException e) {
             throw new IllegalArgumentException("Date Format invalid, expected ISO 8601");
         }
-        return buendiaService.getEncountersModifiedOnOrAfter(syncFrom);
+        return buendiaService.getEncountersCreatedAtOrAfter(syncFrom);
     }
 
     /**


### PR DESCRIPTION
In response to comments on #20, I renamed some API methods from `getEncountersModifiedOnOrAfter` to `getEncountersCreatedAtOrAfter`. I missed a couple of places though.