### PR TITLE
Cherry-pick various fixes from the 2016-dev branch

### DIFF
--- a/openmrs/api/src/main/resources/liquibase.xml
+++ b/openmrs/api/src/main/resources/liquibase.xml
@@ -17,6 +17,9 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <changeSet id="buendia-add-person-date-updated-index" author="@capnfabs">
+        <!--
+        Note: this changeset is buggy. See `buendia-modify-person-insert-triggers` for the fix.
+        -->
         <createTable
                 tableName="buendia_patient_sync_map"
                 remarks="Records are automatically inserted by triggers on the `person` table." >
@@ -210,5 +213,33 @@
                 DROP TRIGGER IF EXISTS `buendia_order_insert_date_updated`;
             </sql>
         </rollback>
+    </changeSet>
+    <changeSet id="buendia-modify-person-insert-triggers" author="@capnfabs">
+        <!--
+        This changeset fixes a bug in `buendia-add-person-date-updated-index`. See
+        https://github.com/projectbuendia/client/issues/187
+        -->
+        <sql>
+            DROP TRIGGER IF EXISTS `buendia_patient_insert_date_updated`;
+
+            <!--
+            The `person` table gets updated for a superset of changes to the `patient` table, so for
+            UPDATES, we define a trigger on the `person` table and check that the `person` is a
+            `patient`. See `buendia-add-person-date-updated-index`.
+
+            For INSERTS, however, we can't do the check that a `person` is a `patient`, because the
+            `patient` row hasn't been inserted in the database yet. We work around this by defining
+            a trigger on the `patient` table that checks the `person` table and obtains details from
+            there if appropriate.
+            -->
+            CREATE TRIGGER `buendia_patient_insert_date_updated` AFTER INSERT
+            ON `patient` FOR EACH ROW
+            REPLACE INTO `buendia_patient_sync_map` (patient_id, date_updated, uuid)
+            VALUES (
+                NEW.patient_id,
+                NOW(),
+                (SELECT uuid FROM person WHERE person_id = NEW.patient_id)
+            );
+        </sql>
     </changeSet>
 </databaseChangeLog>

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
@@ -141,7 +141,7 @@ public class ConceptResource extends AbstractReadOnlyResource<Concept> {
                 return Collections.emptyList();
             }
 
-            List list = (List) extendedData.get("concepts");
+            List list = (List) object;
             for (Object obj : list) {
                 if (obj == null) {
                     continue;

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
@@ -110,10 +110,7 @@ public class EncounterResource implements Creatable {
             (List) post.get("observations"), (List) post.get("order_uuids"),
             patient, encounterTime, "new observation", "ADULTRETURN",
             // TODO: Consider using patient's location instead of the root location.
-            LocationResource.ROOT_UUID);
-        if (encounter == null) {
-            throw new InvalidObjectDataException("No observations specified");
-        }
+            LocationResource.ROOT_UUID, (String) post.get("enterer_uuid"));
         SimpleObject simpleObject = new SimpleObject();
         populateJsonProperties(encounter, simpleObject);
         return simpleObject;
@@ -133,7 +130,7 @@ public class EncounterResource implements Creatable {
         encounterJson.put("timestamp", Utils.toIso8601(encounter.getEncounterDatetime()));
         encounterJson.put("uuid", encounter.getUuid());
 
-        SimpleObject observations = new SimpleObject();
+        ArrayList<SimpleObject> observations = new ArrayList<>();
         List<String> orderUuids = new ArrayList<>();
         for (Obs obs : encounter.getObs()) {
             Concept concept = obs.getConcept();
@@ -143,7 +140,7 @@ public class EncounterResource implements Creatable {
                 continue;
             }
 
-            observations.put(obs.getConcept().getUuid(), ObservationsHandler.obsValueToString(obs));
+            observations.add(ObservationsHandler.obsToJson(obs));
         }
         if (!observations.isEmpty()) {
             encounterJson.put("observations", observations);

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
@@ -14,7 +14,6 @@
 package org.openmrs.projectbuendia.webservices.rest;
 
 import org.openmrs.Obs;
-import org.openmrs.Provider;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -23,7 +22,6 @@ import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.resource.api.Listable;
 import org.openmrs.module.webservices.rest.web.resource.api.Searchable;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
-import org.openmrs.projectbuendia.Utils;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
 import org.projectbuendia.openmrs.api.SyncToken;
 import org.projectbuendia.openmrs.api.db.SyncPage;
@@ -70,47 +68,13 @@ public class ObservationResource implements Listable, Searchable {
                         syncFrom, syncFrom != null, MAX_OBS_PER_PAGE);
         List<SimpleObject> jsonResults = new ArrayList<>(observations.results.size());
         for (Obs obs : observations.results) {
-            jsonResults.add(obsToJson(obs));
+            jsonResults.add(ObservationsHandler.obsToJson(obs));
         }
         SyncToken newToken = SyncTokenUtils.clampSyncTokenToBufferedRequestTime(
                 observations.syncToken, requestTime);
         // If we fetched a full page, there's probably more data available.
         boolean more = observations.results.size() == MAX_OBS_PER_PAGE;
         return ResponseUtil.createIncrementalSyncResults(jsonResults, newToken, more);
-    }
-
-    private SimpleObject obsToJson(Obs obs) {
-        SimpleObject object = new SimpleObject()
-            .add("uuid", obs.getUuid())
-            .add("voided", obs.isVoided());
-
-        if (obs.isVoided()) {
-            return object;
-        }
-
-        object
-            .add("patient_uuid", obs.getPerson().getUuid())
-            .add("encounter_uuid", obs.getEncounter().getUuid())
-            .add("concept_uuid", obs.getConcept().getUuid())
-            .add("timestamp", Utils.toIso8601(obs.getObsDatetime()));
-
-        Provider provider = Utils.getProviderFromUser(obs.getCreator());
-        object.add("enterer_uuid", provider != null ? provider.getUuid() : null);
-
-        boolean isExecutedOrder =
-                DbUtil.getOrderExecutedConcept().equals(obs.getConcept()) && obs.getOrder() != null;
-        if (isExecutedOrder) {
-            // As far as the client knows, a chain of orders is represented by the root order's
-            // UUID, so we have to work back through the chain or orders to get the root UUID.
-            // Normally, the client will only ever supply observations for the root order ID, but
-            // in the event that an order is marked as executed on the server (for example) we don't
-            // want that to mean that an order execution gets missed.
-            object.add("value", Utils.getRootOrder(obs.getOrder()).getUuid());
-        } else {
-            object.add("value", ObservationsHandler.obsValueToString(obs));
-        }
-
-        return object;
     }
 
     @Override

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
@@ -276,7 +276,7 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
         ObservationsHandler.addEncounter(
             (List) json.get("observations"), null,
             patient, patient.getDateCreated(), "Initial triage",
-            "ADULTINITIAL", LocationResource.TRIAGE_UUID);
+            "ADULTINITIAL", LocationResource.TRIAGE_UUID, (String) json.get("enterer_id"));
         return patientToJson(patient);
     }
 

