### PR TITLE
Add CircleCI support.

### DIFF
--- a/.circleci/Makefile
+++ b/.circleci/Makefile
@@ -1,0 +1,6 @@
+# https://support.circleci.com/hc/en-us/articles/360006735753-Validating-CircleCI-configuration-files-YAML-linting-issues-etc-
+
+all: test
+
+test:
+	cd .. && circleci config validate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,18 @@ jobs:
               - buendia-v1-{{ .Branch }}-{{ .Revision }}
               - buendia-v1-{{ .Branch }}
               - buendia-v1-
+
+      - run:
+          # The package version is set to n.n-b or n.n.n-b if the current Git
+          # tag is "vn.n" or "vn.n.n" and the current build number is b; else
+          # it is 0.0.0-b
+          name: Determine package version number
+          command: |
+              perl -e 'print(($ENV{"CIRCLE_TAG"} =~ /^v([0-9]+(\.[0-9]+){0,2})$/ ? $1 : "0.0.0"), "-", $ENV{"CIRCLE_BUILD_NUM"})' > /tmp/buendia-version
           
-      - run: make -C packages PACKAGE_VERSION=1.0.${CIRCLE_BUILD_NUM}
+      - run:
+          name: Build all Debian packages
+          command: make -C packages PACKAGE_VERSION=$(cat /tmp/buendia-version)
 
       - save_cache:
           key: buendia-v1-{{ .Branch }}-{{ .Revision }}
@@ -23,18 +33,19 @@ jobs:
             - ~/.m2
             - /tmp/buendia-fetched
 
-      # Collect and store test results
-      - run: >
-          mkdir -p /tmp/test-results &&
-          cp -a openmrs/api/target/surefire-reports /tmp/test-results/api &&
-          cp -a openmrs/omod/target/surefire-reports /tmp/test-results/omod
+      - run:
+          name: Collect and store test results
+          command: |
+              mkdir -p /tmp/test-results &&
+              cp -a openmrs/api/target/surefire-reports /tmp/test-results/api &&
+              cp -a openmrs/omod/target/surefire-reports /tmp/test-results/omod
 
       - store_test_results:
           path: /tmp/test-results
              
-      # Collect and store artifacts
-      - run: >
-            mkdir -p /tmp/packages && cp $(find packages -name '*.deb') /tmp/packages
+      - run: 
+          name: Collect and store built packages
+          command: mkdir -p /tmp/packages && cp $(find packages -name '*.deb') /tmp/packages
 
       - store_artifacts:
           path: /tmp/packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,18 +37,18 @@ jobs:
           name: Collect and store test results
           command: |
               mkdir -p /tmp/test-results &&
-              cp -a openmrs/api/target/surefire-reports /tmp/test-results/api &&
-              cp -a openmrs/omod/target/surefire-reports /tmp/test-results/omod
+              cp -a openmrs/api/target/surefire-reports /tmp/build/results/api &&
+              cp -a openmrs/omod/target/surefire-reports /tmp/build/results/omod
 
       - store_test_results:
-          path: /tmp/test-results
+          path: /tmp/build/results
              
       - run: 
           name: Collect and store built packages
-          command: mkdir -p /tmp/packages && cp $(find packages -name '*.deb') /tmp/packages
+          command: mkdir -p /tmp/build/packages && cp $(find packages -name '*.deb') /tmp/build/packages
 
       - store_artifacts:
-          path: /tmp/packages
+          path: /tmp/build/packages
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,3 +49,22 @@ jobs:
 
       - store_artifacts:
           path: /tmp/packages
