### PR TITLE
Limit the size of mail spools to 1M (with 5 rotations) using logrotate.

### DIFF
--- a/packages/buendia-monitoring/data/usr/share/buendia/diversions/etc/logrotate.conf
+++ b/packages/buendia-monitoring/data/usr/share/buendia/diversions/etc/logrotate.conf
@@ -100,6 +100,7 @@ missingok
 /var/log/*.log
 /var/log/buendia/*.log
 /usr/share/buendia/openmrs/*.log
+/var/mail/*
 {
     olddir old
 }


### PR DESCRIPTION
We're not running a mail server here, so this otherwise unorthodox treatment of the UNIX mail spool has the advantage of being a consistent and reliable way to ensure that `/var/mail` never fills up the disk.