### PR TITLE
Make the buendia-update script actually error if one of its steps fails.

### DIFF
--- a/packages/buendia-update/data/usr/bin/buendia-update
+++ b/packages/buendia-update/data/usr/bin/buendia-update
@@ -10,7 +10,9 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-set -e; . /usr/share/buendia/utils.sh
+# Exit on first failure.
+set -e;
+. /usr/share/buendia/utils.sh
 name=$(basename $0)
 
 if [ "$1" = "-h" ]; then
@@ -38,13 +40,15 @@ buendia-status
 # Update the package list.
 echo
 echo "--- Updating package list"
+# Some sources might fail, but the only one we care about is the Project Buendia source.
+# We don't have a way to filter that at the moment, so we just ignore errors.
 apt-get update || true
 
 # Fix up any broken things.
 echo
 echo "--- Fixing up partially installed packages"
-dpkg --configure -a || true
-apt-get -V -y -f install || true
+dpkg --configure -a
+apt-get -V -y -f install
 
 # Install and upgrade the specified packages, or all the Buendia packages.
 if [ -n "$1" ]; then
@@ -57,7 +61,7 @@ echo "--- Updating packages: $packages"
 # Applying updates: red and yellow
 buendia-led red on || true
 buendia-led yellow on || true
-apt-get -V -y --allow-unauthenticated install $packages || true
+apt-get -V -y --allow-unauthenticated install $packages
 
 echo
 echo "--- Finished update:"

--- a/packages/buendia-update/data/usr/bin/buendia-update
+++ b/packages/buendia-update/data/usr/bin/buendia-update
@@ -10,8 +10,6 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-# Exit on first failure.
-set -e;
 . /usr/share/buendia/utils.sh
 name=$(basename $0)
 
@@ -30,8 +28,8 @@ if ! flock -n 9; then
 fi
 
 # Checking for updates: red on
-buendia-led red on || true
-trap 'buendia-led red off || true; buendia-led yellow off || true' EXIT
+buendia-led red on
+trap 'buendia-led red off; buendia-led yellow off' EXIT
 
 export DEBIAN_FRONTEND=noninteractive
 echo "--- Starting: $0 $@"
@@ -42,7 +40,7 @@ echo
 echo "--- Updating package list"
 # Some sources might fail, but the only one we care about is the Project Buendia source.
 # We don't have a way to filter that at the moment, so we just ignore errors.
-apt-get update || true
+apt-get update
 
 # Fix up any broken things.
 echo
@@ -59,15 +57,24 @@ fi
 echo
 echo "--- Updating packages: $packages"
 # Applying updates: red and yellow
-buendia-led red on || true
-buendia-led yellow on || true
+buendia-led red on
+buendia-led yellow on
+
 apt-get -V -y --allow-unauthenticated install $packages
+install_status=$?
 
 echo
-echo "--- Finished update:"
+if [ $install_status -eq 0 ]; then
+  echo "--- Finished update:"
+else
+  echo "--- Some packages failed to update:"
+fi
+
 buendia-status
 
 if [ -f /var/run/reboot-required ]; then
     echo
     echo "One or more packages have indicated that a reboot is required!"
 fi
+
+exit $install_status


### PR DESCRIPTION
We had a problem where Jenkins wasn't pushing new builds to dev.projectbuendia.org, and we had no
idea because the buendia-update script was squelching errors.

This change removes some of the squelching such that update failures cause Jenkins to actually show
failures.