### PR TITLE
Strip whitespace from all cells in the profile_apply script.

### DIFF
--- a/tools/profile_apply
+++ b/tools/profile_apply
@@ -115,7 +115,11 @@ def read_csv(filename, tab=None):
     """Returns a dictionary mapping tab names to lists of row dictionaries."""
     infile = open(filename)
     tabs = {}
+    # Strip whitespace from every field. For a user-created CSV, it's almost
+    # certainly accidental whitespace.
     for row in csv.DictReader(infile):
+        for k, v in row.iteritems():
+            row[k] = v.strip()
         tab = row['tab'] or tab
         tabs.setdefault(tab, []).append(row)
     return tabs


### PR DESCRIPTION
It was almost certainly introduced by accident, because our users are hand-writing CSV files.
Whitespace at the end of strings is indetectable to users, but breaks ODK collect's form persistence
feature, because it is trimming concept labels at some stage and expecting the (trimmed) concept
label to match the label that we supply.