### PR TITLE
Add a manual trigger to rebuild the Debian package archive.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
           # https://circleci.com/docs/2.0/env-vars/#using-bash_env-to-set-environment-variables
           command: |
               TARGET_BRANCH=${BUENDIA_BRANCH:-$CIRCLE_BRANCH}
+              echo "export BUENDIA_BRANCH=${TARGET_BRANCH}" >> $BASH_ENV
               if [ "${TARGET_BRANCH}" = "master" ]; then
                 echo "export BUENDIA_SUITE=stable" >> $BASH_ENV
               elif [ "${TARGET_BRANCH}" = "dev" ]; then
@@ -86,6 +87,16 @@ jobs:
 
       - attach_workspace:
           at: /tmp/artifacts
+
+      - run:
+          name: Fetch latest artifacts (if not already present)
+          command: |
+              PACKAGES=/tmp/artifacts/packages
+              if [ ! -d $PACKAGES -a -n "${CIRCLE_API_TOKEN}" ]; then
+                echo "Build triggered manually by ${CIRCLE_USERNAME}; fetching artifacts from latest ${BUENDIA_BRANCH} build job."
+                mkdir -p $PACKAGES && cd $PACKAGES
+                $HOME/buendia/tools/fetch_circleci_artifacts projectbuendia/buendia ${BUENDIA_BRANCH} '*.deb'
+              fi
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,19 +60,29 @@ jobs:
       - image: circleci/buildpack-deps:stretch
 
     steps:
-      - checkout # check out the code in the project directory
-
       - run:
-          name: Determine which Debian package suite to build
+          name: Determine build branch and package suite
+          # Decide which branch of projectbuendia/buendia to build from, by
+          # checking $TARGET_BRANCH and then falling back to $CIRCLE_BRANCH.
+          #
+          # Then, choose the target Debian package suite based on the given
+          # branch.
+          #
+          # See `tools/rebuild_apt_repo` for a usage example.
+          #
+          # https://circleci.com/docs/2.0/env-vars/#using-bash_env-to-set-environment-variables
           command: |
-              if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              TARGET_BRANCH=${BUENDIA_BRANCH:-$CIRCLE_BRANCH}
+              if [ "${TARGET_BRANCH}" = "master" ]; then
                 echo "export BUENDIA_SUITE=stable" >> $BASH_ENV
-              elif [ "${CIRCLE_BRANCH}" = "dev" ]; then
+              elif [ "${TARGET_BRANCH}" = "dev" ]; then
                 echo "export BUENDIA_SUITE=unstable" >> $BASH_ENV
               else
                 echo "Can only rebuild the apt archive for the 'master' or 'dev' branch!"
                 exit 1
               fi
+
+      - checkout # check out the code in the project directory
 
       - attach_workspace:
           at: /tmp/artifacts

--- a/tools/README.md
+++ b/tools/README.md
@@ -187,6 +187,11 @@ A stress-testing script that attempts to rapidly and concurrently post
 patients with duplicate IDs to a Buendia API, to verify that the Buendia
 server correctly enforces uniqueness of patient IDs in its database.
 
+#### `trigger_archive_update`
+
+Manually triggers a rebuild for the projectbuendia.github.io apt repo in
+CircleCI. Intended as an aid to CI development.
+
 #### `update_apt_archive`
 
 Copies Debian packages into an apt repository which is also a Github repository

--- a/tools/README.md
+++ b/tools/README.md
@@ -57,6 +57,11 @@ data to a SQL file (see `buendia_concept_dictionary.sql`).
 Fetches a file from a URL to a local path.  Files are cached in /tmp and
 the network download is skipped if the requested file is already in the cache.
 
+#### `fetch_circleci_artifacts`
+
+Downloads the artifacts from the latest successful build of a given project and
+branch on CircleCI.
+
 #### `generate_concept_remapping_sql`
 
 Given a directory full of `*.sql` table schemas, produces the SQL commands to

--- a/tools/fetch_circleci_artifacts
+++ b/tools/fetch_circleci_artifacts
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+# Copyright 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+import sys, json, os, os.path, urllib.request, fnmatch
+
+def usage():
+    print("""
+Usage: fetch_circleci_artifacts <project> <branch> [<glob>] [<token>]
+
+Fetches all artifacts matching a particular filename glob from the latest
+CircleCI build for the given Github project and branch to the current
+directory. Prints the names of all files fetched.
+
+<project> should be of the form '<username>/<repo>'.
+
+<glob> defaults to '*'.
+
+If <token> is not set, the script will look in the $CIRCLE_API_TOKEN
+environment variable.
+""")
+    sys.exit(-1)
+
+latest_artifacts = \
+    "https://circleci.com/api/v1.1/project/github/{project}/latest/artifacts?" + \
+        "circle-token={token}&branch={branch}&filter=successful"
+
+if len(sys.argv) < 3:
+    usage()
+
+project, branch = sys.argv[1:3]
+match = sys.argv[3] if len(sys.argv) > 3 else "*"
+token = sys.argv[4] if len(sys.argv) > 4 else os.environ.get("CIRCLE_API_TOKEN")
+
+if not all((token, match, branch)):
+    usage()
+
+query = latest_artifacts.format(token=token, project=project, branch=branch)
+request = urllib.request.Request(query, headers={"Accept": "application/json"})
+with urllib.request.urlopen(request) as response:
+    content = response.read()
+    artifacts = json.loads(content.decode())
+    for artifact in artifacts:
+        if fnmatch.fnmatch(artifact["path"], match):
+            filename = os.path.basename(artifact["path"])
+            urllib.request.urlretrieve(artifact["url"], filename)
+            print(filename)

