### PR TITLE
[2016] Add stats for pilot

### DIFF
--- a/packages/buendia-dashboard/data/etc/nginx/sites-available/buendia-dashboard
+++ b/packages/buendia-dashboard/data/etc/nginx/sites-available/buendia-dashboard
@@ -37,6 +37,14 @@ server {
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param QUERY_STRING $query_string;
     }
+    location /shutdown {
+        fastcgi_pass unix:/var/run/fcgiwrap.socket;
+        fastcgi_param SCRIPT_NAME shutdown;
+        fastcgi_param SCRIPT_FILENAME /usr/share/buendia/dashboard/shutdown;
+        fastcgi_param REQUEST_METHOD $request_method;
+        fastcgi_param REQUEST_URI $request_uri;
+        fastcgi_param QUERY_STRING $query_string;
+    }
     location /clock {
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_NAME clock;

--- a/packages/buendia-dashboard/data/etc/nginx/sites-available/buendia-dashboard
+++ b/packages/buendia-dashboard/data/etc/nginx/sites-available/buendia-dashboard
@@ -21,6 +21,14 @@ server {
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param QUERY_STRING $query_string;
     }
+    location /backups {
+        fastcgi_pass unix:/var/run/fcgiwrap.socket;
+        fastcgi_param SCRIPT_NAME backups;
+        fastcgi_param SCRIPT_FILENAME /usr/share/buendia/dashboard/backups;
+        fastcgi_param REQUEST_METHOD $request_method;
+        fastcgi_param REQUEST_URI $request_uri;
+        fastcgi_param QUERY_STRING $query_string;
+    }
     location /client {
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_NAME client;

--- a/packages/buendia-dashboard/data/etc/nginx/sites-available/buendia-dashboard
+++ b/packages/buendia-dashboard/data/etc/nginx/sites-available/buendia-dashboard
@@ -13,6 +13,14 @@ server {
         fastcgi_param REQUEST_URI $request_uri;
         fastcgi_param QUERY_STRING $query_string;
     }
+    location /downtime {
+        fastcgi_pass unix:/var/run/fcgiwrap.socket;
+        fastcgi_param SCRIPT_NAME downtime;
+        fastcgi_param SCRIPT_FILENAME /usr/share/buendia/dashboard/downtime;
+        fastcgi_param REQUEST_METHOD $request_method;
+        fastcgi_param REQUEST_URI $request_uri;
+        fastcgi_param QUERY_STRING $query_string;
+    }
     location /client {
         fastcgi_pass unix:/var/run/fcgiwrap.socket;
         fastcgi_param SCRIPT_NAME client;

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/backups
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/backups
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Copyright 2015 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+set -e
+
+usb_devices=$(ls /dev/sd* | wc -l)
+if [ $usb_devices -eq 2 ]; then
+	usb_status="USB device connected ($(ls /dev/sd* | sed -e 's/\/dev\/[a-z][a-z][a-z]$//') )"
+else
+	usb_status="No USB device recognised. If you have one plugged in, try disconnecting the cable and reconnecting it."
+fi
+
+buendia_status=$(cat /home/buendia/server_status.txt)
+
+if [ $buendia_status -eq 2 ]; then
+	current_status="<b>Currently backing up internally...</b> (this will take 1-2 minutes, refreshing every 10s...)<script>setTimeout('window.location = \"\"', 10000)</script>"
+elif [ $buendia_status -eq 3 ]; then
+	current_status="<b>Currently backing up to USB...</b> (this will take 1-2 minutes, refreshing every 10s...)<script>setTimeout('window.location = \"\"', 10000)</script>"
+elif [ $buendia_status -eq 4 ]; then
+	current_status="<b>Last backup failed</b> (see backup log below for details)"
+elif [ $buendia_status -eq 5 ]; then
+	current_status="<b>Currently restoring from backup...</b> (this will take 10-20 minutes, refreshing every 10s...)<script>setTimeout('window.location = \"\"', 10000)</script>"
+elif [ $buendia_status -eq 6 ]; then
+	current_status="<b>Last restore failed</b> (see restore log below for details)"
+elif [ $buendia_status -eq 1 ]; then
+	current_status="<b>Last backup/restore succeeded</b>"
+fi
+
+num_backups_failed=$(cat -v /var/log/buendia/buendia-backup.log | grep '(end, status 1)' | wc -l)
+failed_backups=$(cat -v /var/log/buendia/buendia-backup.log | grep '(end, status 1)' | sed -e 's/^/<li>/' -e 's/:[0-9][0-9]\W*[0-9]*> .*/<\/li>/')
+
+num_backups_done=$(cat -v /var/log/buendia/buendia-backup.log | grep '(end, status 0)' | wc -l)
+successful_backups=$(cat -v /var/log/buendia/buendia-backup.log | grep '(end, status 0)' | sed -e 's/^/<li>/' -e 's/:[0-9][0-9]\W*[0-9]*> .*/<\/li>/')
+
+num_restores_done=$(cat -v /var/log/buendia/buendia-restore.log | grep '(end, status 0)' | wc -l)
+successful_restores=$(cat -v /var/log/buendia/buendia-restore.log | grep '(end, status 0)' | sed -e 's/^/<li>/' -e 's/:[0-9][0-9]\W*[0-9]*> .*/<\/li>/')
+
+backup_log=$(cat -v /var/log/buendia/buendia-backup.log | grep '(end, status 1)' -B 100 | sed -e 's/^/<br\/>/')
+restore_log=$(tail -100 /var/log/buendia/buendia-restore.log | sed -e 's/^/<br\/>/')
+
+cat <<EOF
+Content-Type: text/html
+
+<link rel="stylesheet" href="style.css">
+
+<h1>Backup and Restore Status</h1>
+
+<p><a href="/">Back to dashboard</a>
+
+<p>USB status:
+<br/><b>$usb_status</b>
+
+<p>Backup / restore status:
+<br/>$current_status
+
+<h2>Restore history</h2>
+<p>
+$num_restores_done restore(s) successfully completed:
+<ul>
+$successful_restores
+</ul>
+
+<h2>Backup history</h2>
+<p>
+$num_backups_failed backup(s) failed:
+<ul>
+$failed_backups
+</ul>
+
+<p>
+$num_backups_done backup(s) successfully completed:
+<ul>
+$successful_backups
+</ul>
+
+<h2>Backup log (most recent failed backup)</h2>
+<small>$backup_log</small>
+
+<h2>Restore log (most recent)</h2>
+<small>$restore_log</small>
+
+<p><a href="/">Back to dashboard</a>
+EOF

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/downtime
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/downtime
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright 2015 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+up_count=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status 0)' | wc -l)
+down_count=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status 1)' | wc -l)
+downtimes=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status 1)' | sed -e 's/:[0-9][0-9]\W*[0-9]*> .*/<br\/>/')
+
+# I would just use bc but it's not installed on Debian so we're constrained to integer arithmetic
+if echo $(( ($up_count + $down_count) > 0 )); then
+	up_percent=$(($up_count*100000 / ($up_count + $down_count) ))
+	up_percent_1=$(( $up_percent/1000 ))
+	up_percent_2=$(( $up_percent - $up_percent_1*1000 ))
+	up_percent=$(echo "$up_percent_1.$up_percent_2%")
+fi
+
+cat <<EOF
+Content-Type: text/html
+
+<link rel="stylesheet" href="style.css">
+<h1>Downtime</h1>
+
+<p>Uptime is $up_percent</p>
+
+<p>Server has been up $up_count minutes and down $down_count minutes.</p>
+
+<p><a href="/">Back to dashboard</a>
+
+<h2>Server downtime:</h2>
+
+$downtimes
+
+<p><a href="/">Back to dashboard</a>
+EOF

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
@@ -46,14 +46,14 @@ else
     counts="No record counts available yet.  This server is brand new!"
 fi
 