--- a/tools/profile_apply
+++ b/tools/profile_apply
@@ -144,9 +144,10 @@ def apply(tabs):
     text_datatype = db.get('concept_datatype_id', name='Text')
     answer_datatype = db.get('concept_datatype_id', name='N/A')
     datatypes_by_type = {
-        'yes_no': coded_datatype,  # unknown (1067), no (1066), or yes (1065)
+        'yes_no': coded_datatype,  # no (1066) or yes (1065)
+        'yes_no_unknown': coded_datatype,  # unknown (1067), no (1066), or yes (1065)
         'select_one': coded_datatype,
-        'select_multiple': coded_datatype,  # no (1066) or yes (1065)
+        'select_multiple': coded_datatype,  # set of no (1066) or yes (1065) fields
         'number': numeric_datatype,
         'text': text_datatype,
     }
@@ -467,9 +468,12 @@ def apply(tabs):
                     section_id = add_field_to_form(form_id, field_id, None, fn)
 
                 if (concept_id and
-                    type in ['number', 'text', 'yes_no', 'select_one']):
+                    type in ['number', 'text', 'yes_no', 'yes_no_unknown', 'select_one']):
                     put_concept(concept_id, label, LOCALE, datatype, obs_class)
                     if type == 'yes_no':
+                        # Answers are: no (1066) or yes (1065)
+                        set_concept_answers(concept_id, [1066, 1065])
+                    elif type == 'yes_no_unknown':
                         # Answers are: unknown (1067), no (1066), or yes (1065)
                         set_concept_answers(concept_id, [1067, 1066, 1065])
                     if datatype == numeric_datatype:

--- a/tools/profile_apply
+++ b/tools/profile_apply
@@ -147,7 +147,7 @@ def apply(tabs):
         'yes_no': coded_datatype,  # no (1066) or yes (1065)
         'yes_no_unknown': coded_datatype,  # unknown (1067), no (1066), or yes (1065)
         'select_one': coded_datatype,
-        'select_multiple': coded_datatype,  # set of no (1066) or yes (1065) fields
+        'select_multiple': coded_datatype,  # set of 'yes_no' fields
         'number': numeric_datatype,
         'text': text_datatype,
     }


### PR DESCRIPTION
This brings over:
  - Fix for patients not syncing until they have been edited once.
  - Sync secondary concepts used in chart rendering.
  - Introduce the yes_no_unknown type, and make yes_no mean only yes or no.
  - Add server changes to support the notes field in encounters.