### PR TITLE
Implement Patient Sync pagination in the DAO

### DIFF
--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/PatientSyncParameters.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/PatientSyncParameters.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2015 The Project Buendia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at: http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distrib-
+ * uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.projectbuendia.openmrs;
+
+import org.openmrs.Patient;
+import org.openmrs.Person;
+
+import java.util.Date;
+
+/**
+ * Represents incremental sync parameters for a {@link Patient}.
+ * <p>
+ * {@link Person Persons} in OpenMRS have three timestamp fields that get updated when the record
+ * changes - dateCreated, dateChanged, and dateVoided. These values aren't usable for incremental
+ * paginated patient sync, because our pagination system needs to sort all records based on
+ * {@code GREATEST(dateCreated, dateChanged, dateVoided)}. It's not currently possible to create
+ * indexes on functions in MySQL [^1], thus adding this computation to every query means that MySQL
+ * would have to load every `patient` for every page fetch. We work around this by creating a
+ * trigger on the `person` database that creates a record in `buendia_patient_sync_map` with the patient ID
+ * and the timestamp of the record update.
+ * <p>
+ * The records in `buendia_patient_sync_map` are loadable by Hibernate, and have a link back to the Patient
+ * that they represent. Thus, by performing Hibernate queries on this class, it is possible to
+ * retrieve pages of patients with relative ease. See `PatientSyncParameters.hbm.xml`.
+ * <p>
+ * This class should be interpreted as read-only - all updates are done by the database triggers.
+ * The setters only exist so that the object can be instantiated by Hibernate.
+ * <p>
+ * [^1]: You can create indexes on generated columns in MySQL 5.7.5+, which is functionally
+ * equivalent, but the Buendia project won't be on 5.7.5+ at least until Debian is.
+ * Current MySQL version for Debian: http://distrowatch.com/table.php?distribution=debian
+ *
+ */
+public class PatientSyncParameters {
+    private int patientId;
+    private Date dateUpdated;
+    private Patient patient;
+    private String uuid;
+
+    public Patient getPatient() {
+        return patient;
+    }
+
+    protected void setPatient(Patient patient) {
+        this.patient = patient;
+    }
+
+    public Date getDateUpdated() {
+        return dateUpdated;
+    }
+
+    protected void setDateUpdated(Date dateUpdated) {
+        this.dateUpdated = dateUpdated;
+    }
+
+    public int getPatientId() {
+        return patientId;
+    }
+
+    protected void setPatientId(int patientId) {
+        this.patientId = patientId;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    protected void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+}

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/ProjectBuendiaService.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/ProjectBuendiaService.java
@@ -16,6 +16,7 @@ import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.api.OpenmrsService;
 import org.projectbuendia.openmrs.api.db.ProjectBuendiaDAO;
+import org.projectbuendia.openmrs.api.db.SyncPage;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Nullable;
@@ -48,9 +49,13 @@ public interface ProjectBuendiaService extends OpenmrsService {
 
     /**
      * Returns all patients modified on or after the given {@code date}.
-     * @param date if {@code null}, returns all encounters since the beginning of time.
+     * @param syncToken a token representing the first record to be excluded from the result set.
+     *                  See {@link SyncToken} for more information.
+     * @param includeVoided if {@code true}, results will include voided patients.
+     * @param maxResults the maximum number of results to fetch. If {@code <= 0}, returns all
      */
-    List<Patient> getPatientsModifiedAtOrAfter(@Nullable Date date, boolean includeVoided);
+    SyncPage<Patient> getPatientsModifiedAtOrAfter(
+            @Nullable SyncToken syncToken, boolean includeVoided, int maxResults);
 
     List<Order> getOrdersModifiedAtOrAfter(@Nullable Date date, boolean includeVoided);
 }

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/SyncToken.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/SyncToken.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015 The Project Buendia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at: http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distrib-
+ * uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.projectbuendia.openmrs.api;
+
+import net.sf.ehcache.concurrent.Sync;
+
+import javax.annotation.Nullable;
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * A {@code SyncToken} represents a bookmark into a dataset.
+ * <p/>
+ * When a {@code SyncToken} is passed to a method in {@link org.projectbuendia.openmrs.api.db
+ * .ProjectBuendiaDAO}, {@code ProjectBuendiaDAO} will ensure that all records returned were either
+ * created, modified, or voided on or after the {@code greaterThanOrEqualToTimestamp}.
+ * For records that were created, modified or voided at the exact instant represented by
+ * {@code greaterThanOrEqualToTimestamp}, {@code greaterThanUuid} is used as an additional filter,
+ * and only records that have a UUID greater than or equal to this value will be returned. If
+ * {@code greaterThanUuid} is null, than only the {@code greaterThanOrEqualToTimestamp} is used.
+ * <p>
+ * Conceptually, the semantics are identical to MySQL's greater-than operator on rows:
+ * (geTimestamp, gtUuid) will return records where {@code (geTimestamp > record.timestamp) OR
+ * ((geTimestamp = record.timestamp) AND (gtUuid > record.uuid))}. See the <a href=
+ * "http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#operator_greater-than">MySQL
+ * manual</a> for more information.
+ */
+public class SyncToken {
+    public final Date greaterThanOrEqualToTimestamp;
+    @Nullable
+    public final String greaterThanUuid;
+
+    public SyncToken(Date greaterThanOrEqualToTimestamp, @Nullable String greaterThanUuid) {
+        if (greaterThanOrEqualToTimestamp == null) {
+            throw new IllegalArgumentException("greaterThanOrEqualToTimestamp cannot be null");
+        }
+        this.greaterThanOrEqualToTimestamp = greaterThanOrEqualToTimestamp;
+        this.greaterThanUuid = greaterThanUuid;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof SyncToken)) {
+            return false;
+        }
+        SyncToken other = (SyncToken) obj;
+        return
+                Objects.equals(
+                    this.greaterThanOrEqualToTimestamp,
+                    other.greaterThanOrEqualToTimestamp)
+                && Objects.equals(
+                    this.greaterThanUuid,
+                    other.greaterThanUuid);
+    }
+}

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/ProjectBuendiaDAO.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/ProjectBuendiaDAO.java
@@ -15,6 +15,7 @@ import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
+import org.projectbuendia.openmrs.api.SyncToken;
 
 import javax.annotation.Nullable;
 import java.util.Date;