+# TODO: Make server name dynamic, coming from a config file, instead of "Project Buendia server", below
+
 cat <<EOF
 Content-Type: text/html
 
 <link rel="stylesheet" href="style.css">
 
 <h1>Project Buendia server</h1>
-
-<h2>Bokoro Pilot - Server 9 (ATFC Simple Server)</h2>
 
 <p><a href="client">Download client app</a>
 

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
@@ -72,6 +72,8 @@ Content-Type: text/html
 
 <p><a href="status">System status</a>
 
+<p><a href="backups">Backup and restore status</a>
+
 <p><a href="//$NETWORKING_IP_ADDRESS:9001">Package repository</a>
 
 <p><a href="reboot">Reboot server</a>

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
@@ -19,7 +19,6 @@ uptime=$(uptime | sed -e 's/.* up//' -e 's/, *[0-9][0-9]* *user.*//')
 
 up_count=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status 0)' | wc -l)
 down_count=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status 1)' | wc -l)
-downtimes=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status ' | sed -e 's/:[0-9][0-9]\W*[0-9]*> .*/<br\/>/')
 
 # I would just use bc but it's not installed on Debian so we're constrained to integer arithmetic
 if echo $(( ($up_count + $down_count) > 0 )); then
@@ -92,5 +91,6 @@ Content-Type: text/html
 
 <p>Server has been up $up_count minutes and down $down_count minutes.</p>
 
