### PR TITLE
Exclude OpenMRS logs from the backup.

### DIFF
--- a/packages/buendia-backup/data/usr/bin/buendia-backup
+++ b/packages/buendia-backup/data/usr/bin/buendia-backup
@@ -116,6 +116,9 @@ tar cfz "$new_dir/buendia.tar.gz" \
     --exclude /usr/share/buendia/db \
     --exclude /usr/share/buendia/diversions \
     --exclude /usr/share/buendia/openmrs/modules \
+    # Exclude the openmrs log because it changes frequently and tar fails if
+    # a file changes whilst it's being compressed.
+    --exclude /usr/share/buendia/openmrs/openmrs.log \
     --exclude /usr/share/buendia/packages
 ls -l "$new_dir/buendia.tar.gz"
 


### PR DESCRIPTION
OpenMRS logs change frequently, and if the file changes whilst being `tar`'d, tar quits with an
error. This was causing backups to fail about 25% of the time in our pilot deployment.