### PR TITLE
Configure CI to purge all but the 3 newest dev builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,70 @@ jobs:
               ssh-keyscan $STAGING_HOST >> $HOME/.ssh/known_hosts
               ssh $SSH_USER@$STAGING_HOST "sudo apt-get update && sudo apt-get -y -f install && sudo apt-get -y upgrade"
 
+  purge-unstable-repo:
+    working_directory: ~/buendia
+
+    docker:
+      - image: circleci/openjdk:stretch
+
+    steps:
+      - checkout # check out the code in the project directory
+
+      - restore_cache:
+          keys:
+            - buendia-builds-v1-{{ .Branch }}-{{ .Revision }}
+            - buendia-builds-v1-{{ .Branch }}
+            - buendia-builds-v1-
+
+      - add_ssh_keys:
+          fingerprints:
+            # github.com/projectbuendia/builds read-write key
+            - "18:e2:e2:8e:12:49:a1:ca:e6:6f:e1:30:08:02:ae:43"
+
+      - run:
+          name: Get the latest builds repository
+          ### NOTE: this job must have a key that can read AND write to
+          ### github.com/projectbuendia/builds
+          command: |
+            [ -d builds ] || git clone git@github.com:projectbuendia/builds
+            cd builds && \
+                  git fetch --force origin gh-pages && \
+                  git reset --hard origin/gh-pages && \
+                  git checkout -q -B gh-pages
+
+      - run:
+          name: Configure the Git user
+          command: |
+              git config --global user.name "CircleCI Build Process"
+              git config --global user.email "zestybuendia@gmail.com"
+
+      - run:
+          name: Install apt-utils
+          command: sudo apt-get update && sudo apt-get -y install apt-utils
+
+      - run:
+          ### NOTE: this step requires Java 8
+          name: Purge older unstable packages
+          command: tools/purge_older_packages builds packages/unstable
+
+      - run:
+          name: Re-index the unstable package suite
+          command: |
+              cd builds
+              ../tools/index_debs packages unstable
+              git add packages/dists/unstable
+              git commit -m "Automated re-indexing from CircleCI build #${CIRCLE_BUILD_NUM} (${CIRCLE_BUILD_URL})"
+
+      - run:
+          name: Force-push the package repo
+          command: cd builds && git push --force --all origin
+
+      - save_cache:
+          key: buendia-builds-v1-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/buendia/builds/.git
+            - /tmp/buendia-fetched
+
 workflows:
   version: 2
   normal-build:
@@ -210,3 +274,19 @@ workflows:
       - apt-archive:
           requires:
             - build
+
+  clean-apt-archive:
+    # Eliminate older unstable packages every night at 2am. This is intended to
+    # keep the projectbuendia.github.io/builds repo from spiraling out of
+    # control in size.
+    #
+    # https://circleci.com/docs/2.0/workflows/#nightly-example
+    triggers:
+      - schedule:
+          cron: "0 2 * * *"
+          filters:
+            branches:
+              only:
+                - dev
+    jobs:
+      - purge-unstable-repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,23 +237,9 @@ workflows:
               # tagged as part of the documented release process.
               ignore:
                 - master
-      - proceed:
-          # If we allow dev to build packages on every merge, our repo will fill up with possibly
-          # meaningless non-changes to the buendia-server package (specifically the .omod inside).
-          # You can always manually trigger an archive update with the
-          # `tools/trigger_archive_update` tool, but this won't trigger the deploy-staging job
-          # afterwards.
-          type: approval
-          requires:
-            - build
-          filters:
-            branches:
-              only:
-                - dev
       - apt-archive:
           requires:
             - build
-            - proceed
           filters:
             branches:
               only:

--- a/tools/README.md
+++ b/tools/README.md
@@ -181,6 +181,12 @@ This script is invoked when you click the "Apply" button on the
 Performs a cursory check that a given CSV file has the general form
 of a Buendia profile.
 
+#### `purge_older_packages`
+
+Scans a Debian apt pool stored in Git and destructively removes all but the _n_
+newest versions of each package. Intended primarily to be run from CI. Use with
+extreme caution.
+
 #### `remote-execution.sh`
 
 A collection of useful Bash functions for running shell commands on

