### PR TITLE
Document the static inclusion in projectbuendia/builds of the "java" package component.

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -46,6 +46,12 @@ Minimal demo data.  Input for `generate_site_sql.py`.
 Compares two .deb files to see if they are the same in all their contents
 except for the version number declared in the control file.  Used by `dedupdeb`.
 
+#### `download_java_deps`
+
+Download the various OpenJDK package dependencies to a given directory.
+Currently, this gets openjdk-7 from experimental, tomcat7 from jessie, and some
+of their dependencies from sid. Downloads files for both amd64 and i386.
+
 #### `dump_new_concepts_sql.py`
 
 Examines an OpenMRS database, using some heuristics to find all the concepts

--- a/tools/README.md
+++ b/tools/README.md
@@ -52,6 +52,8 @@ Download the various OpenJDK package dependencies to a given directory.
 Currently, this gets openjdk-7 from experimental, tomcat7 from jessie, and some
 of their dependencies from sid. Downloads files for both amd64 and i386.
 
+See the [openjdk-7.md](openjdk-7.md) documentation file for more details.
+
 #### `dump_new_concepts_sql.py`
 
 Examines an OpenMRS database, using some heuristics to find all the concepts

--- a/tools/apt/preferences.d/openjdk-7-all
+++ b/tools/apt/preferences.d/openjdk-7-all
@@ -15,26 +15,7 @@ Package: *
 Pin: release o=Debian,n=sid
 Pin-Priority: -1
 
-Package: openjdk-7-jdk
-Pin: release o=Debian,n=experimental
-Pin-Priority: 500
-
-Package: openjdk-7-jre
-Pin: release o=Debian,n=experimental
-Pin-Priority: 500
-
-Package: openjdk-7-jre-headless
-Pin: release o=Debian,n=experimental
-Pin-Priority: 500
-
-Package: libjpeg62-turbo
-Pin: release o=Debian,n=sid
-Pin-Priority: 999
-
-Package: libfontconfig1
-Pin: release o=Debian,n=sid
-Pin-Priority: 999
-
 Package: fontconfig-config
 Pin: release o=Debian,n=sid
 Pin-Priority: 999
+

--- a/tools/apt/preferences.d/openjdk-7-amd64
+++ b/tools/apt/preferences.d/openjdk-7-amd64
@@ -1,0 +1,28 @@
+# Installing openjdk-7 on Debian 9 (Stretch) requires the openjdk-7-* packages
+# from experimental, as well as certain prerequisites at suitable versions
+# (available in Sid)
+#
+# https://askubuntu.com/questions/761127/how-do-i-install-openjdk-7-on-ubuntu-16-04-or-higher
+#
+# Note the use of priority 999 to ensure that the sid versions (or better) are installed,
+# in preference to what's in stretch. https://gist.github.com/JPvRiel/8ae81e21ce6397a0502fedddca068507
+
+Package: openjdk-7-jdk:amd64
+Pin: release o=Debian,n=experimental
+Pin-Priority: 500
+
+Package: openjdk-7-jre:amd64
+Pin: release o=Debian,n=experimental
+Pin-Priority: 500
+
+Package: openjdk-7-jre-headless:amd64
+Pin: release o=Debian,n=experimental
+Pin-Priority: 500
+
+Package: libjpeg62-turbo:amd64
+Pin: release o=Debian,n=sid
+Pin-Priority: 999
+
+Package: libfontconfig1:amd64
+Pin: release o=Debian,n=sid
+Pin-Priority: 999