+<p><a href="downtime">See downtime details</a>
 
 EOF

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
@@ -22,7 +22,6 @@ down_count=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status 1)' | 
 downtimes=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status ' | sed -e 's/:[0-9][0-9]\W*[0-9]*> .*/<br\/>/')
 
 # I would just use bc but it's not installed on Debian so we're constrained to integer arithmetic
-# This will give a 'percentage' between 0 and 100,000
 if echo $(( ($up_count + $down_count) > 0 )); then
 	up_percent=$(($up_count*100000 / ($up_count + $down_count) ))
 	up_percent_1=$(( $up_percent/1000 ))
@@ -77,6 +76,8 @@ Content-Type: text/html
 <p><a href="//$NETWORKING_IP_ADDRESS:9001">Package repository</a>
 
 <p><a href="reboot">Reboot server</a>
+
+<p><a href="shutdown">Shutdown server</a>
 
 
 <h2>Currently $updown</h2>

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
@@ -17,6 +17,19 @@ tail -5 /var/log/buendia/buendia-warmup.log | grep -q Success && updown=SERVING 
 
 uptime=$(uptime | sed -e 's/.* up//' -e 's/, *[0-9][0-9]* *user.*//')
 
+up_count=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status 0)' | wc -l)
+down_count=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status 1)' | wc -l)
+downtimes=$(cat /var/log/buendia/buendia-warmup.log | grep '(end, status ' | sed -e 's/:[0-9][0-9]\W*[0-9]*> .*/<br\/>/')
+
+# I would just use bc but it's not installed on Debian so we're constrained to integer arithmetic
+# This will give a 'percentage' between 0 and 100,000
+if echo $(( ($up_count + $down_count) > 0 )); then
+	up_percent=$(($up_count*100000 / ($up_count + $down_count) ))
+	up_percent_1=$(( $up_percent/1000 ))
+	up_percent_2=$(( $up_percent - $up_percent_1*1000 ))
+	up_percent=$(echo "$up_percent_1.$up_percent_2%")
+fi
+
 cd /usr/share/buendia/counts
 latest=$(ls -t *.count | head -1)
 cdot='&#xb7;'
@@ -42,13 +55,15 @@ Content-Type: text/html
 
 <h1>Project Buendia server</h1>
 
-<h2>Staff access</h2>
+<h2>Bokoro Pilot - Server 9 (ATFC Simple Server)</h2>
 
 <p><a href="client">Download client app</a>
 
 <p><a href="//$NETWORKING_IP_ADDRESS:9000/openmrs">Login to OpenMRS</a></p>
 
 <p><a href="//$NETWORKING_IP_ADDRESS:9000/openmrs/moduleServlet/buendiadata">Download CSV data</a>
