### PR TITLE
Ensure that buendia-pkgserver / buendia-update still work.

### DIFF
--- a/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-import
+++ b/packages/buendia-pkgserver/data/usr/bin/buendia-pkgserver-import
@@ -75,7 +75,8 @@ function adjust_filename() {
 # packages dropped there can be moved into the repo instantaneously.
 name=$(basename $0)
 exdir=/tmp/$name.ex.$$
-pkgdir=/usr/share/buendia/packages.import.$$
+package_repo=/usr/share/buendia/packages
+pkgdir=${package_repo}.import.$$
 rm -rf $exdir $pkgdir
 mkdir -p $exdir $pkgdir
 
@@ -146,17 +147,21 @@ if [ -n "$unpacked" ]; then
             # Installing update: red and yellow
             buendia-led red on || true
             buendia-led yellow on || true
+
+            # Ensure that the suite subdirectory exists for the package repo
+            mkdir -p ${package_repo}/${suite}
+
             s=s; [ "$count" == 1 ] && s= || true
-            if mv $pkgdir/* /usr/share/buendia/packages; then
+            if mv $pkgdir/* ${package_repo}/${suite}; then
                 echo "Imported $count package$s."
             else
                 echo "Error trying to import $count package$s; continuing."
             fi
 
             # Regenerate indexes.
-            buendia-pkgserver-index-debs $pkgdir $suite || true
+            buendia-pkgserver-index-debs $package_repo $suite || true
             buendia-pkgserver-index-apks || true
-            chmod -R a+rX /usr/share/buendia/packages || true
+            chmod -R a+rX $package_repo || true
         fi
 
         # Copy over site settings files.


### PR DESCRIPTION
In #108 I brought my changes to `tools/index_debs` into `buendia-pkgserver`, and in 9eb9b671, modified `buendia-pkgserver-import` to add the suite argument to the call to `index_debs`. However, this change broke the former script as the package repo directory was not structured with suites in separate subdirectories.

This PR fixes that update by ensuring that `/usr/share/buendia/packages` ends up with the new packages copied into the appropriate suite subdirectory, as `index_debs` now expects.

I have also (manually) confirmed that with this change, `buendia-pkgserver-import` will take a bundle ZIP, and:

1. copy any `.deb` files from the bundle into `/usr/share/buendia/packages/` and reindex them
1. copy any `NN-configuration` files into `/usr/share/buendia/site/`
1. run `commands.sh` if found

Moreover, with `buendia-update` installed, any new `.deb` files are installed according to the configuration of that package.
