### PR TITLE
Add build server pushes to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: java
 script:
+  - export PACKAGE_VERSION=`tools/travis-ci/choose_version_number.sh`
+  - echo "Assigning package version $PACKAGE_VERSION"
   - tools/openmrs_build
-  - cd packages
-  - make clean && PACKAGE_VERSION="0.0.$TRAVIS_BUILD_NUMBER" make
+  # Spawn this in a subshell so we don't need to push / pop directories.
+  # Note that `make` makes use of $PACKAGE_VERSION.
+  - ( cd packages && make clean && make )
+  - tools/travis-ci/update_build_server.sh
 # TODO: add after_success clause that pushes builds to our build server.
 jdk: openjdk7
 notifications:
   slack:
     # Generated using `travis encrypt "buendia:[token]#server"
     secure: "Vmk7XmLRhzVfS9hAy6slF9YTPurO07cSj2Qny6lhjMN7P8Q+7Ty6TF9gXyfMBvgXXG7EF7EzKDC+PLu1Rq6bQI39ESaq2Pn2Uh/sSVXERhXMqyDNy7GWscExRtpC8iytaS9dmXTfv7kArgnINyXRztLIyeRQSOjMQH30ZDsLnag="
+env:
+  global:
+    # Generated using `travis encrypt GITHUB_API_TOKEN=[token]`
+    secure: C4kgvqQh1qI3GUIK2QpOHR8y0QB5Rl8sP1RxV1L3MalfSep4lANqmli4k2WlIp616rwSImcdcSzddSgaYuB2pPW38GqopxTo3vK2UFAu8KILOD1sWQfGqOMjP7wKBBEyiTw7Tm3XtPu86u/ilcksZ2IbMMPdKT1Z+NTPAueieJo=

--- a/tools/travis-ci/choose_version_number.sh
+++ b/tools/travis-ci/choose_version_number.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Match 'v1000' or 'v1000.3000' or 'v1000.30.12'
+if [[ "$TRAVIS_TAG" =~ ^v([0-9]+(\.[0-9]+){0,2})$ ]]; then
+  echo "${BASH_REMATCH[1]}"
+else
+  echo "0.0.$TRAVIS_BUILD_NUMBER"
+fi

--- a/tools/travis-ci/update_build_server.sh
+++ b/tools/travis-ci/update_build_server.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# NOTE: Because this script uses git to create the build server, there's a non-zero chance that
+# we'll get merge conflicts and the script will fail because Travis CI builds can run in parallel.
+# Let's see how that goes for the time being, and if it doesn't work we'll sort it out later.
+
+# Die if any command fails. Better that we know about it through a build failure.
+set -e
+
+# Setup: Sanity checks!
+
+# Check that this actually is the correct repo, and not a fork.
+if [ "$TRAVIS_REPO_SLUG" != "projectbuendia/buendia" ]; then
+  echo "This repo is a fork, not pushing the build."
+  exit 0
+fi
+
+# Check that GITHUB_API_TOKEN is set. We do this before other checks because if this isn't set, we
+# want early notification - that is, we want the CI to fail on all builds, not just releases.
+if [ -z "$GITHUB_API_TOKEN" ]; then
+  echo "No GITHUB_API_TOKEN environment variable set, we require one to push builds."
+  exit 1
+fi
+
+if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "This is a pull request, not deploying to build server."
+  # Shouldn't count as failure
+  exit 0
+fi
+
+case "$TRAVIS_BRANCH" in
+    dev|master) ;;
+    *)
+      echo "This branch isn't \`dev\` or \`master\`, not deploying to build server."
+      # Not a failure
+      exit 0
+      ;;
+esac
+
+echo "Deploying to build server."
+
+# Configure git so that commits look sensible.
+git config --global user.email "noreply+travis-ci@projectbuendia.org"
+git config --global user.name "Travis CI"
+
+# Make a working directory to create the file structure in.
+dir=`mktemp -d`
+# Clone the build server repo.
+git clone https://${GITHUB_API_TOKEN}@github.com:projectbuendia/builds.git --depth=1 --single-branch --branch=gh-pages "$dir"
+
+# The output debian packages from the build process are dropped in their individual source
+# directories (TODO: fix this) so we consolidate them all to the temporary directory.
+
+cp `find packages -name *.deb` dir
+# Actually run the index step.
+packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-index-debs "$dir"
+cd "$dir"
+git add .
+git commit -m "Autoupdate package server from Travis CI build $TRAVIS_BUILD_NUMBER."
+# The API token is encoded in the remote, so the `git push` will use the same credentials as the
+# clone.
+git push
+rm "$dir"
+
+echo "Successfully deployed."


### PR DESCRIPTION
This is pretty complicated and I'm not entirely sure if it works yet. Here's the gist:

- I created a repo `projectbuendia/builds`. It's going to act as our new build server.
- When a build on either the `dev` or `master` branch finishes, it gets pushed to the builds repo.
- The builds repo works out to be a flat-file debian package server, so it should be accessible directly as `http://projectbuendia.github.io/builds`.

But we won't know for sure until I've submitted :)