+
+workflows:
+  version: 2
+  normal-build:
+    jobs:
+      - build:
+          filters:
+            tags:
+              ignore: /.*/
+  release-build:
+    # Ensure that tagged releases get their own CircleCI build:
+    # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,40 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/buendia
+
+    docker:
+      - image: projectbuendia/debian-stretch:1.0.0
+
+    steps:
+      - checkout # check out the code in the project directory
+
+      - restore_cache:
+          keys:
+              - buendia-v1-{{ .Branch }}-{{ .Revision }}
+              - buendia-v1-{{ .Branch }}
+              - buendia-v1-
+          
+      - run: make -C packages PACKAGE_VERSION=1.0.${CIRCLE_BUILD_NUM}
+
+      - save_cache:
+          key: buendia-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/.m2
+            - /tmp/buendia-fetched
+
+      # Collect and store test results
+      - run: >
+          mkdir -p /tmp/test-results &&
+          cp -a openmrs/api/target/surefire-reports /tmp/test-results/api &&
+          cp -a openmrs/omod/target/surefire-reports /tmp/test-results/omod
+
+      - store_test_results:
+          path: /tmp/test-results
+             
+      # Collect and store artifacts
+      - run: >
+            mkdir -p /tmp/packages && cp $(find packages -name '*.deb') /tmp/packages
+
+      - store_artifacts:
+          path: /tmp/packages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,20 +35,21 @@ jobs:
 
       - run:
           name: Collect and store test results
+          # https://circleci.com/docs/2.0/collect-test-data/#maven-surefire-plugin-for-java-junit-results
           command: |
-              mkdir -p /tmp/test-results &&
-              cp -a openmrs/api/target/surefire-reports /tmp/build/results/api &&
-              cp -a openmrs/omod/target/surefire-reports /tmp/build/results/omod
+            mkdir -p /tmp/artifacts/tests/junit
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} /tmp/artifacts/tests/junit/ \;
+          when: always
 
       - store_test_results:
-          path: /tmp/build/results
+          path: /tmp/artifacts/tests
              
       - run: 
           name: Collect and store built packages
-          command: mkdir -p /tmp/build/packages && cp $(find packages -name '*.deb') /tmp/build/packages
+          command: mkdir -p /tmp/artifacts/packages && cp $(find packages -name '*.deb') /tmp/artifacts/packages
 
       - store_artifacts:
-          path: /tmp/build/packages
+          path: /tmp/artifacts
 
 workflows:
   version: 2

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:stretch-slim
+LABEL Description="Project Buendia Debian build image" Vendor="Project Buendia" Version="1.0"
+COPY apt/ /etc/apt/
+# The extra mkdir step is a workaround for an error in update-alternatives
+# running on stretch-slim:
+#   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199#28
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    mkdir -p /usr/share/man/man1 && \
+    apt-get install -y openjdk-7-jdk && \
+    apt-get install -y maven zip unzip git curl openssh-client make binutils
+ENTRYPOINT /bin/bash

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -1,0 +1,15 @@
+IMAGE := projectbuendia/debian-stretch
+VERSION := 1.0.1
+TAG := $(IMAGE):$(VERSION)
+CONTEXT := $(shell mktemp -d)
+
+all:
+	cp -a Dockerfile ../apt $(CONTEXT)
+	cd $(CONTEXT) && docker build -t $(TAG) .
+	rm -rf $(CONTEXT)
+
+push:
+	docker push $(TAG) || echo "Do you need to run \`docker login\`?"
+
+.DELETE_ON_ERROR:
+	rm -rf $(CONTEXT)

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,0 +1,10 @@
+# Custom Docker images for build automation
+
+Since OpenMRS 1.x relies on Java 7, we maintain our own custom Docker base
+images for build automation.
+
+`make` builds a Debian stretch image with OpenJDK 7 and other build prereqs for
+Buendia. Additional packages have been included to satisfy [CircleCI
+requirements](https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers).
+
+`make push` will push the tagged image to Docker Hub.


### PR DESCRIPTION
* Add `tools/docker/` to create a minimal Debian stretch image with OpenJDK 7 and the other prerequisites for building our Debian packages. A Makefile builds and ships the image.
* Add `.circleci/` to provide configuration for building Debian packages in CircleCI. A Makefile there can be optionally used with the [CircleCI local-cli tools](https://support.circleci.com/hc/en-us/articles/360006735753-Validating-CircleCI-configuration-files-YAML-linting-issues-etc-) to lint `config.yml` before committing/pushing.

In the process, I also set up a [Docker Hub repository](https://cloud.docker.com/u/projectbuendia/repository/docker/projectbuendia/debian-stretch) for our Docker images. The credentials have been put in the project credential store.

This branch [builds successfully](https://circleci.com/gh/projectbuendia/buendia/5) in CircleCI and produces Debian packages as artifacts.