--- a/tools/apt/preferences.d/openjdk-7-i386
+++ b/tools/apt/preferences.d/openjdk-7-i386
@@ -1,0 +1,32 @@
+# Installing openjdk-7 on Debian 9 (Stretch) requires the openjdk-7-* packages
+# from experimental, as well as certain prerequisites at suitable versions
+# (available in Sid)
+#
+# https://askubuntu.com/questions/761127/how-do-i-install-openjdk-7-on-ubuntu-16-04-or-higher
+#
+# Note the use of priority 999 to ensure that the sid versions (or better) are installed,
+# in preference to what's in stretch. https://gist.github.com/JPvRiel/8ae81e21ce6397a0502fedddca068507
+
+Package: openjdk-7-jdk:i386
+Pin: release o=Debian,n=experimental
+Pin-Priority: 500
+
+Package: openjdk-7-jre:i386
+Pin: release o=Debian,n=experimental
+Pin-Priority: 500
+
+Package: openjdk-7-jre-headless:i386
+Pin: release o=Debian,n=experimental
+Pin-Priority: 500
+
+Package: libjpeg62-turbo:i386
+Pin: release o=Debian,n=sid
+Pin-Priority: 999
+
+Package: libfontconfig1:i386
+Pin: release o=Debian,n=sid
+Pin-Priority: 999
+
+Package: fontconfig-config:i386
+Pin: release o=Debian,n=sid
+Pin-Priority: 999

