### PR TITLE
Provide an endpoint for syncing observations directly instead of sync…

### DIFF
--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/ProjectBuendiaService.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/ProjectBuendiaService.java
@@ -11,7 +11,7 @@
 
 package org.projectbuendia.openmrs.api;
 
-import org.openmrs.Encounter;
+import org.openmrs.Obs;
 import org.openmrs.api.OpenmrsService;
 import org.projectbuendia.openmrs.api.db.ProjectBuendiaDAO;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,8 +37,10 @@ public interface ProjectBuendiaService extends OpenmrsService {
     void setDAO(ProjectBuendiaDAO dao);
 
     /**
-     * Returns all encounters modified on or after the given {code date}.
-     * @param date if {@code null}, returns all encounters since the beginning of time.
+     * Returns all observations modified on or after the given {@code date}.
+     * @param date if {@code null}, returns all observations since the beginning of time
+     * @param includeVoided if {@code true}, returns observations that have been voided since the
+     *                      specified {@code date}.
      */
-    List<Encounter> getEncountersCreatedAtOrAfter(@Nullable Date date);
+    List<Obs> getObservationsModifiedAtOrAfter(@Nullable Date date, boolean includeVoided);
 }

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/ProjectBuendiaDAO.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/ProjectBuendiaDAO.java
@@ -11,7 +11,7 @@
 
 package org.projectbuendia.openmrs.api.db;
 
-import org.openmrs.Encounter;
+import org.openmrs.Obs;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
 
 import javax.annotation.Nullable;
@@ -20,6 +20,6 @@ import java.util.List;
 
 /** Database methods for {@link ProjectBuendiaService}. */
 public interface ProjectBuendiaDAO {
-    List<Encounter> getEncountersCreatedAtOrAfter(@Nullable Date date);
 
+    List<Obs> getObservationsModifiedAtOrAfter(@Nullable Date date, boolean includeVoided);
 }

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/impl/ProjectBuendiaServiceImpl.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/impl/ProjectBuendiaServiceImpl.java
@@ -13,7 +13,7 @@ package org.projectbuendia.openmrs.api.impl;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openmrs.Encounter;
+import org.openmrs.Obs;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
 import org.projectbuendia.openmrs.api.db.ProjectBuendiaDAO;
@@ -34,7 +34,7 @@ public class ProjectBuendiaServiceImpl extends BaseOpenmrsService implements Pro
     }
 
     @Override
