### PR TITLE
Fix mtimes of build dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,10 @@ workflows:
           requires:
             - build
           filters:
+            # If we allow dev to build packages on every merge, our repo will fill up with possibly
+            # meaningless non-changes to the buendia-server package (specifically the .omod inside).
+            # If you want a dev build for now, use the `tools/trigger_archive_update` tool.
             branches:
               only:
                 - master
-                - dev
+                # - dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: ~/buendia
 
     docker:
-      - image: projectbuendia/debian-stretch:1.0.0
+      - image: projectbuendia/debian-stretch:1.1.0
 
     steps:
       - checkout # check out the code in the project directory
@@ -19,6 +19,10 @@ jobs:
           name: Determine package version number
           command: |
               tools/get_package_version > /tmp/buendia-version
+
+      - run:
+          name: Restore file mtimes for later package comparison
+          command: git restore-mtime
           
       - run:
           name: Build all Debian packages

--- a/packages/buendia-server/Makefile
+++ b/packages/buendia-server/Makefile
@@ -14,11 +14,11 @@ $(MAIN_MODULE_BUILD):
 
 $(MAIN_MODULE): $(MAIN_MODULE_BUILD)
 	mkdir -p $(TARGET_DIR)
-	cp $(MAIN_MODULE_BUILD) $@
+	cp -p $(MAIN_MODULE_BUILD) $@
 
 $(OTHER_MODULES):
 	mkdir -p $(TARGET_DIR)
-	cp $(SOURCE_DIR)/$(notdir $@) $@
+	cp -p $(SOURCE_DIR)/$(notdir $@) $@
 
 $(EXTRA_DATA)/usr/bin/buendia-openmrs-account-setup:
 	mkdir -p $$(dirname $@)

--- a/packages/buendia-utils/Makefile
+++ b/packages/buendia-utils/Makefile
@@ -4,5 +4,5 @@ $(EXTRA_DATA): $(EXTRA_DATA)/usr/bin/buendia-warmup
 
 $(EXTRA_DATA)/usr/bin/buendia-warmup: $(TOP)/tools/warmup
 	mkdir -p $$(dirname $@)
-	cp $< $@
+	cp -p $< $@
 	chmod 755 $@

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stretch-slim
-LABEL Description="Project Buendia Debian build image" Vendor="Project Buendia" Version="1.0"
+LABEL Description="Project Buendia Debian build image" Vendor="Project Buendia" Version="1.1"
 COPY apt/ /etc/apt/
 # The extra mkdir step is a workaround for an error in update-alternatives
 # running on stretch-slim:
@@ -8,5 +8,5 @@ RUN apt-get update && \
     apt-get -y upgrade && \
     mkdir -p /usr/share/man/man1 && \
     apt-get install -y openjdk-7-jdk && \
-    apt-get install -y maven zip unzip git curl openssh-client make binutils
+    apt-get install -y maven zip unzip git curl openssh-client make binutils git-restore-mtime
 ENTRYPOINT /bin/bash

--- a/tools/docker/Makefile
+++ b/tools/docker/Makefile
@@ -1,5 +1,5 @@
 IMAGE := projectbuendia/debian-stretch
-VERSION := 1.0.1
+VERSION := 1.1.0
 TAG := $(IMAGE):$(VERSION)
 CONTEXT := $(shell mktemp -d)
 


### PR DESCRIPTION
Although `diffdeb` now disregards file timestamps, it will still return true for files that contain internal file directories, e.g. `.zip`, `.jar`, and `.omod` files.

This PR uses the [`git restore-mtime`](https://github.com/MestreLion/git-tools#git-restore-mtime) tool to set the modification times of the files in the local repository to the mtime of the file in its last commit.

This fixes the problem for just about everything except the `.omod` files, which contain freshly build `.class` and `.properties` files every time, and will defy this otherwise simplistic approach to functional comparison.

As a result, this PR also switches off automatic apt repo rebuilds for the `dev` branch of this repository, so that we don't fill up [our apt archive](http://github.com/projectbuendia/builds) with lots of copies of `buendia-server-x.y.z+bnnn.deb` that aren't really different from one another. These builds should still be manually runnable using `tools/trigger_archive_update dev` with a properly set `$CIRCLE_API_TOKEN` in your shell environment.