--- a/tools/fetch_circleci_artifacts
+++ b/tools/fetch_circleci_artifacts
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # Copyright 2019 The Project Buendia Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -10,7 +10,12 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-import sys, json, os, os.path, urllib.request, fnmatch
+import sys, json, os, os.path, fnmatch
+try:
+    from urllib.request import Request, urlopen, urlretrieve  # Python 3
+except ImportError:
+    from urllib2 import Request, urlopen  # Python 2
+    from urllib import urlretrieve
 
 def usage():
     print("""
@@ -30,8 +35,8 @@ environment variable.
     sys.exit(-1)
 
 latest_artifacts = \
-    "https://circleci.com/api/v1.1/project/github/{project}/latest/artifacts?" + \
-        "circle-token={token}&branch={branch}&filter=successful"
+    "https://circleci.com/api/v1.1/project/github/%(project)s/latest/artifacts?" + \
+        "circle-token=%(token)s&branch=%(branch)s&filter=successful"
 
 if len(sys.argv) < 3:
     usage()
@@ -43,13 +48,15 @@ token = sys.argv[4] if len(sys.argv) > 4 else os.environ.get("CIRCLE_API_TOKEN")
 if not all((token, match, branch)):
     usage()
 
-query = latest_artifacts.format(token=token, project=project, branch=branch)
-request = urllib.request.Request(query, headers={"Accept": "application/json"})
-with urllib.request.urlopen(request) as response:
-    content = response.read()
-    artifacts = json.loads(content.decode())
-    for artifact in artifacts:
-        if fnmatch.fnmatch(artifact["path"], match):
-            filename = os.path.basename(artifact["path"])
-            urllib.request.urlretrieve(artifact["url"], filename)
-            print(filename)
+query = latest_artifacts % {"token":token, "project":project, "branch":branch}
+request = Request(query)
+request.add_header("Accept", "application/json")
+
+response = urlopen(request)
+content = response.read()
+artifacts = json.loads(content.decode())
+for artifact in artifacts:
+    if fnmatch.fnmatch(artifact["path"], match):
+        filename = os.path.basename(artifact["path"])
+        urlretrieve(artifact["url"], filename)
+        print(filename)

--- a/tools/trigger_archive_update
+++ b/tools/trigger_archive_update
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+PROJECT=projectbuendia/buendia
+
+if [ "$1" == "-h" -o -z "$1" ]; then
+    echo "Usage: $0 <ci_branch> [<target_branch>]"
+    echo
+    echo "Manually triggers a rebuild for the projectbuendia.github.io apt"
+    echo "repo in CircleCI, using the .circleci/config.yml from <ci_branch>."
+    echo 
+    echo "<target_branch> is the project branch against which the repo will be"
+    echo "rebuilt; it must be either 'master' or 'dev' and it defaults to"
+    echo "'dev'. You must have \$CIRCLE_API_TOKEN set in your environment"
+    echo "with a valid CircleCI API token for the $PROJECT project."
+    exit 1
+fi
+
+if [ -z "$CIRCLE_API_TOKEN" ]; then
+    echo 'You must have $CIRCLE_API_TOKEN set in order to trigger a build!'
+    exit 1
+fi
+
+CI_BRANCH=$1
+TARGET_BRANCH=${2:-dev}
+CIRCLE_API=https://circleci.com/api/v1.1/project
+
+# https://circleci.com/docs/api/#trigger-a-new-build-with-a-branch
+#
+curl -X POST --header "Content-Type: application/json" -d @- \
+    -u $CIRCLE_API_TOKEN: \
+	$CIRCLE_API/github/$PROJECT/tree/$CI_BRANCH <<DATA
+{
+    "build_parameters": {
+        "CIRCLE_JOB": "apt-archive", 
+        "BUENDIA_BRANCH": "$TARGET_BRANCH"
+    }
+}
+DATA


### PR DESCRIPTION
As an aid to development, this PR adds the ability to trigger a rebuild of the 'stable' or 'unstable' package suites, using the `tools/trigger_archive_update` script and a [valid CircleCI API token](https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-personal-api-token) in the `$CIRCLE_API_TOKEN` environment variable.

Since the manual rebuild is running without the benefit of a successful build leaving packages in the CircleCI workspace, this PR also includes a generic Python script which fetches the build artifacts from the latest successful build of the given branch. This script is called from CI whenever it appears that the apt repo rebuild has been triggered manually, using a [CircleCI API project token](https://circleci.com/docs/2.0/managing-api-tokens/#creating-a-project-api-token) with read-only access.