+
+<p><a href="//$NETWORKING_IP_ADDRESS:9000/openmrs/module/projectbuendia/openmrs/printable.form">Print patient charts</a>
 
 <p><a href="stats.zip">Download usage stats</a>
 
@@ -69,5 +84,12 @@ Content-Type: text/html
 <p>$(date +'%Y-%m-%d at %H:%M:%S') UTC $cdot $uptime since boot
 
 <p>$counts
+
+<h2>Uptime</h2>
+
+<p>Uptime is $up_percent</p>
+
+<p>Server has been up $up_count minutes and down $down_count minutes.</p>
+
 
 EOF

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/reboot
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/reboot
@@ -23,8 +23,8 @@ if [ "$REQUEST_METHOD" == "POST" ]; then
 Rebooting now.  The server will come back up in about 5 minutes.
 
 <p>
-Please wait 1 minute before <a href="status">checking for status</a>...
-<script>setTimeout('window.location = "status"', 60000)</script>
+Redirecting in 1 minute back to <a href="/">dashboard</a>...
+<script>setTimeout('window.location = "/"', 60000)</script>
 EOF
     touch /tmp/reboot-requested
 else

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/shutdown
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/shutdown
@@ -14,26 +14,34 @@ cat <<EOF
 Content-Type: text/html
 
 <link rel="stylesheet" href="style.css">
-<h1>Reboot</h1>
+<h1>Shutdown</h1>
 EOF
 
 if [ "$REQUEST_METHOD" == "POST" ]; then
     cat <<EOF
 <p>
-Rebooting now.  The server will come back up in about 5 minutes.
+Shutting down...
 
 <p>
-Please wait 1 minute before <a href="status">checking for status</a>...
-<script>setTimeout('window.location = "status"', 60000)</script>
+This will take about 1 minute.
+
+<p>
+Once status page cannot be reached, wait 10 seconds and then switch the server off.
+
+<p>
+Remember to set the server clock after you switch it back on!
+
+<p><a href="status">Check system status now</a>
+
 EOF
-    touch /tmp/reboot-requested
+    touch /tmp/shutdown-requested
 else
     cat <<EOF
+<p>
+This will safely shut down the server so you can switch it off.
+
 <form method="POST">
-<p>
-After reboot, the server will take about 5 minutes to come up.
-<p>
-<input type="submit" value="Reboot now">
+<input type="submit" value="Shutdown now">
 </form>
 EOF
 fi

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/style.css
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/style.css
@@ -8,6 +8,6 @@ p { margin: 0.7em 0; }
 .item { font-weight: 400; margin: 0 12px; display: inline-block; }
 .date { font-weight: 100; opacity: 0.5; }
 a, .item a { text-decoration: none; color: inherit; }
