### PR TITLE
Support multiple servers on same host.

### DIFF
--- a/tools/openmrs_account_setup
+++ b/tools/openmrs_account_setup
@@ -15,22 +15,44 @@
 set -e
 openmrs_user="$1"
 openmrs_password="$2"
+
+function usage() {
+  echo "Usage: $0 <username> <password>"
+  echo
+  echo "Sets up an OpenMRS user with the given username and password"
+  echo "as the account to be used for Buendia API requests.  If the"
+  echo "OpenMRS user account already exists, changes its password."
+  echo
+  echo 'Requires a MySQL user that has been granted database access with'
+  echo '    GRANT USAGE ON <database-name>.* to <user>@<host>'
+  echo 'Specify the user, password and database with $MYSQL_USER, $MYSQL_PASSWORD and $MYSQL_DB'
+  echo ' respectively.'
+  echo
+}
+
 if [ -z "$openmrs_password" ]; then
-    echo "Usage: $0 <username> <password>"
-    echo
-    echo "Sets up an OpenMRS user with the given username and password"
-    echo "as the account to be used for Buendia API requests.  If the"
-    echo "OpenMRS user account already exists, changes its password."
-    echo
-    echo 'Requires a MySQL user that has been granted database access with'
-    echo '    GRANT USAGE ON <database-name>.* to <user>@<host>'
-    echo 'Specify the user and password with $MYSQL_USER and $MYSQL_PASSWORD.'
-    echo
+    usage
     exit 1
 fi
 
 if [ -z "$MYSQL_USER" ]; then
-    echo '$MYSQL_USER is not set; please set $MYSQL_USER and $MYSQL_PASSWORD.'
+    echo '$MYSQL_USER is not set; please set $MYSQL_USER, $MYSQL_PASSWORD and $MYSQL_DB.'
+    echo
+    usage
+    exit 1
+fi
+
+if [ -z "$MYSQL_PASSWORD" ]; then
+    echo '$MYSQL_PASSWORD is not set; please set $MYSQL_USER, $MYSQL_PASSWORD and $MYSQL_DB.'
+    echo
+    usage
+    exit 1
+fi
+
+if [ -z "$MYSQL_DB" ]; then
+    echo '$MYSQL_DB is not set; please set $MYSQL_USER, $MYSQL_PASSWORD and $MYSQL_DB.'
+    echo
+    usage
     exit 1
 fi
 
@@ -43,7 +65,7 @@ PERSON_UUID=a0e512fd-a6e0-11e4-b418-040ccecfdba4
 PERSON_NAME_UUID=a1332cdc-a6e0-11e4-8711-040ccecfdba4
 
 # Ensure MySQL is running.
-MYSQL="mysql -u $MYSQL_USER -p$MYSQL_PASSWORD openmrs"
+MYSQL="mysql -u $MYSQL_USER -p$MYSQL_PASSWORD $MYSQL_DB"
 
 # If there is no user account with the expected UUID, add one.
 if ! $MYSQL <<< "select count(*) from users where uuid='$USER_UUID'" | grep -q 1; then

--- a/tools/openmrs_build
+++ b/tools/openmrs_build
@@ -13,7 +13,13 @@
 # Builds the Buendia module and installs it in an OpenMRS development server.
 
 set -e
-SERVER_ID=server
+
+if [ -z "$OPENMRS_SERVER" ]; then
+  SERVER_ID="server"
+else
+  SERVER_ID="$OPENMRS_SERVER"
+fi
+
 SERVER_DIR=$HOME/openmrs/$SERVER_ID
 MODULE_DIR=$SERVER_DIR/modules
 INSTALL="mvn openmrs-sdk:install -DserverId=$SERVER_ID"

--- a/tools/openmrs_run
+++ b/tools/openmrs_run
@@ -12,17 +12,51 @@
 
 # Starts a local OpenMRS server for development.
 
+## Usage:
+##   tools/openmrs_run [-p PORTNUM] [--debug]
+##
+## Note that it's possible to change the OpenMRS server ID by setting OPENMRS_SERVER.
+
 set -e
-SERVER_ID=server
+
+PORT="9000"
+DEBUG=0
+
+while [[ $# > 1 ]]
+  do
+  key="$1"
+
+  case $key in
+    -p)
+      PORT="$2"
+      shift # past argument
+      ;;
+    --debug)
+      DEBUG=1
+      ;;
+  esac
+  shift # past argument or value
+done
+
+
+if [ -z "$OPENMRS_SERVER" ]; then
+  SERVER_ID="server"
+else
+  SERVER_ID="$OPENMRS_SERVER"
+fi
 
 # Serve on port 9000 to match production.
