### PR TITLE
Sync secondary concepts that aren't referenced anywhere else.

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
@@ -141,7 +141,7 @@ public class ConceptResource extends AbstractReadOnlyResource<Concept> {
                 return Collections.emptyList();
             }
 
-            List list = (List) extendedData.get("concepts");
+            List list = (List) object;
             for (Object obj : list) {
                 if (obj == null) {
                     continue;


### PR DESCRIPTION
Previously, secondary concepts in chart fields (any concepts other than the first listed concept)
were not synced to the client. This resulted in the client not knowing how to render these secondary
concepts unless they were also a primary concept in another chart field.

Fixes https://github.com/projectbuendia/client/issues/202.