-    public List<Encounter> getEncountersCreatedAtOrAfter(@Nullable Date date) {
-        return dao.getEncountersCreatedAtOrAfter(date);
+    public List<Obs> getObservationsModifiedAtOrAfter(@Nullable Date date, boolean includeVoided) {
+        return dao.getObservationsModifiedAtOrAfter(date, includeVoided);
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2015 The Project Buendia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at: http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distrib-
+ * uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.openmrs.projectbuendia.webservices.rest;
+
+import org.openmrs.Obs;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.resource.api.Listable;
+import org.openmrs.module.webservices.rest.web.resource.api.Searchable;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.openmrs.projectbuendia.Utils;
+import org.projectbuendia.openmrs.api.ProjectBuendiaService;
+import org.projectbuendia.openmrs.webservices.rest.RestController;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A resource that allows observations to be incrementally synced.
+ * Note: this resource is read-only. For creates, see {@link EncounterResource}.
+ */
+@Resource(
+    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/observations",
+    supportedClass = Obs.class,
+    supportedOpenmrsVersions = "1.10.*,1.11.*")
+public class ObservationResource implements Listable, Searchable {
+
+    private final ProjectBuendiaService buendiaService;
+
+    public ObservationResource() {
+        buendiaService = Context.getService(ProjectBuendiaService.class);
+    }
+
+    @Override
+    public SimpleObject getAll(RequestContext context) throws ResponseException {
+        return handleSync(context);
+    }
+
+    @Override
+    public SimpleObject search(RequestContext context) throws ResponseException {
+        return handleSync(context);
+    }
+
+    private SimpleObject handleSync(RequestContext context) {
+        Date syncFrom = RequestUtil.mustParseSyncFromDate(context);
+
+        // Set the next sync from time to be one second in the past because there's issues
+        // due to OpenMRS rounding truncating insertion times. See
+        // https://github.com/projectbuendia/client/pull/90
+        Date nextSyncFrom = new Date(System.currentTimeMillis() - 1000);
+
+        List<Obs> observations =
+                buendiaService.getObservationsModifiedAtOrAfter(syncFrom, syncFrom != null);
+        List<SimpleObject> jsonResults = new ArrayList<>(observations.size());
+        for (Obs obs : observations) {
+            jsonResults.add(obsToJson(obs));
+        }
+        return ResponseUtil.createIncrementalSyncResults(jsonResults, nextSyncFrom);
+    }
+
+    private SimpleObject obsToJson(Obs obs) {
+        SimpleObject object = new SimpleObject()
+            .add("uuid", obs.getUuid())
+            .add("voided", obs.isVoided());
+
+        if (obs.isVoided()) {
+            return object;
+        }
+
+        object
+            .add("patient_uuid", obs.getPerson().getUuid())
+            .add("encounter_uuid", obs.getEncounter().getUuid())
+            .add("concept_uuid", obs.getConcept().getUuid())
+            .add("timestamp", Utils.toIso8601(obs.getObsDatetime()));
+
+        boolean isExecutedOrder =
+                DbUtil.getOrderExecutedConcept().equals(obs.getConcept()) && obs.getOrder() != null;
+        if (isExecutedOrder) {
+            object.add("value", obs.getOrder().getUuid());
+        } else {
+            object.add("value", ObservationsHandler.obsValueToString(obs));
+        }
+
+        return object;
+    }
+
+    @Override
+    public String getUri(Object instance) {
+        Obs obs = (Obs) instance;
+        Resource res = getClass().getAnnotation(Resource.class);
+        return RestConstants.URI_PREFIX + res.name() + "/" + obs.getUuid();
+    }
+}

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationsHandler.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationsHandler.java
@@ -25,6 +25,7 @@ import org.openmrs.api.EncounterService;
 import org.openmrs.api.ObsService;
 import org.openmrs.api.context.Context;
 import org.openmrs.projectbuendia.Utils;
+import org.openmrs.projectbuendia.VisitObsValue;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -168,7 +169,36 @@ public class ObservationsHandler {
         }
         Obs obs = new Obs(patient, DbUtil.getOrderExecutedConcept(), encounterTime, location);
         obs.setOrder(order);
-        obs.setValueNumeric(new Double(1));
+        obs.setValueNumeric(1d);
         return obs;
+    }
+
+    public static String obsValueToString(Obs obs) {
+        return VisitObsValue.visit(
+                obs, new VisitObsValue.ObsValueVisitor<String>() {
+                    @Override public String visitCoded(Concept value) {
+                        return value.getUuid();
+                    }
+
+                    @Override public String visitNumeric(Double value) {
+                        return "" + value;
+                    }
+
+                    @Override public String visitBoolean(Boolean value) {
+                        return "" + value;
+                    }
+
+                    @Override public String visitText(String value) {
+                        return value;
+                    }
+
+                    @Override public String visitDate(Date value) {
+                        return Utils.YYYYMMDD_UTC_FORMAT.format(value);
+                    }
+
+                    @Override public String visitDateTime(Date value) {
+                        return Utils.toIso8601(value);
+                    }
+                });
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/RequestUtil.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/RequestUtil.java
@@ -12,6 +12,7 @@
 package org.openmrs.projectbuendia.webservices.rest;
 
 import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.response.IllegalPropertyException;
 import org.openmrs.projectbuendia.Utils;
 
 import javax.annotation.Nullable;
@@ -36,5 +37,20 @@ public class RequestUtil {
             return null;
         }
         return Utils.fromIso8601(param);
+    }
+
+    /**
+     * Identical to {@link #getSyncFromDate(RequestContext)}, but throws an
+     * {@link IllegalPropertyException} with an appropriate error message instead of a
+     * {@link ParseException} if the date fails to parse.
+     */
+    @Nullable
+    public static Date mustParseSyncFromDate(RequestContext context)
+            throws IllegalPropertyException {
+        try {
+            return getSyncFromDate(context);
+        } catch (ParseException e) {
+            throw new IllegalPropertyException("Date Format invalid, expected ISO 8601");
+        }
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ResponseUtil.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ResponseUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 The Project Buendia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at: http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distrib-
+ * uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.openmrs.projectbuendia.webservices.rest;
+
+import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.projectbuendia.Utils;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Utility methods for creating responses.
+ */
+public class ResponseUtil {
+    private ResponseUtil() {}
+
+    public static SimpleObject createIncrementalSyncResults(
+            List<SimpleObject> results, Date newSyncToken) {
+        return new SimpleObject()
+                .add("results", results)
+                .add("snapshotTime", Utils.toIso8601(newSyncToken));
+    }
+}


### PR DESCRIPTION
…ing encounters.

Encounter sync worked well whilst we could guarantee that encounters and their associated
observations could never be modified, but that will change soon, as we introduce the ability to void
patients.

Note that when an individual observation is voided in OpenMRS, it makes no change to the encounter
record.

There are two solutions that allow for observations to be voided, then:
- Change the encounter modification detection logic such that it queries for observations that have
  been voided or modified. Then, if a modified encounter is detected, send the entire encounter to
  the client. The client then has to drop all existing records for the encounter, and re-add the
  ones present in the response.
- Change so that we sync observations instead of syncing encounters. This makes the modification
  detection logic much more straightforward and standard, and makes the implementation on the client
  side more consistent as well.

Note that we have some weirdness now in that the client always writes encounters, and reads
observations as a result of those encounters. I don't like the asymmetry there, but we already had
that anyway in the way that we store data and the way that we display it.