### PR TITLE
Allow no-op migration among versions 0.9, 0.10, 0.11, 0.12.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,8 @@ jobs:
               elif [ "${TARGET_BRANCH}" = "dev" ]; then
                 echo "export BUENDIA_SUITE=unstable" >> $BASH_ENV
               else
-                echo "Can only rebuild the apt archive for the 'master' or 'dev' branch!"
+                echo "Attempting to build on the ${TARGET_BRANCH} branch, but "
+                echo "can only rebuild the apt archive for the 'master' or 'dev' branch!"
                 exit 1
               fi
               source $BASH_ENV
@@ -166,8 +167,10 @@ jobs:
       - deploy:
           name: Deploy to staging.buendia.org
           command: |
-              ssh-keyscan $STAGING_HOST >> $HOME/.ssh/known_hosts
-              ssh $SSH_USER@$STAGING_HOST "sudo apt-get update && sudo apt-get -y -f install && sudo apt-get -y upgrade"
+            if [ "$BUENDIA_BRANCH" = "dev" ]; then
+                ssh-keyscan $STAGING_HOST >> $HOME/.ssh/known_hosts
+                ssh $SSH_USER@$STAGING_HOST "sudo apt-get update; sudo apt-get -y -f install; sudo apt-get -y upgrade; sudo apt-get -y -f install"
+            fi
 
   purge-unstable-repo:
     working_directory: ~/buendia

--- a/packages/buendia-db-migrate/data/usr/bin/buendia-db-migrate
+++ b/packages/buendia-db-migrate/data/usr/bin/buendia-db-migrate
@@ -47,14 +47,11 @@ if [ "$current_minor" = "0.0" -o "$target_minor" = "0.0" ]; then
     exit 0
 fi
 
-if [ "$current_minor/$target_minor" = "0.9/0.10" ]; then
-    echo "$0: Migrated from $current to $target (no-op: no schema changes in 0.10)."
-    exit 0
-fi
-
-if [ "$current_minor/$target_minor" = "0.10/0.11" ]; then
-    echo "$0: Migrated from $current to $target (no-op: no schema changes in 0.10)."
-    exit 0
+if [[ $current_minor =~ ^(0.9|0.10|0.11|0.12)$ ]]; then
+    if [[ $target_minor =~ ^(0.9|0.10|0.11|0.12)$ ]]; then
+        echo "$0: Migrated from $current to $target (no-op: no schema changes from 0.9 through 0.12)."
+        exit 0
+    fi
 fi
 
 echo "$0: Don't know how to migrate from version $current to version $target."

--- a/packages/buendia-db-migrate/data/usr/bin/buendia-db-migrate
+++ b/packages/buendia-db-migrate/data/usr/bin/buendia-db-migrate
@@ -37,6 +37,8 @@ if [[ $target =~ ^([0-9]+.[0-9]+) ]]; then
     target_minor=$BASH_REMATCH
 fi
 
+echo "$0: Attempting to migrate from $current_minor to $target_minor"
+
 if [ -n "$current_minor" -a $current_minor = $target_minor ]; then
     echo "$0: Migrated from $current to $target (no-op: same minor version)."
     exit 0

--- a/tools/dedupdeb
+++ b/tools/dedupdeb
@@ -30,10 +30,7 @@ for name in $names; do
 
     if [ -n "$last_minor" -a "$last_minor" != "$second_last_minor" ]; then
         echo "different minor versions between $last and $second_last; skipping"
-        continue
-    fi
-
-    if [ "$last" != "$second_last" ] && $TOOLS/diffdeb $last $second_last; then
+    elif [ "$last" != "$second_last" ] && $TOOLS/diffdeb $last $second_last; then
         echo "removing $last (no substantive changes from $second_last)"
         rm $last
     fi


### PR DESCRIPTION
After this is merged to `dev`, let's do a `0.12.1` release.  @schuyler  Anything else we need to do to clear everything up?