### PR TITLE
Expose port 9000 in Vagrant for testing.

### DIFF
--- a/tools/vagrant/Vagrantfile
+++ b/tools/vagrant/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine and only allow access
   # via 127.0.0.1 to disable public access
-  config.vm.network "forwarded_port", guest: 9000, host: 9000, host_ip: "127.0.0.1"
+  #config.vm.network "forwarded_port", guest: 9000, host: 9000, host_ip: "127.0.0.1"
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -66,6 +66,9 @@ Vagrant.configure("2") do |config|
       v.name = "buendia-debian"
     end
     node.vm.provision "shell", path: "./provision-debian.sh"
+    node.vm.network "forwarded_port", guest: 9000, host: 9000, host_ip: "127.0.0.1"
+    node.vm.network "forwarded_port", guest: 9001, host: 9001, host_ip: "127.0.0.1"
+    node.vm.network "forwarded_port", guest: 9999, host: 9999, host_ip: "127.0.0.1"
   end 
 
   config.vm.define "server", autostart: false do |node|
@@ -75,6 +78,10 @@ Vagrant.configure("2") do |config|
       v.name = "buendia-server"
     end
     node.vm.provision "shell", path: "./provision-server.sh"
+    # Allow outside clients to connect to ports 9000-9001
+    node.vm.network "forwarded_port", guest: 9000, host: 9000
+    node.vm.network "forwarded_port", guest: 9001, host: 9001
+    node.vm.network "forwarded_port", guest: 9999, host: 9999, host_ip: "127.0.0.1"
   end 
 
   config.vm.define "alpine", autostart: false do |node|
@@ -83,5 +90,6 @@ Vagrant.configure("2") do |config|
       v.name = "buendia-alpine"
     end
     node.vm.provision "shell", path: "./provision-alpine.sh"
+    node.vm.network "forwarded_port", guest: 9000, host: 9000, host_ip: "127.0.0.1"
   end
 end

--- a/tools/vagrant/provision-server.sh
+++ b/tools/vagrant/provision-server.sh
@@ -1,5 +1,5 @@
 #/bin/bash
 apt-get install -y apt-transport-https
-echo "deb [trusted=yes] https://projectbuendia.github.io/builds/packages unstable main java" >/etc/apt/sources.list.d/buendia.list
+echo "deb [trusted=yes] https://projectbuendia.github.io/builds/packages unstable main java" >/etc/apt/sources.list.d/buendia-github.list
 apt-get update
-apt-get install -y buendia-server buendia-site-test
+apt-get install -y buendia-server buendia-site-test buendia-dashboard


### PR DESCRIPTION
Only applies to the canned server VM config, i.e. `vagrant up server`. Enables testers to run a server in Vagrant and connect from an Android client on the local Wi-Fi.

This PR also includes a patch to keep the Vagrant provisioned sources.list from being blown away by the Buendia Debian package install.

