### PR TITLE
Setting an empty MAILTO in crontab requires quotes.

### DIFF
--- a/packages/buendia-backup/data/etc/cron.d/buendia-backup
+++ b/packages/buendia-backup/data/etc/cron.d/buendia-backup
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 # Back up to the first /dev/sd* partition we can find.
 0 * * * * root . /usr/share/buendia/utils.sh; if bool "$BACKUP_EXTERNAL"; then for dev in /dev/sd?[0-9]*; do [ -e $dev ] && buendia-log buendia-backup $dev $BACKUP_EXTERNAL_LIMIT_PERCENT && break; done; fi

--- a/packages/buendia-dashboard/data/etc/cron.d/buendia-dashboard
+++ b/packages/buendia-dashboard/data/etc/cron.d/buendia-dashboard
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 */10 * * * * root /usr/bin/buendia-distill /var/log/large/requests /usr/share/buendia/distilled /var/log/requests
 

--- a/packages/buendia-monitoring/data/etc/cron.d/buendia-monitoring
+++ b/packages/buendia-monitoring/data/etc/cron.d/buendia-monitoring
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 * * * * * root chmod -R a+rX /var/log
 0 * * * * root buendia-log 'logrotate /etc/logrotate.conf; buendia-apply-limits'

--- a/packages/buendia-mysql/data/etc/cron.d/buendia-mysql
+++ b/packages/buendia-mysql/data/etc/cron.d/buendia-mysql
@@ -1,5 +1,5 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 */5 * * * * root buendia-log buendia-mysql-watchdog

--- a/packages/buendia-networking/data/etc/cron.d/buendia-networking
+++ b/packages/buendia-networking/data/etc/cron.d/buendia-networking
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 * * * * * root buendia-update-hosts
 

--- a/packages/buendia-pkgserver/data/etc/cron.d/buendia-pkgserver
+++ b/packages/buendia-pkgserver/data/etc/cron.d/buendia-pkgserver
@@ -1,5 +1,5 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 * * * * * root sleep 5; for i in $(seq 6); do for dev in /dev/sd?1; do [ -e $dev ] && buendia-log buendia-pkgserver-import $dev; done; sleep 10; done

--- a/packages/buendia-server/data/etc/cron.d/buendia-server
+++ b/packages/buendia-server/data/etc/cron.d/buendia-server
@@ -1,5 +1,5 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 * * * * * root buendia-log buendia-warmup localhost:9000

--- a/packages/buendia-tomcat7/data/etc/cron.d/buendia-tomcat7
+++ b/packages/buendia-tomcat7/data/etc/cron.d/buendia-tomcat7
@@ -1,5 +1,5 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 */5 * * * * root buendia-log buendia-tomcat7-watchdog

--- a/packages/buendia-update/data/etc/cron.d/buendia-update
+++ b/packages/buendia-update/data/etc/cron.d/buendia-update
@@ -1,5 +1,5 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-MAILTO=
+MAILTO=""
 
 * * * * * root buendia-log buendia-autoupdate -u 60

--- a/packages/buendia-utils/control/postinst
+++ b/packages/buendia-utils/control/postinst
@@ -26,7 +26,7 @@ case $1 in
         # user in /etc/aliases) by setting MAILTO= empty in /etc/crontab.
         if ! grep -q MAILTO= /etc/crontab; then
             echo "Disabling email output from /etc/crontab..."
-            sed -re 's/(PATH=.*)/\1\nMAILTO=/g' /etc/crontab > /tmp/crontab.$$
+            sed -re 's/(PATH=.*)/\1\nMAILTO=""/g' /etc/crontab > /tmp/crontab.$$
             mv /tmp/crontab.$$ /etc/crontab
             systemctl restart cron
         fi

--- a/packages/buendia-utils/control/prerm
+++ b/packages/buendia-utils/control/prerm
@@ -14,7 +14,7 @@ set -e; . /usr/share/buendia/utils.sh
 
 update-rc.d buendia-utils remove
 
-if grep -q '^MAILTO=$' /etc/crontab; then
+if grep -q '^MAILTO=""$' /etc/crontab; then
     echo "Email is still disabled in /etc/crontab; please confirm that this is"
     echo "still desired."
 fi


### PR DESCRIPTION
Otherwise cron breaks. Fixes #132 & #134.

Confirmed that this solution works in vagrant by checking the contents of `/var/log/buendia/` several minutes after [installing new packages](https://circleci.com/gh/projectbuendia/buendia/355#artifacts/containers/0) from this branch.