--- a/tools/download_java_deps
+++ b/tools/download_java_deps
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+architectures="i386 amd64"
+
+set -e
+
+if [ "$1" = "-h" -o $EUID != 0 ]; then
+    echo "Usage: $0 [<path>]"
+    echo
+    echo "Downloads the Java 7 dependencies for Buendia for all architectures"
+    echo "to <path>. Defaults to pwd."
+    echo 
+    echo "This command must be run as root."
+    echo 
+    echo "This command is meant to be run on disposable Debian instances,"
+    echo "so don't expect it to clean up after itself perfectly."
+    exit 1
+fi
+
+tools=$(cd $(dirname "$0") && pwd)
+if [ -n "$1" ]; then
+    mkdir -p "$1"
+    cd "$1"
+fi
+
+cat $tools/apt/preferences.d/* >/etc/apt/preferences.d/tmp
+cat $tools/apt/sources.list.d/* >/etc/apt/sources.list.d/tmp.list
+
+for arch in $architectures; do
+    echo "Fetching packages for $arch..."
+    dpkg --add-architecture $arch
+    apt-get update
+    apt-get download openjdk-7-jdk:$arch openjdk-7-jre:$arch openjdk-7-jre-headless:$arch
+    apt-get download libjpeg62-turbo:$arch libfontconfig1:$arch
+    dpkg --remove-architecture $arch || true
+done
+apt-get download fontconfig-config tomcat7 tomcat7-admin tomcat7-common libtomcat7-java
+
+rm -f /etc/apt/preferences.d/tmp /etc/apt/sources.list.d/tmp.list
+apt-get update

--- a/tools/index_debs
+++ b/tools/index_debs
@@ -13,24 +13,36 @@
 set -e
 
 if [ "$1" = "-h" -o -z "$1" -o -z "$2" ]; then
-    echo "Usage: $0 <packages-dir> <suite>"
+    echo "Usage: $0 <packages-dir> <suite> [<component>]"
     echo
     echo "Creates or updates the Release and Package indexes for the pool"
-    echo "of .deb files located at the given directory."
+    echo "of .deb files located at the given directory. <component> defaults"
+    echo "to 'main'."
     exit 1
 fi
 
-repo=$1
+repo=$(cd "$1" && pwd)
 suite=$2
 
-# This is a slow operation; each index takes a couple of minutes to build.
+# $pool in this context is "which directory of packages are we indexing right now?"
+if [ -n "$3" ]; then
+    # If "java" was specified as the component, index the Java deps.
+    # For now, the java component for stable *and* unstable is OpenJDK 7 et al
+    component=$3
+    pool=$component
+else
+    # Otherwise index the packages for the relevant suite (stable/unstable)
+    component=main
+    pool=$suite
+fi
+
 cd $repo
-rm -rf dists/${suite}
+rm -rf dists/${suite}/${component}
 for arch in i386 amd64 all; do
     echo "Indexing packages for architecture '$arch'..."
-    packages=dists/${suite}/main/binary-$arch/Packages
+    packages=dists/${suite}/${component}/binary-$arch/Packages
     mkdir -p $(dirname $packages)
-    apt-ftparchive --arch $arch packages ${suite} > $packages
+    apt-ftparchive --arch $arch packages $pool > $packages
 done
 
 # Create the overall index of indexes.
@@ -39,7 +51,7 @@ cat <<END > $release
 Origin: Buendia
 Label: Buendia Debian Packages
 Architectures: all
-Components: main
+Components: main java
 Description: Buendia Debian Packages
 END
 

--- a/tools/openjdk-7.md
+++ b/tools/openjdk-7.md
@@ -1,0 +1,51 @@
+# What's the deal with OpenJDK 7?
+
+Versions of Buendia <= 0.10.x rely on OpenMRS v1, which in turn requires
+Tomcat 7 and Java 7. However, Java 7 is [not available in Debian
+Stretch](https://packages.debian.org/search?keywords=openjdk-7). The trick to
+[getting it working in
+stretch](https://askubuntu.com/questions/761127/how-do-i-install-openjdk-7-on-ubuntu-16-04-or-higher)
+involves pulling in packages from three different Debian distributions (jessie,
+sid, and experimental), which requires making extensive changes to
+[`/etc/apt/preferences.d`](apt/preferences.d) and
+[`/etc/apt/sources.list.d`](apt/sources.list.d).
+
+Our solution, for ease of installation elsewhere, is to pull static copies of
+the necessary packages into our apt repository in
+https://projectbuendia.github.com/builds/packages/java, and then to incorporate
+those packages as `java` component in both the `stable` and `unstable` suites.
+
+# How do I install the Java 7 requirements?
+
+Configure apt to talk to our apt repository:
+
+```
+sudo apt-get install apt-transport-https
+echo "deb [trusted=yes] https://projectbuendia.github.io/builds/packages unstable main java" >/etc/apt/sources.list.d/buendia.list
+sudo apt-get update
+```
+
+Then you should be able to simply:
+
+```
+sudo apt-get install -y buendia-server buendia-site-test
+```
+
+You could also `apt-get install openjdk-7-jre-headless` et cetera.
+
+# How do I update our copies of the Java 7 requirements?
+
+We will probably never need to do this again, but if we do, the process looks
+like this.
+
+```
+git clone git@github.com:projectbuendia/builds      # this will take a while, the repo is huge
+sudo tools/download_java_deps builds/packages/java  # NOTE: this must run as root, since it modifies /etc/apt
+tools/index_debs builds/packages unstable java
+tools/index_debs builds/packages stable java
+cd builds
+git add packages/java packages/dists/*/java
+git commit -m "Update to latest Java 7 requirements"
+git push
+```
+

--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -68,6 +68,15 @@ Vagrant.configure("2") do |config|
     node.vm.provision "shell", path: "./provision-debian.sh"
   end 
 
+  config.vm.define "server" do |node|
+    # debian/contrib-stretch64 includes the vboxsf guest additions
+    node.vm.box = "debian/contrib-stretch64"
+    node.vm.provider "virtualbox" do |v|
+      v.name = "buendia-server"
+    end
+    node.vm.provision "shell", path: "./provision-server.sh"
+  end 
+
   config.vm.define "alpine", autostart: false do |node|
     node.vm.box = "maier/alpine-3.8-x86_64"
     node.vm.provider "virtualbox" do |v|

--- a/tools/vagrant/provision-server.sh
+++ b/tools/vagrant/provision-server.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+apt-get install -y apt-transport-https
+echo "deb [trusted=yes] https://projectbuendia.github.io/builds/packages unstable main java" >/etc/apt/sources.list.d/buendia.list
+apt-get update
+apt-get install -y buendia-server buendia-site-test


### PR DESCRIPTION
See [the documentation](https://github.com/projectbuendia/buendia/blob/2e6fd279/tools/openjdk-7.md) for details on how this all is supposed to work.