-PORT_OPTS="-Djetty.port=9000"
+PORT_OPTS="-Djetty.port=$PORT"
 
 # Increase memory limits.
 MEMORY_OPTS="-Xmx2G -XX:MaxPermSize=128m"
 
 # Enable remote debugging.
-DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+if [ "$DEBUG" -eq 1 ]; then
+  DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
+else
+  DEBUG_OPTS=""
+fi
 
 # Go to the OpenMRS installation directory.
 if [ ! -d $HOME/openmrs/$SERVER_ID ]; then

--- a/tools/openmrs_run
+++ b/tools/openmrs_run
@@ -22,7 +22,7 @@ set -e
 PORT="9000"
 DEBUG=0
 
-while [[ $# > 1 ]]
+while [[ $# > 0 ]]
   do
   key="$1"
 

--- a/tools/openmrs_setup
+++ b/tools/openmrs_setup
@@ -14,7 +14,14 @@
 
 set -e
 SITE_SQL_DIR=packages/buendia-db-init/data/usr/share/buendia/db
-SERVER_ID=server
+if [ -z "$OPENMRS_SERVER" ]; then
+  SERVER_ID="server"
+  echo "Setting up server named \"$SERVER_ID\", set \$OPENMRS_SERVER to change"
+else
+  SERVER_ID="$OPENMRS_SERVER"
+  echo "Setting up server named \"$SERVER_ID\""
+fi
+
 # This version numbers is duplicated in [git root]/openmrs/pom.xml
 OPENMRS_PLATFORM_VERSION=1.10.2  # db-snapshot data is compatible with 1.10.x
 if [ "$1" = "-f" ]; then
@@ -63,10 +70,12 @@ if [ ! -f $server_dir/openmrs-$OPENMRS_PLATFORM_VERSION.war ]; then
         -DserverId=$SERVER_ID -Dversion=$OPENMRS_PLATFORM_VERSION
 fi
 
+database_name="openmrs_$SERVER_ID"
+
 # Create the openmrs_user account in MySQL.
 echo "Enter the MySQL root password, or just hit Enter if there is no password."
 mysql -uroot -p <<< "
-    grant all on openmrs.* to openmrs_user@localhost identified by 'openmrs';
+    grant all on $database_name.* to openmrs_user@localhost identified by 'openmrs';
     grant file on *.* to openmrs_user@localhost;
     flush privileges;
 "
@@ -106,7 +115,7 @@ sudo chmod -R 755 $buendia_dir
 
 # Configure OpenMRS to use the openmrs_user MySQL account.
 cat <<EOF >$server_dir/openmrs-runtime.properties
-connection.url=jdbc\:mysql\://localhost\:3306/openmrs?autoReconnect\=true&sessionVariables\=storage_engine\=InnoDB&useUnicode\=true&characterEncoding\=UTF-8
+connection.url=jdbc\:mysql\://localhost\:3306/$database_name?autoReconnect\=true&sessionVariables\=storage_engine\=InnoDB&useUnicode\=true&characterEncoding\=UTF-8
 connection.username=openmrs_user
 connection.password=openmrs
 auto_update_database=true
@@ -123,13 +132,14 @@ trap 'rm -f /tmp/init.$$.zip' EXIT
 # Load the snapshot into the MySQL database.
 export MYSQL_USER=openmrs_user
 export MYSQL_PASSWORD=openmrs
+export MYSQL_DB="$database_name"
 echo
-tools/openmrs_load $force_flag openmrs /tmp/init.$$.zip
+tools/openmrs_load $force_flag $database_name /tmp/init.$$.zip
 
 # Apply the selected site configuration.
 echo
 echo "Loading $site_sql..."
-mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" openmrs < $site_sql
+mysql -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" $database_name < $site_sql
 echo
 
 # Set up the OpenMRS account for Buendia.


### PR DESCRIPTION
- `tools/openmrs_setup`, `tools/openmrs_build` and `tools/openmrs_run` all support having an
  environment variable `OPENMRS_SERVER` defined, which specifies the server to setup, build and run.
- `OPENMRS_SERVER` defaults to `"server"`, which retains compatibility with existing behavior.
- The database name `"openmrs_$OPENMRS_SERVER"` is now used, instead of just `openmrs`.
- `tools/openmrs_run` now supports a `-p` parameter to specify a port to run on, and a `--debug`
  flag, which enables debugging. By default, `-p` is `9000` (same as before), and `--debug` is off
  (behavior has changed).