### PR TITLE
Fix tagged builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,3 @@ workflows:
       - apt-archive:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,14 @@ workflows:
   version: 2
   normal-build:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              # Don't do a normal build for master; instead let the
+              # release-build job do the builds off master iff that branch is
+              # tagged as part of the documented release process.
+              ignore:
+                - master
       - apt-archive:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Determine package version number
           command: |
-              tools/get_package_version > /tmp/buendia-version
+              tools/get_package_version | tee /tmp/buendia-version
 
       - run:
           name: Restore file mtimes for later package comparison

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,9 +97,15 @@ jobs:
           command: |
               PACKAGES=/tmp/artifacts/packages
               if [ ! -d $PACKAGES -a -n "${CIRCLE_API_TOKEN}" ]; then
-                echo "Build triggered manually by ${CIRCLE_USERNAME}; fetching artifacts from latest ${BUENDIA_BRANCH} build job."
+                echo -n "Build triggered manually by ${CIRCLE_USERNAME}; "
                 mkdir -p $PACKAGES && cd $PACKAGES
-                $HOME/buendia/tools/fetch_circleci_artifacts projectbuendia/buendia ${BUENDIA_BRANCH} '*.deb'
+                if [ -n "${BUENDIA_TARGET_JOB}" ]; then
+                    echo "fetching artifacts from job #${BUENDIA_TARGET_JOB}"
+                else
+                    echo "fetching artifacts from latest ${BUENDIA_BRANCH} build."
+                    BUENDIA_TARGET_JOB=latest
+                fi
+                $HOME/buendia/tools/fetch_circleci_artifacts -j ${BUENDIA_TARGET_JOB} -g '*.deb' projectbuendia/buendia ${BUENDIA_BRANCH}
               fi
 
       - restore_cache:

--- a/tools/fetch_circleci_artifacts
+++ b/tools/fetch_circleci_artifacts
@@ -10,45 +10,45 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-import sys, json, os, os.path, fnmatch
+import sys, json, os, os.path, fnmatch, argparse
 try:
     from urllib.request import Request, urlopen, urlretrieve  # Python 3
 except ImportError:
     from urllib2 import Request, urlopen  # Python 2
     from urllib import urlretrieve
 
-def usage():
-    print("""
-Usage: fetch_circleci_artifacts <project> <branch> [<glob>] [<token>]
+parser = argparse.ArgumentParser(description="""Fetches all artifacts matching
+a particular filename glob from a CircleCI job for the given Github project and
+branch to the current directory.""")
 
-Fetches all artifacts matching a particular filename glob from the latest
-CircleCI build for the given Github project and branch to the current
-directory. Prints the names of all files fetched.
+parser.add_argument("project", metavar="project",
+    help="<project> should be of the form '<username>/<repo>'")
 
-<project> should be of the form '<username>/<repo>'.
+parser.add_argument("branch", metavar="branch")
 
-<glob> defaults to '*'.
+parser.add_argument("-j", "--job", metavar="job", default="latest",
+    help="if present, the artifacts from <job> are fetched; otherwise, " + \
+         "the latest successful build on <branch> is used.")
+parser.add_argument("-g", "--glob", metavar="glob", default="*")
+parser.add_argument("-t", "--token", metavar="token",
+    help="If not set, the script will look in the $CIRCLE_API_TOKEN " + \
+         "environment variable.")
 
-If <token> is not set, the script will look in the $CIRCLE_API_TOKEN
-environment variable.
-""")
-    sys.exit(-1)
+args = parser.parse_args()
 
 latest_artifacts = \
-    "https://circleci.com/api/v1.1/project/github/%(project)s/latest/artifacts?" + \
+    "https://circleci.com/api/v1.1/project/github/%(project)s/%(job)s/artifacts?" + \
         "circle-token=%(token)s&branch=%(branch)s&filter=successful"
 
-if len(sys.argv) < 3:
-    usage()
+project, branch, job, match = args.project, args.branch, args.job, args.glob
+token = args.token or os.environ.get("CIRCLE_API_TOKEN")
 
-project, branch = sys.argv[1:3]
-match = sys.argv[3] if len(sys.argv) > 3 else "*"
-token = sys.argv[4] if len(sys.argv) > 4 else os.environ.get("CIRCLE_API_TOKEN")
+if not all((project, token, match, branch, job)):
+    args.print_help()
+    args.exit(1)
 
-if not all((token, match, branch)):
-    usage()
-
-query = latest_artifacts % {"token":token, "project":project, "branch":branch}
+query = latest_artifacts % {
+        "token":token, "project":project, "branch":branch, "job": job}
 request = Request(query)
 request.add_header("Accept", "application/json")
 

--- a/tools/trigger_archive_update
+++ b/tools/trigger_archive_update
@@ -13,14 +13,20 @@
 PROJECT=projectbuendia/buendia
 
 if [ "$1" == "-h" -o -z "$1" ]; then
-    echo "Usage: $0 <ci_branch> [<target_branch>]"
+    echo "Usage: $0 <ci_branch> [<target_branch>] [<job>]"
     echo
     echo "Manually triggers a rebuild for the projectbuendia.github.io apt"
     echo "repo in CircleCI, using the .circleci/config.yml from <ci_branch>."
     echo 
     echo "<target_branch> is the project branch against which the repo will be"
     echo "rebuilt; it must be either 'master' or 'dev' and it defaults to"
-    echo "'dev'. You must have \$CIRCLE_API_TOKEN set in your environment"
+    echo "'dev'."
+    echo
+    echo "If <job> is set, trigger the rebuild against the specific CircleCI"
+    echo "job; otherwise rebuild against the latest successful build on"
+    echo "<branch>."
+    echo
+    echo "You must have \$CIRCLE_API_TOKEN set in your environment"
     echo "with a valid CircleCI API token for the $PROJECT project."
     exit 1
 fi
@@ -32,6 +38,7 @@ fi
 
 CI_BRANCH=$1
 TARGET_BRANCH=${2:-dev}
+TARGET_JOB=$3
 CIRCLE_API=https://circleci.com/api/v1.1/project
 
 # https://circleci.com/docs/api/#trigger-a-new-build-with-a-branch
@@ -42,7 +49,8 @@ curl -X POST --header "Content-Type: application/json" -d @- \
 {
     "build_parameters": {
         "CIRCLE_JOB": "apt-archive", 
-        "BUENDIA_BRANCH": "$TARGET_BRANCH"
+        "BUENDIA_BRANCH": "$TARGET_BRANCH",
+        "BUENDIA_TARGET_JOB": "$TARGET_JOB"
     }
 }
 DATA


### PR DESCRIPTION
The (previously untestable) code path in our CircleCI code path did not successfully trigger the `apt-archive` job to update the `stable` suite in the projectbuendia.org/builds apt repository when we (successfully) [built packages for the `v0.10.0` release](https://circleci.com/gh/projectbuendia/buendia/185) in CI.

This PR provides the necessary code to allow a post-facto manual rebuild of the stable suite in CI. This process was carried out successfully in [CircleCI job 193](https://circleci.com/gh/projectbuendia/buendia/193), which brought the apt archive up to date with the v0.10.0 release of the buendia server.

The purpose of this PR is merely to pull the correct configuration and tools into the `dev` branch, so that the next release will build _and_ update the apt repository for the `stable` suite automatically.