### PR TITLE
Server-side changes required to support notes panel.

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
@@ -110,10 +110,7 @@ public class EncounterResource implements Creatable {
             (List) post.get("observations"), (List) post.get("order_uuids"),
             patient, encounterTime, "new observation", "ADULTRETURN",
             // TODO: Consider using patient's location instead of the root location.
-            LocationResource.ROOT_UUID);
-        if (encounter == null) {
-            throw new InvalidObjectDataException("No observations specified");
-        }
+            LocationResource.ROOT_UUID, (String) post.get("enterer_uuid"));
         SimpleObject simpleObject = new SimpleObject();
         populateJsonProperties(encounter, simpleObject);
         return simpleObject;
@@ -133,7 +130,7 @@ public class EncounterResource implements Creatable {
         encounterJson.put("timestamp", Utils.toIso8601(encounter.getEncounterDatetime()));
         encounterJson.put("uuid", encounter.getUuid());
 
-        SimpleObject observations = new SimpleObject();
+        ArrayList<SimpleObject> observations = new ArrayList<>();
         List<String> orderUuids = new ArrayList<>();
         for (Obs obs : encounter.getObs()) {
             Concept concept = obs.getConcept();
@@ -143,7 +140,7 @@ public class EncounterResource implements Creatable {
                 continue;
             }
 
-            observations.put(obs.getConcept().getUuid(), ObservationsHandler.obsValueToString(obs));
+            observations.add(ObservationsHandler.obsToJson(obs));
         }
         if (!observations.isEmpty()) {
             encounterJson.put("observations", observations);

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
@@ -14,7 +14,6 @@
 package org.openmrs.projectbuendia.webservices.rest;
 
 import org.openmrs.Obs;
-import org.openmrs.Provider;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -23,7 +22,6 @@ import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.resource.api.Listable;
 import org.openmrs.module.webservices.rest.web.resource.api.Searchable;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
-import org.openmrs.projectbuendia.Utils;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
 import org.projectbuendia.openmrs.api.SyncToken;
 import org.projectbuendia.openmrs.api.db.SyncPage;
@@ -70,47 +68,13 @@ public class ObservationResource implements Listable, Searchable {
                         syncFrom, syncFrom != null, MAX_OBS_PER_PAGE);
         List<SimpleObject> jsonResults = new ArrayList<>(observations.results.size());
         for (Obs obs : observations.results) {
-            jsonResults.add(obsToJson(obs));
+            jsonResults.add(ObservationsHandler.obsToJson(obs));
         }
         SyncToken newToken = SyncTokenUtils.clampSyncTokenToBufferedRequestTime(
                 observations.syncToken, requestTime);
         // If we fetched a full page, there's probably more data available.
         boolean more = observations.results.size() == MAX_OBS_PER_PAGE;
         return ResponseUtil.createIncrementalSyncResults(jsonResults, newToken, more);
-    }
-
-    private SimpleObject obsToJson(Obs obs) {
-        SimpleObject object = new SimpleObject()
-            .add("uuid", obs.getUuid())
-            .add("voided", obs.isVoided());
-
-        if (obs.isVoided()) {
-            return object;
-        }
-
-        object
-            .add("patient_uuid", obs.getPerson().getUuid())
-            .add("encounter_uuid", obs.getEncounter().getUuid())
-            .add("concept_uuid", obs.getConcept().getUuid())
-            .add("timestamp", Utils.toIso8601(obs.getObsDatetime()));
-
-        Provider provider = Utils.getProviderFromUser(obs.getCreator());
-        object.add("enterer_uuid", provider != null ? provider.getUuid() : null);
-
-        boolean isExecutedOrder =
-                DbUtil.getOrderExecutedConcept().equals(obs.getConcept()) && obs.getOrder() != null;
-        if (isExecutedOrder) {
-            // As far as the client knows, a chain of orders is represented by the root order's
-            // UUID, so we have to work back through the chain or orders to get the root UUID.
-            // Normally, the client will only ever supply observations for the root order ID, but
-            // in the event that an order is marked as executed on the server (for example) we don't
-            // want that to mean that an order execution gets missed.
-            object.add("value", Utils.getRootOrder(obs.getOrder()).getUuid());
-        } else {
-            object.add("value", ObservationsHandler.obsValueToString(obs));
-        }
-
-        return object;
     }
 
     @Override

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
@@ -276,7 +276,7 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
         ObservationsHandler.addEncounter(
             (List) json.get("observations"), null,
             patient, patient.getDateCreated(), "Initial triage",
-            "ADULTINITIAL", LocationResource.TRIAGE_UUID);
+            "ADULTINITIAL", LocationResource.TRIAGE_UUID, (String) json.get("enterer_id"));
         return patientToJson(patient);
     }
 


### PR DESCRIPTION
- Allow free-text observations to be submitted as part of encounters.
- Attribute encounters to the user who entered them.
- Standardise the way observations are represented in encounters, so they more closely match the
  representation used for observation sync.