@@ -25,7 +26,8 @@ public interface ProjectBuendiaDAO {
 
     List<Obs> getObservationsModifiedAtOrAfter(@Nullable Date date, boolean includeVoided);
 
-    List<Patient> getPatientsModifiedAtOrAfter(@Nullable Date date, boolean includeVoided);
+    SyncPage<Patient> getPatientsModifiedAfter(
+            @Nullable SyncToken syncToken, boolean includeVoided, int maxResults);
 
     List<Order> getOrdersModifiedAtOrAfter(@Nullable Date date, boolean includeVoided);
 }

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/SyncPage.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/SyncPage.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 The Project Buendia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at: http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distrib-
+ * uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.projectbuendia.openmrs.api.db;
+
+import org.projectbuendia.openmrs.api.SyncToken;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * A result set that contains a list of results, and possibly a {@link SyncToken}
+ * that can be used to fetch the next set of results.
+ */
+public class SyncPage<T> {
+    public final List<T> results;
+    @Nullable
+    public final SyncToken syncToken;
+
+    public SyncPage(List<T> results, @Nullable SyncToken syncToken) {
+        this.results = results;
+        this.syncToken = syncToken;
+    }
+}

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/hibernate/HibernateProjectBuendiaDAO.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/db/hibernate/HibernateProjectBuendiaDAO.java
@@ -15,19 +15,28 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
+import org.hibernate.classic.Session;
 import org.hibernate.criterion.Disjunction;
-import org.hibernate.criterion.Restrictions;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.Type;
 import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.Patient;
+import org.projectbuendia.openmrs.PatientSyncParameters;
+import org.projectbuendia.openmrs.api.SyncToken;
 import org.projectbuendia.openmrs.api.db.ProjectBuendiaDAO;
+import org.projectbuendia.openmrs.api.db.SyncPage;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static org.hibernate.criterion.Order.asc;
+import static org.hibernate.criterion.Restrictions.disjunction;
 import static org.hibernate.criterion.Restrictions.eq;
 import static org.hibernate.criterion.Restrictions.ge;