--- a/tools/purge_older_packages
+++ b/tools/purge_older_packages
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Copyright 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+# BFG is a utility for removing files from a Git repository
+# https://rtyley.github.io/bfg-repo-cleaner/
+BFG_VERSION=1.13.0
+BFG_JAR_MD5=f437b07a4651c8b549703940de6ce1d2 
+
+set -e
+
+usage() {
+    echo "Usage: $0 --manual <builds repo> [<suite directory>] [<keep-n>]"
+    echo
+    echo "Aggressively removes all trace of all but the n newest Debian"
+    echo "packages from a particular suite of a builds repository."
+    echo
+    echo "USE WITH CAUTION! This script can cause serious damage to your Git"
+    echo "repo!"
+    echo
+    echo "Suite defaults to 'packages/unstable'. N defaults to 3."
+    exit 1
+}
+
+if [ "$1" = "--manual" ]; then
+    shift
+elif [ -z "$CI" ]; then
+    echo "*** Not running in CI; try again with --manual if you're certain."
+    echo
+    usage
+fi
+
+TOOLS=$(cd $(dirname $0) && pwd)
+repo=$(cd "$1" && pwd)
+subdir=${2:-packages/unstable}
+keep_newest=${3:-3}
+
+if [ ! -d "$repo" -o ! -d "$repo/.git" -o ! -d "$repo/$subdir" ]; then
+    usage
+fi
+
+older_files=$(mktemp)
+original_du=$(mktemp)
+trap "rm -f $older_files $original_du" EXIT
+
+cd $repo
+du -sm | cut -f1 > $original_du
+
+packages=$(ls $subdir | grep '\.deb$' | sed -e 's/_.*//' | sort -u)
+for name in $packages; do
+    ls ${subdir}/${name}_*.deb | sort -bt. -k1,1r -k2,2nr -k3,3r | \
+        tail +$(($keep_newest + 1)) >> $older_files
+done
+
+if [ -s $older_files ]; then
+    xargs git rm < $older_files
+else
+    echo "No older packages to remove."
+    exit 0
+fi
+
+if [ -n "$CI" ]; then
+    msg="Removing older packages in CircleCI job #${CIRCLE_BUILD_NUM} (${CIRCLE_BUILD_URL})"
+else
+    msg="Older packages removed using '$0 $repo $subdir $keep_newest'"
+fi
+git commit -m "$msg"
+
+BFG=$(pwd)/bfg.jar
+$TOOLS/fetch https://repo1.maven.org/maven2/com/madgag/bfg/$BFG_VERSION/bfg-${BFG_VERSION}.jar \
+    $BFG_JAR_MD5 $BFG
+
+trap "rm -rf $BFG *.bfg-report" EXIT
+
+cat $older_files | while read older_file; do
+    echo "Removing $older_file from repo..."
+    java -jar $BFG --delete-files $(basename $older_file) >/dev/null
+done
+
+echo "Purge complete; now collecting garbage..."
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+
+echo -n "Original repo size (in MB): "
+cat $original_du
+echo -n "Current repo size (in MB): "
+du -sm | cut -f1
+
+echo "Attempting to push with a dry run..."
+git push --all --force --dry-run origin
+echo "Run 'cd $repo && git push --all --force origin' if everything went as planned."

--- a/tools/trigger_archive_update
+++ b/tools/trigger_archive_update
@@ -13,7 +13,7 @@
 PROJECT=projectbuendia/buendia
 
 if [ "$1" == "-h" -o -z "$1" ]; then
-    echo "Usage: $0 <ci_branch> [<target_branch>] [<job>]"
+    echo "Usage: $0 [--build <build_num>] [--job <job_name>] <ci_branch> [<target_branch>]"
     echo
     echo "Manually triggers a rebuild for the projectbuendia.github.io apt"
     echo "repo in CircleCI, using the .circleci/config.yml from <ci_branch>."
@@ -22,9 +22,11 @@ if [ "$1" == "-h" -o -z "$1" ]; then
     echo "rebuilt; it must be either 'master' or 'dev' and it defaults to"
     echo "'dev'."
     echo
-    echo "If <job> is set, trigger the rebuild against the specific CircleCI"
-    echo "job; otherwise rebuild against the latest successful build on"
-    echo "<branch>."
+    echo "If <build_num> is set, trigger the rebuild against the specific"
+    echo "CircleCI job; otherwise rebuild against the latest successful build"
+    echo "on <target_branch>."
+    echo
+    echo "<job_name> defaults to 'apt-archive'."
     echo
     echo "You must have \$CIRCLE_API_TOKEN set in your environment"
     echo "with a valid CircleCI API token for the $PROJECT project."
@@ -36,9 +38,22 @@ if [ -z "$CIRCLE_API_TOKEN" ]; then
     exit 1
 fi
 
+if [ "$1" = "--build" ]; then
+    TARGET_BUILD=$2
+    shift; shift
+else
+    TARGET_BUILD=""
+fi
+
+if [ "$1" = "--job" ]; then
+    JOB_NAME=$2
+    shift; shift
+else
+    JOB_NAME=apt-archive
+fi
+
 CI_BRANCH=$1
 TARGET_BRANCH=${2:-dev}
-TARGET_JOB=$3
 CIRCLE_API=https://circleci.com/api/v1.1/project
 
 # https://circleci.com/docs/api/#trigger-a-new-build-with-a-branch
@@ -48,9 +63,9 @@ curl -X POST --header "Content-Type: application/json" -d @- \
 	$CIRCLE_API/github/$PROJECT/tree/$CI_BRANCH <<DATA
 {
     "build_parameters": {
-        "CIRCLE_JOB": "apt-archive", 
+        "CIRCLE_JOB": "$JOB_NAME", 
         "BUENDIA_BRANCH": "$TARGET_BRANCH",
-        "BUENDIA_TARGET_JOB": "$TARGET_JOB"
+        "BUENDIA_TARGET_JOB": "$TARGET_BUILD"
     }
 }
 DATA


### PR DESCRIPTION
In order to keep the projectbuendia/builds repo from growing unwieldy from new packages added with each dev build, this PR adds a `purge_older_packages` tool and a CI configuration that calls it nightly at 2am to permanently remove all but the 3 newest packages from the unstable suite in that Git repo. The file removal is performed using the [BFG utility](https://rtyley.github.io/bfg-repo-cleaner/). The stable suite in any event is left untouched.

I tested this manually in [CircleCI build #241](https://circleci.com/gh/projectbuendia/buendia/241) with the attached changes to `trigger_archive_update` and the purge ran successfully, bringing the repo size down from to >1.5G to <650M.

With this change, we are also dropping the manual approval step for unstable repo updates included in #122. As a result, merges to dev will now automatically update the repo and deploy to staging.