### PR TITLE
Add apt dependencies for Tomcat 7.

### DIFF
--- a/tools/apt/preferences.d/tomcat7
+++ b/tools/apt/preferences.d/tomcat7
@@ -1,0 +1,11 @@
+# buendia-openmrs requires tomcat7.
+#
+# The only tomcat7 packages currently available are in jessie.
+
+Package: *
+Pin: release o=Debian,n=jessie
+Pin-Priority: -1
+
+Package: *tomcat7*
+Pin: release o=Debian,n=jessie
+Pin-Priority: 999

--- a/tools/apt/sources.list.d/tomcat7.list
+++ b/tools/apt/sources.list.d/tomcat7.list
@@ -1,0 +1,3 @@
+# Installing Tomcat 7 on Stretch requires including these repos
+# https://packages.debian.org/search?keywords=tomcat7
+deb http://deb.debian.org/debian jessie main


### PR DESCRIPTION
Turns out, Tomcat 7 doesn't live in any of the Debian repos we've already documented. This PR adds additional config files to `tools/apt/` (to be installed in `/etc/apt` on a stretch system) to allow `apt-get install buendia-server` to pull in the right dependencies.