### PR TITLE
Add the enterer's UUID to observations sent from the server.

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
@@ -12,8 +12,13 @@
 package org.openmrs.projectbuendia;
 
 import org.openmrs.Order;
+import org.openmrs.Person;
+import org.openmrs.Provider;
+import org.openmrs.User;
+import org.openmrs.api.context.Context;
 import org.openmrs.projectbuendia.webservices.rest.InvalidObjectDataException;
 
+import javax.annotation.Nullable;
 import java.text.DateFormat;
 import java.text.Normalizer;
 import java.text.ParseException;
@@ -21,6 +26,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
@@ -182,5 +188,19 @@ public class Utils {
             order = order.getPreviousOrder();
         }
         return order;
+    }
+
+    public static @Nullable Provider getProviderFromUser(@Nullable User user) {
+        if (user == null) {
+            return null;
+        }
+        Person person = user.getPerson();
+        Iterator<Provider> providers =
+                Context.getProviderService().getProvidersByPerson(person).iterator();
+        if (providers.hasNext()) {
+            return providers.next();
+        } else {
+            return null;
+        }
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
@@ -14,6 +14,7 @@
 package org.openmrs.projectbuendia.webservices.rest;
 
 import org.openmrs.Obs;
+import org.openmrs.Provider;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -92,6 +93,9 @@ public class ObservationResource implements Listable, Searchable {
             .add("encounter_uuid", obs.getEncounter().getUuid())
             .add("concept_uuid", obs.getConcept().getUuid())
             .add("timestamp", Utils.toIso8601(obs.getObsDatetime()));
+
+        Provider provider = Utils.getProviderFromUser(obs.getCreator());
+        object.add("enterer_uuid", provider != null ? provider.getUuid() : null);
 
         boolean isExecutedOrder =
                 DbUtil.getOrderExecutedConcept().equals(obs.getConcept()) && obs.getOrder() != null;


### PR DESCRIPTION
This allows clients to properly attribute observations to a specific user.

Note that we're especially carefully not to crash sync if an observation was recorded by someone
that doesn't exist in a way that's compatible with the Buendia model of a 'User'.

Each Buendia user has the following three objects in OpenMRS:
- A Person, which contains information such as the person's name
- A User, which contains login credentials (though Buendia doesn't really populate these properly)
- A Provider, which is the OpenMRS representation of a person who administers orders.

When users are synced from the server to the client, the Provider ID gets sent down at the moment,
so we have to do a bit of work to convert providers into users and back throughout.