### PR TITLE
Fixes to buendia-networking

### DIFF
--- a/packages/buendia-networking/control/prerm
+++ b/packages/buendia-networking/control/prerm
@@ -30,6 +30,9 @@ case $1 in
         revert $hostapd_conf
         revert $dhcpd_conf
 
+        # Remove added configuration files, if present
+        rm -f /etc/dnsmasq.d/buendia-dhcp.conf
+
         # Restore the original setup (DHCP client enabled, not an AP)
         systemctl disable hostapd
         systemctl stop hostapd || true

--- a/packages/buendia-networking/data/usr/bin/buendia-update-hosts
+++ b/packages/buendia-networking/data/usr/bin/buendia-update-hosts
@@ -30,7 +30,7 @@ names=$(echo $(hostname) $(cat /usr/share/buendia/names.d/* | sed -e 's/#.*//'))
 
 # Add a line for each of the machine's IP addresses.
 # TODO this matching pattern apparently isn't quite right
-for ip in $(ip a | grep -o 'inet [0-9.]\+' | sed -e 's/.*://'); do
+for ip in $(ip a | grep 'inet ' | cut -d' ' -f6 | cut -d/ -f1 | grep -v '^127\.'); do
     echo "$ip $names  # added by buendia-update-hosts" >> $tmp
 done
 

--- a/packages/buendia-networking/data/usr/share/buendia/config.d/networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/networking
@@ -136,6 +136,8 @@ if $(bool $NETWORKING_DHCP_DNS_SERVER); then
     else
         rm -f /etc/dnsmasq.d/buendia-dhcp.conf
     fi
+
+    ln -sf /usr/bin/buendia-update-hosts /etc/network/if-up.d/
             
     service dnsmasq restart
     update-rc.d dnsmasq enable
@@ -145,6 +147,8 @@ else
     # Turn on the local DHCP client.
     systemctl enable dhcpcd
     systemctl start dhcpcd
+
+    rm -f /etc/network/if-up.d/buendia-update-hosts
 
     # Disable dnsmasq now, and also for future boots.
     service dnsmasq stop

--- a/packages/buendia-networking/data/usr/share/buendia/config.d/networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/networking
@@ -62,14 +62,14 @@ cp $tmp_settings /etc/buendia-networking.settings
 
 # Apply the settings to the Debian network interface configuration.
 unindent <<< "
-    auto lo usb0 $WIFI_INTERFACE $ETHERNET_INTERFACE
+    auto lo $WIFI_INTERFACE
 
     iface lo inet loopback
 
     iface $ETHERNET_INTERFACE inet dhcp
 
     iface $WIFI_INTERFACE inet static
-	address $NETWORKING_IP_ADDRESS/24
+	    address $NETWORKING_IP_ADDRESS/24
         wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
 " > /etc/network/interfaces
 

--- a/packages/buendia-networking/data/usr/share/buendia/config.d/networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/networking
@@ -10,7 +10,7 @@
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
 WIFI_INTERFACE=wlp2s0
-ETHERNET_INTERFACE=eth2s0
+ETHERNET_INTERFACE=enp3s0
 
 if [ -z $WIFI_INTERFACE ]; then
   MAIN_INTERFACE=$ETHERNET_INTERFACE
@@ -68,9 +68,13 @@ unindent <<< "
 
     iface $ETHERNET_INTERFACE inet dhcp
 
-    iface $WIFI_INTERFACE inet manual
+    iface $WIFI_INTERFACE inet static
+	address $NETWORKING_IP_ADDRESS/24
         wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
 " > /etc/network/interfaces
+
+# Apply wpa_supplicant configuration.
+wpa_passphrase $NETWORKING_SSID $NETWORKING_PASSWORD > /etc/wpa_supplicant/wpa_supplicant.conf
 
 # Apply dhcpcd configuration
 unindent <<< "
@@ -109,38 +113,32 @@ unindent <<< "
     rsn_pairwise=CCMP
 " > $hostapd_conf
 
-# Apply dnsmasq configuration
-unindex <<< "
-  interface=$WIFI_INTERFACE
-  listen-address=$NETWORKING_IP_ADDRESS
-  bind-interfaces
-" > /etc/dnsmasq.conf
-
 # Enable the wpa_supplicant hook
-if [[ ! -d /usr/lib/dhcpcd ]]; then
-  mkdir /usr/lib/dhcpcd;
-  mkdir /usr/lib/dhcpcd/dhcpcd-hooks;
-fi
-if [[ ! -d /usr/lib/dhcpcd/dhcpcd-hooks ]]; then
-  mkdir /usr/lib/dhcpcd/dhcpcd-hooks;
-fi
+mkdir -p /usr/lib/dhcpcd/dhcpcd-hooks
 if [[ ! -f /usr/share/dhcpcd/hooks/10-wpa_supplicant ]]; then
   ln -s /usr/share/dhcpcd/hooks/10-wpa_supplicant /usr/lib/dhcpcd/dhcpcd-hooks/
 fi
 
 # Activate or deactivate the DHCP server and client according to the settings.
 if $(bool $NETWORKING_DHCP_DNS_SERVER); then
-    echo 'Turning on DHCP/DNS server; disabling DHCP client.'
+    echo 'Turning on DHCP and DNS server; disabling DHCP client.'
 
     # Turn off the local DHCP client.
     systemctl stop dhcpcd
     systemctl disable dhcpcd
 
-    # Enable dnsmasq now, and also for future boots.  dnsmasq.conf is
-    # managed in /usr/share/buendia/diversions, so we only need to turn it on.
+    if [ -n "$NETWORKING_DHCP_RANGE" ]; then
+        unindent <<< "
+            dhcp-authoritative
+            dhcp-range=$NETWORKING_DHCP_RANGE
+            dhcp-option=option:ntp-server,$NETWORKING_IP_ADDRESS
+        " > /etc/dnsmasq.d/buendia-dhcp.conf
+    else
+        rm -f /etc/dnsmasq.d/buendia-dhcp.conf
+    fi
+            
     service dnsmasq restart
     update-rc.d dnsmasq enable
-
 else
     echo "Turning off DHCP/DNS server; enabling DHCP client."
 

--- a/packages/buendia-networking/data/usr/share/buendia/diversions/etc/dnsmasq.conf
+++ b/packages/buendia-networking/data/usr/share/buendia/diversions/etc/dnsmasq.conf
@@ -3,4 +3,10 @@
 # (10.0.0.50, not its local address 127.0.0.1 or USB address 192.168.2.15).
 localise-queries
 
+# Don't forward domainless queries
+domain-needed
+
+# Don't forward addresses in private IP spaces
+bogus-priv
+
 domain=local

--- a/packages/buendia-networking/data/usr/share/buendia/diversions/etc/dnsmasq.conf
+++ b/packages/buendia-networking/data/usr/share/buendia/diversions/etc/dnsmasq.conf
@@ -4,7 +4,3 @@
 localise-queries
 
 domain=local
-
-dhcp-authoritative
-dhcp-range=10.0.0.100,10.0.0.199,12h
-dhcp-option=option:ntp-server,10.0.0.50

--- a/packages/buendia-networking/data/usr/share/buendia/site/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/site/10-networking
@@ -10,5 +10,8 @@ NETWORKING_PASSWORD=password
 # provide DHCP and DNS service for the network.
 NETWORKING_DHCP_DNS_SERVER=0
 
+# Set to provide DHCP (if NETWORKING_DHCP_DNS_SERVER is set); otherwise none is provided.
+NETWORKING_DHCP_RANGE=10.0.0.100,10.0.0.199,12h
+
 # This host's IP address.  Only used if NETWORKING_DHCP_DNS_SERVER is 1.
 NETWORKING_IP_ADDRESS=10.0.0.50

--- a/packages/buendia-site-test/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-test/data/usr/share/buendia/site/40-site
@@ -16,10 +16,15 @@ MONITORING_LIMITS='
 100000 /usr/share/buendia/packages
 '
 
-# Creates the buendia-test wifi network and provides DHCP/DNS.
-NETWORKING_AP=1
-NETWORKING_SSID=buendia-test
+# Join the existing "buendia" network as provided by the Nanostation
+NETWORKING_AP=0
+NETWORKING_SSID=buendia
+NETWORKING_PASSWORD=password
+
+# Get a static address on the network and provide DNS but not DHCP.
+NETWORKING_IP_ADDRESS=10.18.0.50
 NETWORKING_DHCP_DNS_SERVER=1
+NETWORKING_DHCP_RANGE=
 
 # Keep the Edison up to date.
 UPDATE_AUTOUPDATE=1

--- a/packages/buendia-utils/data/usr/share/buendia/systemd/reboot-check.timer
+++ b/packages/buendia-utils/data/usr/share/buendia/systemd/reboot-check.timer
@@ -2,7 +2,7 @@
 Description=Periodically check for a reboot request
 
 [Timer]
-OnBootSec=30
+OnBootSec=120
 OnUnitActiveSec=5
 Unit=reboot-check.service
 


### PR DESCRIPTION
This set of changes more or less ensures that a properly configured NUC can get on the network at boot and stay there.

* Add configuration of DHCP ranges to `$NETWORKING_DHCP_RANGE` and disable serving DHCP if this is not set
* Ensure that `/etc/hosts` and `dnsmasq` (if needed) get a refresh every time a network interface comes up
* Don't automatically bring up the Ethernet device on DHCP if there's a chance it might fail; this seems to cause the networking service to die before it gets to setting up the WPA connection on the wireless interface.
* Other minor bits of polishing.