-a:hover, .item a:hover { color: #000000; opacity: 1; }
+a:hover, .item a:hover { text-decoration:underline; color: #000000; opacity: 1; }
 ul { margin: 0; }
 li { margin: 0.5em 0; }

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/style.css
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/style.css
@@ -1,4 +1,5 @@
 * { font-family: helvetica, arial; font-size: 24px; line-height: 1.2; }
+small { font-size:16px; }
 body { background: #93a1a1; color: #113355; margin: 2em 2em; opacity: 0.8; }
 h1 { font-weight: 300; font-size: 48px; margin: 0 0 1em; }
 h2 { margin: 2em 0 0; text-transform: uppercase; }

--- a/packages/buendia-utils/control/postinst
+++ b/packages/buendia-utils/control/postinst
@@ -19,9 +19,12 @@ case $1 in
             cp /debian/usr/share/buendia/systemd/* /lib/systemd/system
             systemctl enable reboot-check.timer
             systemctl start reboot-check.timer
+            systemctl enable shutdown-check.timer
+            systemctl start shutdown-check.timer
         fi
 EOF
         buendia-divert $1 /sbin/reboot
+        buendia-divert $1 /sbin/shutdown
         update-rc.d buendia-utils defaults
         ;;
 

--- a/packages/buendia-utils/data/usr/bin/buendia-status
+++ b/packages/buendia-utils/data/usr/bin/buendia-status
@@ -75,6 +75,9 @@ if [ -n "$all" ]; then
         echo -e '\n---- buendia-backup'
         buendia-last buendia-backup
 
+        echo -e '\n---- buendia-restore'
+        buendia-last buendia-restore
+
         echo -e '\n---- buendia-pkgserver-import'
         buendia-last buendia-pkgserver-import
 

--- a/packages/buendia-utils/data/usr/share/buendia/diversions/sbin/shutdown
+++ b/packages/buendia-utils/data/usr/share/buendia/diversions/sbin/shutdown
@@ -10,30 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 
-cat <<EOF
-Content-Type: text/html
+echo 'Shutting down in 5 seconds!' | wall
 
-<link rel="stylesheet" href="style.css">
-<h1>Reboot</h1>
-EOF
-
-if [ "$REQUEST_METHOD" == "POST" ]; then
-    cat <<EOF
-<p>
-Rebooting now.  The server will come back up in about 5 minutes.
-
-<p>
-Please wait 1 minute before <a href="status">checking for status</a>...
-<script>setTimeout('window.location = "status"', 60000)</script>
-EOF
-    touch /tmp/reboot-requested
-else
-    cat <<EOF
-<form method="POST">
-<p>
-After reboot, the server will take about 5 minutes to come up.
-<p>
-<input type="submit" value="Reboot now">
-</form>
-EOF
-fi
+sleep 5
+echo 'shutdown -hP now' | buendia-enter-yocto

--- a/packages/buendia-utils/data/usr/share/buendia/systemd/reboot-check.timer
+++ b/packages/buendia-utils/data/usr/share/buendia/systemd/reboot-check.timer
@@ -3,7 +3,7 @@ Description=Periodically check for a reboot request
 
 [Timer]
 OnBootSec=30
-OnUnitActiveSec=5
+OnUnitActiveSec=30
 Unit=reboot-check.service
 
 [Install]

--- a/packages/buendia-utils/data/usr/share/buendia/systemd/shutdown-check.service
+++ b/packages/buendia-utils/data/usr/share/buendia/systemd/shutdown-check.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Check for a shutdown request
+
+[Service]
+Type=simple
+ExecStart=/bin/sh -c 'if [ -e /debian/tmp/shutdown-requested ]; then rm -f /debian/tmp/shutdown-requested; /sbin/shutdown; fi'
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/buendia-utils/data/usr/share/buendia/systemd/shutdown-check.timer
+++ b/packages/buendia-utils/data/usr/share/buendia/systemd/shutdown-check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodically check for a shutdown request
+
+[Timer]
+OnBootSec=30
+OnUnitActiveSec=5
+Unit=shutdown-check.service
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/buendia-utils/data/usr/share/buendia/systemd/shutdown-check.timer
+++ b/packages/buendia-utils/data/usr/share/buendia/systemd/shutdown-check.timer
@@ -3,7 +3,7 @@ Description=Periodically check for a shutdown request
 
 [Timer]
 OnBootSec=30
-OnUnitActiveSec=5
+OnUnitActiveSec=30
 Unit=shutdown-check.service
 
 [Install]


### PR DESCRIPTION
This PR reconstitutes Dan Cunningham's PR #90 with the following description.  See #90 for discussion.

Adds some additional tools to the "dashboard" for the pilot team to use:
- Soft shutdown link
- Uptime stats and downtime report
- Backup and restore status page (including USB stick status)

To deploy this on a live server, all the files need to be put in place in Debian and then the commands in /packages/buendia-utils/control/postinst need to be run.

Alternatively, you could build new versions of the buendia-dashboard and buendia-utils packages and let the autoupdate script install those from USB.
