### PR TITLE
Fix the datatype of `buendia-concept-order_executed`.

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtil.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtil.java
@@ -107,7 +107,7 @@ public class DbUtil {
             // arbitrary string IDs unrelated to RFC 4122.  Therefore, to prevent
             // collisions, UUIDs specific to this module are prefixed "buendia-".
             "buendia-concept-order_executed",
-            "N/A",
+            "Numeric",
             "Finding");
     }
 


### PR DESCRIPTION
Previously, the datatype was `N/A`, but we're storing a numeric value in there.

This is an inconsistency in the data model that was causing validation errors for certain operations
on observations.

Note that this change has no impact on the user experience, or in the way the system works - it just
resolves a problem that I hit when tinkering.

I'm not sure if this is the best way to resolve this inconsistency - other valid approaches would
be to
- Simply not store a value with the observation, or
- Change the type of the concept to `Boolean`

It seems possible to me that it could be useful to keep this numeric to indicate (for example)
a double or half-dose.