+import static org.hibernate.criterion.Restrictions.sqlRestriction;
 
 /** Default implementation of {@link ProjectBuendiaDAO}. */
 public class HibernateProjectBuendiaDAO implements ProjectBuendiaDAO {
@@ -53,7 +62,7 @@ public class HibernateProjectBuendiaDAO implements ProjectBuendiaDAO {
         }
 
         if (date != null) {
-            Disjunction orClause = Restrictions.disjunction();
+            Disjunction orClause = disjunction();
             orClause.add(ge("dateCreated", date));
 
             if (includeVoided) {
@@ -66,25 +75,52 @@ public class HibernateProjectBuendiaDAO implements ProjectBuendiaDAO {
     }
 
     @Override
-    public List<Patient> getPatientsModifiedAtOrAfter(@Nullable Date date, boolean includeVoided) {
-        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(Patient.class);
+    public SyncPage<Patient> getPatientsModifiedAfter(
+            @Nullable SyncToken syncToken, boolean includeVoided, int maxResults) {
+        Session session = sessionFactory.getCurrentSession();
+
+        Criteria criteria = session.createCriteria(PatientSyncParameters.class);
+
+        if (syncToken != null) {
+            // (a, b) > (x, y) is equivalent to (a > x) OR ((a = x) AND (b > y)). See
+            // http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#operator_greater-than
+            criteria.add(sqlRestriction(
+                    // {alias} is substituted for the table alias that hibernate uses for the type.
+                    "({alias}.date_updated, {alias}.uuid) > (?, ?)",
+                    new Object[]{
+                            syncToken.greaterThanOrEqualToTimestamp,
+                            // If syncToken.greaterThanUuid is null, we use the empty string, which
+                            // is 'smaller' than every other string in terms of sort order.
+                            syncToken.greaterThanUuid == null ? "" : syncToken.greaterThanUuid},
+                    new Type[] {StandardBasicTypes.TIMESTAMP, StandardBasicTypes.STRING}));
+        }
 
         if (!includeVoided) {
-            criteria.add(eq("personVoided", false));
+            criteria.createCriteria("patient").add(eq("personVoided", false));
         }
 
-        if (date != null) {
-            Disjunction orClause = Restrictions.disjunction();
-            orClause.add(ge("personDateChanged", date))
-                    .add(ge("personDateCreated", date));
+        criteria.addOrder(asc("dateUpdated"))
+                .addOrder(asc("uuid"));
 
-            if (includeVoided) {
-                orClause.add(ge("personDateVoided", date));
-            }
-            criteria.add(orClause);
+        if (maxResults > 0) {
+            criteria.setMaxResults(maxResults);
         }
+
         //noinspection unchecked
-        return criteria.list();
+        List<PatientSyncParameters> dbList = criteria.list();
+
+        // PatientSyncParameters --> Patient
+        ArrayList<Patient> patients = new ArrayList<>(dbList.size());
+        for (PatientSyncParameters params : dbList) {
+            patients.add(params.getPatient());
+        }
+
+        SyncToken token = null;
+        if (dbList.size() > 0) {
+            PatientSyncParameters lastEntry = dbList.get(dbList.size() - 1);
+            token = new SyncToken(lastEntry.getDateUpdated(), lastEntry.getUuid());
+        }
+        return new SyncPage<>(patients, token);
     }
 
     @Override
@@ -94,7 +130,7 @@ public class HibernateProjectBuendiaDAO implements ProjectBuendiaDAO {
             criteria.add(eq("voided", false));
         }
         if (date != null) {
-            Disjunction orClause = Restrictions.disjunction();
+            Disjunction orClause = disjunction();
             orClause.add(ge("dateCreated", date));
 
             if (includeVoided) {

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/impl/ProjectBuendiaServiceImpl.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/impl/ProjectBuendiaServiceImpl.java
@@ -18,7 +18,9 @@ import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
+import org.projectbuendia.openmrs.api.SyncToken;
 import org.projectbuendia.openmrs.api.db.ProjectBuendiaDAO;
+import org.projectbuendia.openmrs.api.db.SyncPage;
 
 import javax.annotation.Nullable;
 import java.util.Date;
@@ -41,8 +43,9 @@ public class ProjectBuendiaServiceImpl extends BaseOpenmrsService implements Pro
     }
 
     @Override
-    public List<Patient> getPatientsModifiedAtOrAfter(@Nullable Date date, boolean includeVoided) {
-        return dao.getPatientsModifiedAtOrAfter(date, includeVoided);
+    public SyncPage<Patient> getPatientsModifiedAtOrAfter(
+            @Nullable SyncToken syncToken, boolean includeVoided, int maxResults) {
+        return dao.getPatientsModifiedAfter(syncToken, includeVoided, maxResults);
     }
 
     @Override

--- a/openmrs/api/src/main/resources/PatientSyncParameters.hbm.xml
+++ b/openmrs/api/src/main/resources/PatientSyncParameters.hbm.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2015 The Project Buendia Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License.  You may obtain a copy
+  ~ of the License at: http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distrib-
+  ~ uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  ~ OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+  ~ specific language governing permissions and limitations under the License.
+  -->
+
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<hibernate-mapping package="org.projectbuendia.openmrs">
+    <!--
+    From a Java perspective, this class should be treated as read-only. Updates are only ever
+    performed by a trigger on the database. See `liquibase.xml` and `PatientSyncParameters.java`
+    for details.
+    -->
+    <class
+        name="PatientSyncParameters"
+        table="buendia_patient_sync_map"
+        mutable="false" >
+        <id
+            name="patientId"
+            column="patient_id"
+            type="int" />
+        <property
+            name="dateUpdated"
+            column="date_updated"
+            type="java.util.Date"
+            not-null="true"
+            length="19"
+            lazy="true" />
+        <property
+            name="uuid"
+            column="uuid"
+            type="string"
+            not-null="true"
+            lazy="true" />
+        <one-to-one
+            name="patient"
+            class="org.openmrs.Patient"
+            lazy="false"
+            constrained="true"/>
+    </class>
+
+</hibernate-mapping>

--- a/openmrs/api/src/main/resources/liquibase.xml
+++ b/openmrs/api/src/main/resources/liquibase.xml
@@ -1,12 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog/1.9"
-                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog/1.9
-                  http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-1.9.xsd">
-  <!--
-      See http://www.liquibase.org/manual/home#available_database_refactorings
-      for a list of supported elements and attributes
+<!--
+  ~ Copyright 2015 The Project Buendia Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License.  You may obtain a copy
+  ~ of the License at: http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distrib-
+  ~ uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  ~ OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+  ~ specific language governing permissions and limitations under the License.
   -->
-
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                  http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet id="buendia-add-person-date-updated-index" author="@capnfabs">
+        <createTable
+                tableName="buendia_patient_sync_map"
+                remarks="Records are automatically inserted by triggers on the `person` table." >
+            <column name="patient_id" type="INTEGER">
+                <constraints
+                        primaryKey="true"
+                        nullable="false" />
+            </column>
+            <column name="date_updated" type="TIMESTAMP" />
+            <!--
+            We need to store UUID here as well as on the person table, because otherwise we can't
+            create an index across the two columns.
+            -->
+            <column name="uuid" type="CHAR(38)" />
+        </createTable>
+        <addForeignKeyConstraint
+            baseTableName="buendia_patient_sync_map"
+            baseColumnNames="patient_id"
+            constraintName="patient_id_to_person"
+            referencedTableName="person"
+            referencedColumnNames="person_id"
+            onDelete="CASCADE"
+            onUpdate="CASCADE" />
+        <createIndex tableName="buendia_patient_sync_map" indexName="pagination_index">
+            <column name="date_updated" />
+            <column name="uuid" />
+        </createIndex>
+        <sql>
+            <!-- Insert records for the patients that are already here. -->
+            INSERT INTO `buendia_patient_sync_map` (`patient_id`, `date_updated`, `uuid`)
+            SELECT `person_id`, NOW(), `uuid`
+            FROM `person`
+            WHERE EXISTS (SELECT 1 FROM `patient` WHERE `patient`.`patient_id` = `person_id`)
+        </sql>
+        <sql splitStatements="false">
+            DROP TRIGGER IF EXISTS `buendia_patient_update_date_updated`
+        </sql>
+        <sql splitStatements="false">
+            <!--
+            We need to use `person` for this instead of `patient` because `person` is where
+            the UUID is stored.
+            -->
+            CREATE TRIGGER `buendia_patient_update_date_updated` AFTER UPDATE
+            ON `person` FOR EACH ROW
+            IF EXISTS (SELECT 1 FROM `patient` WHERE `patient_id` = NEW.`person_id`) THEN
+                REPLACE INTO `buendia_patient_sync_map` (patient_id, date_updated, uuid)
+                VALUES (NEW.person_id, NOW(), NEW.uuid);
+            END IF;
+        </sql>
+        <sql>
+            DROP TRIGGER IF EXISTS `buendia_patient_insert_date_updated`
+        </sql>
+        <sql splitStatements="false">
+            <!--
+            We need to use `person` for this instead of `patient` because `person` is where
+            the UUID is stored.
+            -->
+            CREATE TRIGGER `buendia_patient_insert_date_updated` AFTER INSERT
+            ON `person` FOR EACH ROW
+            IF EXISTS (SELECT 1 FROM `patient` WHERE `patient_id` = NEW.`person_id`) THEN
+                REPLACE INTO `buendia_patient_sync_map` (patient_id, date_updated, uuid)
+                VALUES (NEW.person_id, NOW(), NEW.uuid);
+            END IF;
+        </sql>
+        <rollback>
+            <dropTable tableName="buendia_patient_sync_map" />
+            <sql>
+                DROP TRIGGER IF EXISTS `buendia_patient_update_date_updated`;
+                DROP TRIGGER IF EXISTS `buendia_patient_insert_date_updated`;
+            </sql>
+        </rollback>
+    </changeSet>
 </databaseChangeLog>

--- a/openmrs/api/src/test/java/org/projectbuendia/openmrs/api/db/hibernate/HibernateProjectBuendiaDAOTest.java
+++ b/openmrs/api/src/test/java/org/projectbuendia/openmrs/api/db/hibernate/HibernateProjectBuendiaDAOTest.java
@@ -112,8 +112,8 @@ public class HibernateProjectBuendiaDAOTest extends BaseModuleContextSensitiveTe
     /**
      * {@link BaseModuleContextSensitiveTest} does this initialization, but also pre-loads the
      * database with a bunch of patient records. We don't want to load those patient records,
-     * because we'd then have to augment them with `buendia_patient_sync_map` records, which would couple
-     * our test integrity to the records in OpenMRS' test data. For this reason, we disable
+     * because we'd then have to augment them with `buendia_patient_sync_map` records, which would
+     * couple our test integrity to the records in OpenMRS' test data. For this reason, we disable
      * {@link BaseModuleContextSensitiveTest}'s setup by putting the {@link SkipBaseSetup}
      * annotation on the class, but then we've got to explicitly init the database and authenticate
      * ourselves.
@@ -160,7 +160,6 @@ public class HibernateProjectBuendiaDAOTest extends BaseModuleContextSensitiveTe
                 Arrays.copyOfRange(EXPECTED_UUID_ORDER_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS, 6, 7),
                 extractListOfUuids(results.results));
     }
-
 
     @Test
     public void testSyncTokenGeneratedFromLastResultInPage() throws Exception {
@@ -276,15 +275,15 @@ public class HibernateProjectBuendiaDAOTest extends BaseModuleContextSensitiveTe
         Statement statement = getConnection().createStatement();
         String query =
                 "SELECT p.person_id, p.uuid, sm.uuid " +
-                "FROM person p LEFT JOIN buendia_patient_sync_map sm ON p.person_id = sm.patient_id " +
+                "FROM person p " +
+                "LEFT JOIN buendia_patient_sync_map sm ON p.person_id = sm.patient_id " +
                 "WHERE p.uuid <> sm.uuid";
         ResultSet results  = statement.executeQuery(query);
         int failures = 0;
         while (results.next()) {
             failures++;
-            System.out.printf(
-                    "WARNING: Person with ID #%d has inconsistent entry in buendia_patient_sync_map.\n" +
-                            "Person UUID: %s Sync Map UUID: %s\n",
+            System.out.printf("WARNING: Person with ID #%d has inconsistent entry in " +
+                    "buendia_patient_sync_map.\nPerson UUID: %s Sync Map UUID: %s\n",
                     results.getInt(1), results.getString(2), results.getString(3));
         }
         if (failures > 0) {

--- a/openmrs/api/src/test/java/org/projectbuendia/openmrs/api/db/hibernate/HibernateProjectBuendiaDAOTest.java
+++ b/openmrs/api/src/test/java/org/projectbuendia/openmrs/api/db/hibernate/HibernateProjectBuendiaDAOTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2015 The Project Buendia Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy
+ * of the License at: http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distrib-
+ * uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.projectbuendia.openmrs.api.db.hibernate;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.SkipBaseSetup;
+import org.projectbuendia.openmrs.api.ProjectBuendiaService;
+import org.projectbuendia.openmrs.api.SyncToken;
+import org.projectbuendia.openmrs.api.db.SyncPage;
+
+import javax.annotation.Nullable;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests in this class test the DAO logic, even though they interact with the service.
+ */
+@SkipBaseSetup
+public class HibernateProjectBuendiaDAOTest extends BaseModuleContextSensitiveTest {
+
+    private ProjectBuendiaService buendiaService;
+
+    private static final SyncToken CATCH_ALL_SYNCTOKEN = new SyncToken(new Date(0), null);
+    private static final DateFormat DB_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
+
+    // Dataset 1: no voided patients, no duplicate timestamps.
+
+    private static final String PATIENT_DATASET_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS =
+            "org/projectbuendia/openmrs/include/patientDataSetNoDuplicateTimestamps.xml";
+
+    private static final String[] EXPECTED_UUID_ORDER_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS =
+            new String[] {
+                "aaaaa",
+                "eeeee",
+                "bbbbb",
+                "fffff",
+                "ddddd",
+                "ccccc",
+                "gggggg"
+            };
+
+    private static final SyncToken SYNC_TOKEN_FOR_RECORD_eeeee =
+            createSyncToken("2015-07-18 12:00:00.0", "eeeee");
+
+    // END Dataset 1.
+
+    // Dataset 2: voided patients, no duplicate timestamps
+    private static final String PATIENT_DATASET_INCLUDES_VOIDED =
+            "org/projectbuendia/openmrs/include/patientDataSetWithVoids.xml";
+
+    private static final String[] EXPECTED_UUID_ORDER_VOIDS_EXCLUDE_VOIDED =
+            new String[] {
+                    "aaaaa",
+                    "bbbbb",
+                    "fffff",
+                    "gggggg"
+            };
+
+    private static final String[] EXPECTED_UUID_ORDER_VOIDS_INCLUDE_VOIDED =
+            EXPECTED_UUID_ORDER_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS;
+
+    // END Dataset 2.
+
+    // Dataset 3: voided patients, duplicate timestamps.
+    private static final String PATIENT_DATASET_DUPLICATE_TIMESTAMPS =
+            "org/projectbuendia/openmrs/include/patientDataSetWithDuplicateTimestamps.xml";
+
+    private static final String[] EXPECTED_UUID_ORDER_DUPLICATE_TIMESTAMPS =
+            new String[] {
+                    "aaaaa",
+                    "bbbbb",
+                    "eeeee",
+                    "fffff",
+                    "ccccc",
+                    "ddddd",
+                    "gggggg"
+            };
+
+    private static final SyncToken SYNC_TOKEN_DATE_ONLY =
+            createSyncToken("2015-07-21 00:00:00.0", null);
+
+    // END Dataset 3.
+
+    /**
+     * {@link BaseModuleContextSensitiveTest} does this initialization, but also pre-loads the
+     * database with a bunch of patient records. We don't want to load those patient records,
+     * because we'd then have to augment them with `buendia_patient_sync_map` records, which would couple
+     * our test integrity to the records in OpenMRS' test data. For this reason, we disable
+     * {@link BaseModuleContextSensitiveTest}'s setup by putting the {@link SkipBaseSetup}
+     * annotation on the class, but then we've got to explicitly init the database and authenticate
+     * ourselves.
+     */
+    @Before
+    public void setUpData() throws Exception {
+        if (useInMemoryDatabase()) {
+            initializeInMemoryDatabase();
+            authenticate();
+        }
+    }
+
+    @Before
+    public void setUpVariables() throws Exception {
+        buendiaService = Context.getService(ProjectBuendiaService.class);
+    }
+
+    @Test
+    public void testResultsInOrderWhenAllHaveDifferentUpdateTimes() throws Exception {
+        executeDataSet(PATIENT_DATASET_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS);
+        SyncPage<Patient> results =
+                buendiaService.getPatientsModifiedAtOrAfter(null, false, 0);
+        String[] actual = extractListOfUuids(results.results);
+        assertArrayEquals(EXPECTED_UUID_ORDER_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS, actual);
+    }
+
+    @Test
+    public void testPagesContainCorrectRecordsWhenAllHaveDifferentUpdateTimes() throws Exception {
+        executeDataSet(PATIENT_DATASET_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS);
+        SyncPage<Patient> results =
+                buendiaService.getPatientsModifiedAtOrAfter(null, false, 3);
+        assertArrayEquals(
+                Arrays.copyOfRange(EXPECTED_UUID_ORDER_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS, 0, 3),
+                extractListOfUuids(results.results));
+        SyncToken token = results.syncToken;
+        results = buendiaService.getPatientsModifiedAtOrAfter(token, false, 3);
+        assertArrayEquals(
+                Arrays.copyOfRange(EXPECTED_UUID_ORDER_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS, 3, 6),
+                extractListOfUuids(results.results));
+        token = results.syncToken;
+        results = buendiaService.getPatientsModifiedAtOrAfter(token, false, 3);
+        assertArrayEquals(
+                // There should only be one in the last page.
+                Arrays.copyOfRange(EXPECTED_UUID_ORDER_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS, 6, 7),
+                extractListOfUuids(results.results));
+    }
+
+
+    @Test
+    public void testSyncTokenGeneratedFromLastResultInPage() throws Exception {
+        executeDataSet(PATIENT_DATASET_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS);
+        SyncToken token = buendiaService.getPatientsModifiedAtOrAfter(null, false, 2).syncToken;
+        assertEquals(SYNC_TOKEN_FOR_RECORD_eeeee, token);
+    }
+
+    @Test
+    public void testFetchPastEndOfResultSet() throws Exception {
+        executeDataSet(PATIENT_DATASET_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS);
+        // First, fetch all the data.
+        SyncToken token = buendiaService.getPatientsModifiedAtOrAfter(null, false, 0).syncToken;
+        // The sync token should be generated from the last result, so using it should return
+        // an empty result set.
+        SyncPage<Patient> result = buendiaService.getPatientsModifiedAtOrAfter(token, false, 0);
+        assertTrue("Expected empty results", result.results.isEmpty());
+        assertNull(result.syncToken);
+    }
+
+    @Test
+    public void testZeroMaxResultsReturnsLotsOfResults() throws Exception {
+        executeDataSet(PATIENT_DATASET_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS);
+        SyncPage<Patient> results = buendiaService.getPatientsModifiedAtOrAfter(null, false, 0);
+        assertNotEquals(0, results.results.size());
+        results = buendiaService.getPatientsModifiedAtOrAfter(CATCH_ALL_SYNCTOKEN, false, 0);
+        assertNotEquals(0, results.results.size());
+    }
+
+    @Test
+    public void testVoidedPatientsIncludedWhenParameterTrue() throws Exception {
+        executeDataSet(PATIENT_DATASET_INCLUDES_VOIDED);
+        SyncPage<Patient> results = buendiaService.getPatientsModifiedAtOrAfter(null, true, 0);
+        assertArrayEquals(
+                EXPECTED_UUID_ORDER_VOIDS_INCLUDE_VOIDED,
+                extractListOfUuids(results.results));
+    }
+
+    @Test
+    public void testVoidedPatientsExcludedWhenParameterFalse() throws Exception {
+        executeDataSet(PATIENT_DATASET_INCLUDES_VOIDED);
+        SyncPage<Patient> results = buendiaService.getPatientsModifiedAtOrAfter(null, false, 0);
+        assertArrayEquals(
+                EXPECTED_UUID_ORDER_VOIDS_EXCLUDE_VOIDED,
+                extractListOfUuids(results.results));
+    }
+
+
+    @Test
+    public void testPagesContainCorrectRecordsWhenSomeHaveSameUpdateTime() throws Exception {
+        executeDataSet(PATIENT_DATASET_DUPLICATE_TIMESTAMPS);
+        SyncPage<Patient> results =
+                buendiaService.getPatientsModifiedAtOrAfter(null, true, 3);
+        assertArrayEquals(
+                Arrays.copyOfRange(EXPECTED_UUID_ORDER_DUPLICATE_TIMESTAMPS, 0, 3),
+                extractListOfUuids(results.results));
+        SyncToken token = results.syncToken;
+        results = buendiaService.getPatientsModifiedAtOrAfter(token, true, 3);
+        assertArrayEquals(
+                Arrays.copyOfRange(EXPECTED_UUID_ORDER_DUPLICATE_TIMESTAMPS, 3, 6),
+                extractListOfUuids(results.results));
+        token = results.syncToken;
+        results = buendiaService.getPatientsModifiedAtOrAfter(token, true, 3);
+        assertArrayEquals(
+                // There should only be one in the last page.
+                Arrays.copyOfRange(EXPECTED_UUID_ORDER_DUPLICATE_TIMESTAMPS, 6, 7),
+                extractListOfUuids(results.results));
+    }
+
+    @Test
+    public void testNullUuidInSyncTokenReturnsAllResultsNewerThanTimestamp() throws Exception {
+        executeDataSet(PATIENT_DATASET_DUPLICATE_TIMESTAMPS);
+        List<Patient> results =
+                buendiaService.getPatientsModifiedAtOrAfter(SYNC_TOKEN_DATE_ONLY, true, 0).results;
+        assertArrayEquals(
+                Arrays.copyOfRange(EXPECTED_UUID_ORDER_DUPLICATE_TIMESTAMPS, 4, 7),
+                extractListOfUuids(results));
+    }
+
+    @Test
+    public void testFetchWithNoResults() throws Exception {
+        // Don't add any data.
+        SyncPage<Patient> result = buendiaService.getPatientsModifiedAtOrAfter(null, false, 0);
+        assertTrue("Expected empty results", result.results.isEmpty());
+        assertNull(result.syncToken);
+    }
+
+    // DATASET CONSISTENCY TESTS. See note on {@link #testDataSetIsConsistent}.
+
+    @Test
+    public void testDataSetNoVoidedNoDuplicateTimestampsIsConsistent() throws Exception {
+        testDataSetIsConsistent(PATIENT_DATASET_NO_VOIDED_NO_DUPLICATE_TIMESTAMPS);
+    }
+
+    @Test
+    public void testDataSetWithVoidsIsConsistent() throws Exception {
+        testDataSetIsConsistent(PATIENT_DATASET_INCLUDES_VOIDED);
+    }
+
+    @Test
+    public void testDataSetWithDuplicateTimestampsisConsistent() throws Exception {
+        testDataSetIsConsistent(PATIENT_DATASET_DUPLICATE_TIMESTAMPS);
+    }
+
+    /**
+     * It's possible to generate inconsistent test data that will cause the other tests to fail,
+     * by using different UUIDs in the `person` table and the corresponding row in the
+     * `buendia_patient_sync_map`. This test explicitly checks for that, and fails if it finds any
+     * discrepancies. See `liquibase.xml` for why this inconsistency is possible in the data model.
+     */
+    private void testDataSetIsConsistent(String dataset) throws Exception {
+        executeDataSet(dataset);
+        Statement statement = getConnection().createStatement();
+        String query =
+                "SELECT p.person_id, p.uuid, sm.uuid " +
+                "FROM person p LEFT JOIN buendia_patient_sync_map sm ON p.person_id = sm.patient_id " +
+                "WHERE p.uuid <> sm.uuid";
+        ResultSet results  = statement.executeQuery(query);
+        int failures = 0;
+        while (results.next()) {
+            failures++;
+            System.out.printf(
+                    "WARNING: Person with ID #%d has inconsistent entry in buendia_patient_sync_map.\n" +
+                            "Person UUID: %s Sync Map UUID: %s\n",
+                    results.getInt(1), results.getString(2), results.getString(3));
+        }
+        if (failures > 0) {
+            fail(String.format("%d patient(s) had inconsistent test data.", failures));
+        }
+    }
+
+    /** Extracts a list of UUIDs from a list of patients. */
+    private String[] extractListOfUuids(List<Patient> patients) {
+        String[] retVal = new String[patients.size()];
+        for (int i = 0; i < patients.size(); i++) {
+            retVal[i] = patients.get(i).getUuid();
+        }
+        return retVal;
+    }
+
+    /**
+     * Creates a sync token, and converts any thrown exceptions to RuntimeExceptions so it can be
+     * used for static fields.
+     *
+     * @param dateString Specified in the same format as in the dataset XML files, for readability.
+     *                   e.g. "2015-07-18 12:00:00.0"
+     */
+    private static SyncToken createSyncToken(String dateString, @Nullable String uuid) {
+        try {
+            return new SyncToken(DB_DATE_FORMAT.parse(dateString), uuid);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/openmrs/api/src/test/resources/TestingApplicationContext.xml
+++ b/openmrs/api/src/test/resources/TestingApplicationContext.xml
@@ -1,0 +1,25 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <!--
+    From applicationContext-service.xml in openmrs-api
+    Normally, the OMOD takes care of ensuring that Hibernate class specs are available, but for
+    testing, the OMOD isn't loaded. We thus need to specify Hibernate configuration manually here
+    to ensure that Hibernate can work with our custom types in tests.
+    -->
+    <bean id="sessionFactory" class="org.openmrs.api.db.hibernate.HibernateSessionFactoryBean">
+        <property name="configLocations">
+            <list>
+                <value>classpath:hibernate.cfg.xml</value>
+                <value>classpath:buendia-hibernate.cfg.xml</value>
+            </list>
+        </property>
+        <property name="mappingJarLocations">
+            <ref bean="mappingJarResources" />
+        </property>
+        <!--  default properties must be set in the hibernate.default.properties -->
+    </bean>
+
+</beans>

--- a/openmrs/api/src/test/resources/buendia-hibernate.cfg.xml
+++ b/openmrs/api/src/test/resources/buendia-hibernate.cfg.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+        <!--
+        If you need Hibernate classes to be available in API (as opposed to OMOD) tests, add the
+        corresponding config files here.
+        -->
+        <mapping resource="PatientSyncParameters.hbm.xml"/>
+    </session-factory>
+</hibernate-configuration>

--- a/openmrs/api/src/test/resources/org/projectbuendia/openmrs/include/patientDataSetNoDuplicateTimestamps.xml
+++ b/openmrs/api/src/test/resources/org/projectbuendia/openmrs/include/patientDataSetNoDuplicateTimestamps.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ Copyright 2015 The Project Buendia Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License.  You may obtain a copy
+  ~ of the License at: http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distrib-
+  ~ uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  ~ OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+  ~ specific language governing permissions and limitations under the License.
+  -->
+<dataset>
+    <!-- These are sorted in order of date_updated -->
+    <patient patient_id="1002" creator="1" date_created="2005-09-22 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:29:59.0" voided="false" void_reason=""/>
+    <person person_id="1002" gender="M" birthdate="1948-01-01 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2005-09-22 00:00:00.0" voided="false" uuid="aaaaa"/>
+    <buendia_patient_sync_map patient_id="1002" date_updated="2015-07-18 00:00:00.0" uuid="aaaaa" />
+    <patient patient_id="1006" creator="1" date_created="2008-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="false" void_reason=""/>
+    <person person_id="1006" gender="F" dead="false" creator="1" birthdate_estimated="0" date_created="2008-01-18 00:00:00.0" voided="false" uuid="eeeee"/>
+    <buendia_patient_sync_map patient_id="1006" date_updated="2015-07-18 12:00:00.0" uuid="eeeee" />
+    <patient patient_id="1003" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:31.0" voided="false" void_reason=""/>
+    <person person_id="1003" gender="M" birthdate="1975-04-08 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="bbbbb"/>
+    <buendia_patient_sync_map patient_id="1003" date_updated="2015-07-19 00:00:00.0" uuid="bbbbb" />
+    <patient patient_id="1004" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
+    <person person_id="1004" gender="M" birthdate="2007-05-27 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="fffff"/>
+    <buendia_patient_sync_map patient_id="1004" date_updated="2015-07-20 00:00:00.0" uuid="fffff" />
+    <patient patient_id="1005" creator="1" date_created="2007-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="false" void_reason=""/>
+    <person person_id="1005" gender="F" birthdate="1976-08-25 00:00:00.0" birthdate_estimated="1" dead="false" creator="1" date_created="2007-01-18 00:00:00.0" voided="false" uuid="ddddd"/>
+    <buendia_patient_sync_map patient_id="1005" date_updated="2015-07-21 00:00:00.0" uuid="ddddd" />
+    <patient patient_id="1007" creator="1" date_created="2006-01-12 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="false" void_reason=""/>
+    <person person_id="1007" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2006-01-12 00:00:00.0" voided="false" uuid="ccccc"/>
+    <buendia_patient_sync_map patient_id="1007" date_updated="2015-07-23 00:00:00.0" uuid="ccccc" />
+    <patient patient_id="1008" creator="1" date_created="2015-07-18 00:00:00.0" changed_by="1" date_changed="2015-08-18 12:24:34.0" voided="false" void_reason=""/>
+    <person person_id="1008" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2015-07-18 00:00:00.0" voided="false" uuid="gggggg"/>
+    <buendia_patient_sync_map patient_id="1008" date_updated="2015-07-24 00:00:00.0" uuid="gggggg" />
+</dataset>

--- a/openmrs/api/src/test/resources/org/projectbuendia/openmrs/include/patientDataSetWithDuplicateTimestamps.xml
+++ b/openmrs/api/src/test/resources/org/projectbuendia/openmrs/include/patientDataSetWithDuplicateTimestamps.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ Copyright 2015 The Project Buendia Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License.  You may obtain a copy
+  ~ of the License at: http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distrib-
+  ~ uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  ~ OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+  ~ specific language governing permissions and limitations under the License.
+  -->
+<dataset>
+    <!-- These are grouped by date_updated for readability. -->
+    <!-- updated 2015-07-18 -->
+    <patient patient_id="1002" creator="1" date_created="2005-09-22 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:29:59.0" voided="false" void_reason=""/>
+    <person person_id="1002" gender="M" birthdate="1948-01-01 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2005-09-22 00:00:00.0" voided="false" uuid="aaaaa"/>
+    <buendia_patient_sync_map patient_id="1002" date_updated="2015-07-18 00:00:00.0" uuid="aaaaa" />
+    <!-- updated 2015-07-19 -->
+    <patient patient_id="1006" creator="1" date_created="2008-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="true" void_reason=""/>
+    <person person_id="1006" gender="F" dead="false" creator="1" birthdate_estimated="0" date_created="2008-01-18 00:00:00.0" voided="true" uuid="eeeee"/>
+    <buendia_patient_sync_map patient_id="1006" date_updated="2015-07-19 00:00:00.0" uuid="eeeee" />
+    <patient patient_id="1003" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:31.0" voided="false" void_reason=""/>
+    <person person_id="1003" gender="M" birthdate="1975-04-08 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="bbbbb"/>
+    <buendia_patient_sync_map patient_id="1003" date_updated="2015-07-19 00:00:00.0" uuid="bbbbb" />
+    <patient patient_id="1004" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
+    <person person_id="1004" gender="M" birthdate="2007-05-27 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="fffff"/>
+    <buendia_patient_sync_map patient_id="1004" date_updated="2015-07-19 00:00:00.0" uuid="fffff" />
+    <!-- updated 2015-07-21 -->
+    <patient patient_id="1005" creator="1" date_created="2007-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="true" void_reason=""/>
+    <person person_id="1005" gender="F" birthdate="1976-08-25 00:00:00.0" birthdate_estimated="1" dead="false" creator="1" date_created="2007-01-18 00:00:00.0" voided="true" uuid="ddddd"/>
+    <buendia_patient_sync_map patient_id="1005" date_updated="2015-07-21 00:00:00.0" uuid="ddddd" />
+    <patient patient_id="1007" creator="1" date_created="2006-01-12 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="true" void_reason=""/>
+    <person person_id="1007" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2006-01-12 00:00:00.0" voided="true" uuid="ccccc"/>
+    <buendia_patient_sync_map patient_id="1007" date_updated="2015-07-21 00:00:00.0" uuid="ccccc" />
+    <patient patient_id="1008" creator="1" date_created="2015-07-18 00:00:00.0" changed_by="1" date_changed="2015-08-18 12:24:34.0" voided="false" void_reason=""/>
+    <person person_id="1008" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2015-07-18 00:00:00.0" voided="false" uuid="gggggg"/>
+    <buendia_patient_sync_map patient_id="1008" date_updated="2015-07-21 00:00:00.0" uuid="gggggg" />
+</dataset>

--- a/openmrs/api/src/test/resources/org/projectbuendia/openmrs/include/patientDataSetWithVoids.xml
+++ b/openmrs/api/src/test/resources/org/projectbuendia/openmrs/include/patientDataSetWithVoids.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ Copyright 2015 The Project Buendia Authors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License.  You may obtain a copy
+  ~ of the License at: http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distrib-
+  ~ uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  ~ OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+  ~ specific language governing permissions and limitations under the License.
+  -->
+<dataset>
+    <!-- These are sorted in order of date_updated. -->
+    <patient patient_id="1002" creator="1" date_created="2005-09-22 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:29:59.0" voided="false" void_reason=""/>
+    <person person_id="1002" gender="M" birthdate="1948-01-01 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2005-09-22 00:00:00.0" voided="false" uuid="aaaaa"/>
+    <buendia_patient_sync_map patient_id="1002" date_updated="2015-07-18 00:00:00.0" uuid="aaaaa" />
+    <patient patient_id="1006" creator="1" date_created="2008-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="true" void_reason=""/>
+    <person person_id="1006" gender="F" dead="false" creator="1" birthdate_estimated="0" date_created="2008-01-18 00:00:00.0" voided="true" uuid="eeeee"/>
+    <buendia_patient_sync_map patient_id="1006" date_updated="2015-07-18 12:00:00.0" uuid="eeeee" />
+    <patient patient_id="1003" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:31.0" voided="false" void_reason=""/>
+    <person person_id="1003" gender="M" birthdate="1975-04-08 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="bbbbb"/>
+    <buendia_patient_sync_map patient_id="1003" date_updated="2015-07-19 00:00:00.0" uuid="bbbbb" />
+    <patient patient_id="1004" creator="1" date_created="2006-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:25:57.0" voided="false" void_reason=""/>
+    <person person_id="1004" gender="M" birthdate="2007-05-27 00:00:00.0" birthdate_estimated="0" dead="false" creator="1" date_created="2006-01-18 00:00:00.0" voided="false" uuid="fffff"/>
+    <buendia_patient_sync_map patient_id="1004" date_updated="2015-07-20 00:00:00.0" uuid="fffff" />
+    <patient patient_id="1005" creator="1" date_created="2007-01-18 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="true" void_reason=""/>
+    <person person_id="1005" gender="F" birthdate="1976-08-25 00:00:00.0" birthdate_estimated="1" dead="false" creator="1" date_created="2007-01-18 00:00:00.0" voided="true" uuid="ddddd"/>
+    <buendia_patient_sync_map patient_id="1005" date_updated="2015-07-21 00:00:00.0" uuid="ddddd" />
+    <patient patient_id="1007" creator="1" date_created="2006-01-12 00:00:00.0" changed_by="1" date_changed="2008-08-18 12:24:34.0" voided="true" void_reason=""/>
+    <person person_id="1007" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2006-01-12 00:00:00.0" voided="true" uuid="ccccc"/>
+    <buendia_patient_sync_map patient_id="1007" date_updated="2015-07-23 00:00:00.0" uuid="ccccc" />
+    <patient patient_id="1008" creator="1" date_created="2015-07-18 00:00:00.0" changed_by="1" date_changed="2015-08-18 12:24:34.0" voided="false" void_reason=""/>
+    <person person_id="1008" gender="M" dead="false" creator="1" birthdate_estimated="0" date_created="2015-07-18 00:00:00.0" voided="false" uuid="gggggg"/>
+    <buendia_patient_sync_map patient_id="1008" date_updated="2015-07-24 00:00:00.0" uuid="gggggg" />
+</dataset>

--- a/openmrs/omod/src/main/resources/config.xml
+++ b/openmrs/omod/src/main/resources/config.xml
@@ -60,6 +60,7 @@
 
   <!-- Maps hibernate files, if present -->
   <mappingFiles>
+    PatientSyncParameters.hbm.xml
     ProjectBuendia.hbm.xml
   </mappingFiles>
 


### PR DESCRIPTION
This is a pretty different approach to the old PR #39.

The old approach:
- created a new DB column on the `person` table, 
- updated that column with a SQL trigger,
- fought against Hibernate to be able to use that column in WHERE and ORDER BY clauses.

The new approach:
- creates a new DB _table_, that's keyed off the `person` table
- updates records in that table with a SQL trigger (similarly to the old approach)
- Accesses those records using Hibernate - Hibernate treats the sync data as actual objects now, which makes them significantly easier to work with.

I rewrote this code using the new approach because it seemed like the old approach wasn't testable. For tests, OpenMRS uses an in-memory database, which has its schema defined by Hibernate's ideas about what the tables should look like on test startup. It is actually possible to test everything under the old method, it just requires making changes to the in-memory DB at test startup to add the appropriate columns.

It seems to me that there's tradeoffs in both approaches - the old approach is heaps cleaner in terms of database representation and updating sync timestamps, whereas the new approach is much cleaner in actually accessing the data. I could get rid of most of the comment on `HibernateProjectBuendiaDAO` that explained the big list of workarounds in use. I don't have strong opinions as to which is better though. I suspect that this one will be more resilient against changes to OpenMRS in future versions, but possibly less performant, and with a less clean DB schema.

As an aside, this new direction would allow us to even consider creating the update records in the Application layer, instead of the DB layer, which could provide better db-independance in the future.