### PR TITLE
Add network installation tools for a complete Buendia server

### DIFF
--- a/tools/iso/README.md
+++ b/tools/iso/README.md
@@ -1,0 +1,70 @@
+# Buendia Network Installer
+
+This directory contains the components needed to construct a *mostly automated*
+installer image for the Buendia server, suitable for burning to USB drive or
+CD-ROM.
+
+## Quick Start
+
+1. Build the installer image as described below, or download it from (somewhere).
+2. Write the installer image to bootable media, using e.g.
+   [balenaEtcher](https://www.balena.io/etcher/) if you're on MacOS.
+3. Boot an Intel NUC or other system from the USB media. Unless the machine is
+   connected to Ethernet with a DHCP server on the network, you will probably
+   be prompted for networking details. This is a network installer, after all.
+3. Follow the prompts related to disk partitioning and boot loader. You can hit
+   enter at any prompt to use the defaults. On the NUC, this is intended to
+   result in a functioning system.
+4. The installer will take ~5 minutes to run, maybe longer, depending on your
+   network speed, and download 300-400 MB of additional software.
+5. You will be prompted to remove the installer media. When the system reboots,
+   it will take about a minute to finish configuring the system. A login prompt
+   may be shown before the first configuration is complete.
+6. After a couple minutes, the OpenMRS console will be available at
+   `http://localhost:9000/openmrs/`. If you've installed to a NUC and have a
+   `buendia` Wi-Fi network, the server will be available at
+   `http://10.18.0.50:9000/openmrs/`.
+7. You can log into the console as either `buendia` or `root`. The password is
+   the same.
+
+## Building the Installer
+
+Building the installer image requires a Debian(-ish) Linux system. From the
+current directory, run the following:
+
+```
+  $ build-buendia-iso
+```
+
+This produces a file called `buendia-install.iso` which is a bootable ISO
+image. This image can be uploaded to a different machine, or installed directly
+to USB media, for example:
+
+```
+  $ sudo bash -c `cat buendia-install.iso > /dev/<usb drive>`
+```
+
+## Details
+
+The [`build-buendia-iso`](build-buendia-iso) constructs the image by starting
+with a standard Debian 9.9 'stretch' ISO, which also contains the non-free
+firmware needed by the Intel NUC wireless card.
+
+The script adds `apt-transport-https` to the list of packages to add to the
+base system, and then adds a [Debian preseed file](preseed.cfg) to seed most of
+the netinst prompts. This preseed configuration adds our
+projectbuendia.github.io _unstable_ repository to the list of apt sources, and
+then appends the following packages to the default server installation:
+
+* `buendia-site-test`
+* `buendia-server`
+* `buendia-networking`
+* `buendia-dashboard`
+
+Also, the preseed configuration triggers the creation of an empty file in
+`/etc/buendia-defer-reconfigure` in the new system, which suppresses most of
+the Buendia-specific configruation steps until after the system has booted for
+the first time and both MySQL and Tomcat are running.
+
+Finally, the installer sets the automated curses installer to be the default,
+and then rebuilds the ISO image into a new file.

--- a/tools/iso/README.md
+++ b/tools/iso/README.md
@@ -52,9 +52,11 @@ firmware needed by the Intel NUC wireless card.
 
 The script adds `apt-transport-https` to the list of packages to add to the
 base system, and then adds a [Debian preseed file](preseed.cfg) to seed most of
-the netinst prompts. This preseed configuration adds our
-projectbuendia.github.io _unstable_ repository to the list of apt sources, and
-then appends the following packages to the default server installation:
+the netinst prompts.
+
+The preseed configuration adds our projectbuendia.github.io _unstable_
+repository to the list of apt sources, and then appends the following packages
+to the default server installation:
 
 * `buendia-site-test`
 * `buendia-server`
@@ -68,3 +70,15 @@ the first time and both MySQL and Tomcat are running.
 
 Finally, the installer sets the automated curses installer to be the default,
 and then rebuilds the ISO image into a new file.
+
+## Preseeding
+
+The preseed file was created by running a Debian installation to completion on
+a NUC, and then installing `debconf-tools` and running `debconf-get-selections
+--installer` and `debconf-get-selections`, and saving the result as a starting
+point. 
+
+Some options related to disk partitioning and bootloader installation
+were removed as these seemed to be causing problems when booting in a virtual
+machine, at least. The omission of these options is most of why the installer
+is not fully automated. Fixing this might be a worthwhile future task.

--- a/tools/iso/build-buendia-iso
+++ b/tools/iso/build-buendia-iso
@@ -89,8 +89,11 @@ MBR_FILE=$(mktemp -t buendia.XXXXX)
 trap "rm -f $MBR_FILE" EXIT
 dd if="$ISO_FILE" bs=1 count=432 of="$MBR_FILE"
 
-# Create the new ISO image
-IMAGE_NAME="Buendia $(git describe --tags master) $(git show HEAD | head -1 | cut -b8-14)"
+echo + Create the new ISO image
+cd $BASE
+IMAGE_NAME="Buendia Server $(git describe --tags master) $(git show HEAD | head -1 | cut -b8-14)"
+chmod -R u+w $BUILD/.disk
+echo -n "$IMAGE_NAME" > $BUILD/.disk/info
 xorriso -as mkisofs \
    -r -V "$IMAGE_NAME" \
    -o "$DEST_ISO" \

--- a/tools/iso/build-buendia-iso
+++ b/tools/iso/build-buendia-iso
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Copyright 2015 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+if [ "$1" = "-h" ]; then
+    echo "$0 [<buendia-install.iso>]"
+    echo
+    echo "Builds a Buendia installer ISO. Takes an optional path to the final"
+    echo "ISO file."
+fi
+
+set -e
+
+# https://www.debian.org/releases/stretch/amd64/apbs02.html.en
+# https://wiki.debian.org/DebianInstaller/Preseed/EditIso
+# https://wiki.debian.org/RepackBootableISO
+
+PREREQS="cpio xorriso git wget"
+BASE=$(cd $(dirname $0) && pwd)
+DEST_ISO=$BASE/buendia-install.iso
+
+sudo apt-get install -y $PREREQS
+
+ISO_URL=http://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/archive/9.9.0+nonfree/amd64/iso-cd/firmware-9.9.0-amd64-netinst.iso
+ISO_MD5=0adef101fb0e9c9d5a495008bc7128ed
+ISO_FILE=$BASE/$(basename $ISO_URL)
+
+if [ ! -r $ISO_FILE -o "$(md5sum $ISO_FILE | cut -d' ' -f1)" != "$ISO_MD5" ]; then
+    echo + Downloading $ISO_URL
+    wget -c -O $ISO_FILE $ISO_URL
+fi
+
+BUILD=$(mktemp -d -t buendia.XXXXX)
+cleanup() {
+    sudo chmod -R +w $BUILD
+    rm -rf $BUILD
+}
+trap cleanup EXIT
+
+echo + Building in $BUILD
+xorriso -osirrox on -indev $ISO_FILE -extract / $BUILD
+
+echo + Adding apt-transport-https to udeb_include
+cd $BUILD/.disk
+chmod +w udeb_include
+echo apt-transport-https >> udeb_include
+
+echo + Unpacking initrd
+cd $BUILD/install.amd
+chmod -R u+w .
+gunzip initrd.gz
+
+echo + Adding preseed.cfg to initrd
+cp $BASE/preseed.cfg .
+echo preseed.cfg | cpio -H newc -o -A -F initrd
+
+echo + Repacking initrd
+gzip initrd
+
+# echo + Update apt-setup udeb
+# cd $BUILD/pool/main/a/apt-setup
+# chmod -R +w .
+# rm -f *.udeb
+# UDEBS="apt-setup-udeb_0.150_amd64 apt-cdrom-setup_0.150_all apt-mirror-setup_0.150_all"
+# MIRROR=http://http.us.debian.org/debian/
+# for pkg in $UDEBS; do
+#     wget $MIRROR/pool/main/a/apt-setup/$pkg.udeb
+# done
+# 
+# echo + Update udeb release file
+# cd $BUILD
+# sudo apt-ftparchive generate $BASE/config-udeb
+
+echo + Updat isolinux.cfg
+chmod u+w $BUILD/isolinux/isolinux.cfg
+cp $BASE/isolinux.cfg $BUILD/isolinux/
+
+echo + Add installer script
+chmod u+w $BUILD
+cp $BASE/buendia-installer $BUILD
+
+echo + Fix MD5 sums
+cd $BUILD
+chmod u+w md5sum.txt
+rm -f md5sum.txt
+md5sum $(find -follow -type f) > md5sum.txt
+
+echo + Extract MBR template file to disk
+MBR_FILE=$(mktemp -t buendia.XXXXX)
+trap "rm -f $MBR_FILE" EXIT
+dd if="$ISO_FILE" bs=1 count=432 of="$MBR_FILE"
+
+# Create the new ISO image
+IMAGE_NAME="Buendia $(git describe --tags master) $(git show HEAD | head -1 | cut -b8-14)"
+xorriso -as mkisofs \
+   -r -V "$IMAGE_NAME" \
+   -o "$DEST_ISO" \
+   -J -J -joliet-long -cache-inodes \
+   -isohybrid-mbr "$MBR_FILE" \
+   -b isolinux/isolinux.bin \
+   -c isolinux/boot.cat \
+   -boot-load-size 4 -boot-info-table -no-emul-boot \
+   -eltorito-alt-boot \
+   -e boot/grub/efi.img \
+   -no-emul-boot -isohybrid-gpt-basdat -isohybrid-apm-hfsplus \
+   "$BUILD"
+
+echo + Cleaning up
+cleanup

--- a/tools/iso/build-buendia-iso
+++ b/tools/iso/build-buendia-iso
@@ -74,7 +74,7 @@ echo preseed.cfg | cpio -H newc -o -A -F initrd
 echo + Repacking initrd
 gzip initrd
 
-echo + Update isolinux.cfg
+echo + Update isolinux.cfg to make the automated installer the default
 chmod u+w $BUILD/isolinux/isolinux.cfg
 cp $BASE/isolinux.cfg $BUILD/isolinux/
 

--- a/tools/iso/build-buendia-iso
+++ b/tools/iso/build-buendia-iso
@@ -25,8 +25,9 @@ set -e
 
 PREREQS="cpio xorriso git wget"
 BASE=$(cd $(dirname $0) && pwd)
-DEST_ISO=$BASE/buendia-install.iso
+DEST_ISO=${1:-$BASE/buendia-install.iso}
 
+echo "+ Installing prerequisites"
 sudo apt-get install -y $PREREQS
 
 ISO_URL=http://cdimage.debian.org/cdimage/unofficial/non-free/cd-including-firmware/archive/9.9.0+nonfree/amd64/iso-cd/firmware-9.9.0-amd64-netinst.iso
@@ -45,13 +46,17 @@ cleanup() {
 }
 trap cleanup EXIT
 
+
 echo + Building in $BUILD
 xorriso -osirrox on -indev $ISO_FILE -extract / $BUILD
 
-echo + Adding apt-transport-https to udeb_include
+echo + Adding apt-transport-https to base_include
 cd $BUILD/.disk
-chmod +w udeb_include
-echo apt-transport-https >> udeb_include
+chmod +w .
+cat >base_include <<END
+apt-transport-https
+ca-certificates
+END
 
 echo + Unpacking initrd
 cd $BUILD/install.amd
@@ -65,27 +70,9 @@ echo preseed.cfg | cpio -H newc -o -A -F initrd
 echo + Repacking initrd
 gzip initrd
 
-# echo + Update apt-setup udeb
-# cd $BUILD/pool/main/a/apt-setup
-# chmod -R +w .
-# rm -f *.udeb
-# UDEBS="apt-setup-udeb_0.150_amd64 apt-cdrom-setup_0.150_all apt-mirror-setup_0.150_all"
-# MIRROR=http://http.us.debian.org/debian/
-# for pkg in $UDEBS; do
-#     wget $MIRROR/pool/main/a/apt-setup/$pkg.udeb
-# done
-# 
-# echo + Update udeb release file
-# cd $BUILD
-# sudo apt-ftparchive generate $BASE/config-udeb
-
-echo + Updat isolinux.cfg
+echo + Update isolinux.cfg
 chmod u+w $BUILD/isolinux/isolinux.cfg
 cp $BASE/isolinux.cfg $BUILD/isolinux/
-
-echo + Add installer script
-chmod u+w $BUILD
-cp $BASE/buendia-installer $BUILD
 
 echo + Fix MD5 sums
 cd $BUILD

--- a/tools/iso/build-buendia-iso
+++ b/tools/iso/build-buendia-iso
@@ -50,6 +50,10 @@ trap cleanup EXIT
 echo + Building in $BUILD
 xorriso -osirrox on -indev $ISO_FILE -extract / $BUILD
 
+echo + Removing graphical components
+chmod -R u+w $BUILD/install.amd
+rm -rf $BUILD/install.amd/{gtk,xen}
+
 echo + Adding apt-transport-https to base_include
 cd $BUILD/.disk
 chmod +w .

--- a/tools/iso/isolinux.cfg
+++ b/tools/iso/isolinux.cfg
@@ -1,0 +1,7 @@
+# D-I config version 2.0
+# search path for the c32 support libraries (libcom32, libutil etc.)
+path 
+include menu.cfg
+default install
+prompt 0
+timeout 0

--- a/tools/iso/preseed.cfg
+++ b/tools/iso/preseed.cfg
@@ -1389,17 +1389,25 @@ apt-listchanges	apt-listchanges/email-address	string	root
 tzdata	tzdata/Areas	select	Etc
 d-i passwd/root-password-crypted password $6$R/Jihdz0q$f2uQ7btizMXbhLhrVoqZRP17S.aHCpybPTh6wgDB1/3ShAbolz8833IFZBvm5yYvfr6XepS/3xXdVBxiKsKkT0
 d-i passwd/user-password-crypted password $6$R/Jihdz0q$f2uQ7btizMXbhLhrVoqZRP17S.aHCpybPTh6wgDB1/3ShAbolz8833IFZBvm5yYvfr6XepS/3xXdVBxiKsKkT0
+
+# This only took hours to figure out...
 # https://debian-boot.debian.narkive.com/0rQzZ4OM/bug-636145-debian-installer-installer-does-not-proceed-at-apt-setup-udeb-on-powerpc-with-preseed-cfg
 # https://forum.openmediavault.org/index.php/Thread/1265-Problem-installing-from-USB-stick/?postID=5797#post5797
 d-i apt-setup/use/netinst string
 
 # Uncertain if these options will work on the NUC
 #grub-installer  grub-installer/only_debian	boolean	true
-#grub-installer  grub-installer/choose_bootdev    select    /dev/sda
-#grub-installer  grub-installer/make_active    boolean    true
+grub-installer  grub-installer/choose_bootdev    select    /dev/sda
+grub-installer  grub-installer/make_active    boolean    true
+partman-base    partman/confirm_nooverwrite  boolean    false
+partman-base    partman/confirm_nochanges    boolean    false
+partman-base    partman/confirm              boolean    true
 
 # https://www.debian.org/releases/stretch/example-preseed.txt
 d-i apt-setup/local0/repository string [trusted=yes] https://projectbuendia.github.io/builds/packages unstable main java
 d-i apt-setup/local0/comment string Buendia Packages
-d-i pkgsel/include string apt-transport-https
-d-i preseed/late_command string bash /cdrom/install-buendia
+d-i pkgsel/include string buendia-server buendia-site-test buendia-networking buendia-dashboard
+# Placing an executable command in /usr/lib/pre-pkgsel.d ensures that the
+# command is run after the chroot is set up but before any packages are
+# installed.
+d-i preseed/early_command string sh -c 'echo "touch /target/etc/buendia-defer-reconfigure" > /usr/lib/pre-pkgsel.d/90buendia; chmod +x /usr/lib/pre-pkgsel.d/90buendia'

--- a/tools/iso/preseed.cfg
+++ b/tools/iso/preseed.cfg
@@ -15,7 +15,7 @@ lilo-installer	lilo-installer/manual_bootdev	string
 apt-setup-udeb	apt-setup/enable-source-repositories	boolean	true
 # Select your time zone:
 # Choices: Eastern, Central, Mountain, Pacific, Alaska, Hawaii, Arizona, East Indiana, Samoa
-tzsetup-udeb	time/zone	select	US/Eastern
+tzsetup-udeb	time/zone	select	UTC
 # Error while reducing volume group
 # 
 # Choices: Argentina, Bolivia, Chile, Colombia, Costa Rica, Cuba, Ecuador, El Salvador, Spain, United States, Guatemala, Honduras, Mexico, Nicaragua, Panama, Paraguay, Peru, Puerto Rico, Dominican Republic, Uruguay, Venezuela, other

--- a/tools/iso/preseed.cfg
+++ b/tools/iso/preseed.cfg
@@ -1,0 +1,1405 @@
+# No partitions to encrypt
+# for internal use; can be preseeded
+d-i	preseed/run/checksum	string	
+# Go back to the menu and correct this problem?
+# Write previous changes to disk and continue?
+# Device file for accessing the CD-ROM:
+d-i	cdrom-detect/cdrom_device	string	/dev/sdb1
+# Network autoconfiguration failed
+netcfg	netcfg/dhcp_failed	note	
+# No boot loader installed
+nobootloader	nobootloader/confirmation_common	note	
+# LILO installation target:
+lilo-installer	lilo-installer/manual_bootdev	string	
+# Enable source repositories in APT?
+apt-setup-udeb	apt-setup/enable-source-repositories	boolean	true
+# Select your time zone:
+# Choices: Eastern, Central, Mountain, Pacific, Alaska, Hawaii, Arizona, East Indiana, Samoa
+tzsetup-udeb	time/zone	select	US/Eastern
+# Error while reducing volume group
+# 
+# Choices: Argentina, Bolivia, Chile, Colombia, Costa Rica, Cuba, Ecuador, El Salvador, Spain, United States, Guatemala, Honduras, Mexico, Nicaragua, Panama, Paraguay, Peru, Puerto Rico, Dominican Republic, Uruguay, Venezuela, other
+d-i	localechooser/shortlist/es	select	
+# state
+# Choices: Acre, Alagoas, Amazonas, Amapá, Bahia, Ceará, Distrito Federal, Espírito Santo, Fernando de Noronha, Goiás, Maranhão, Minas Gerais, Mato Grosso do Sul, Mato Grosso, Pará, Paraíba, Pernambuco, Piauí, Paraná, Rio de Janeiro, Rio Grande do Norte, Rondônia, Roraima, Rio Grande do Sul, Santa Catarina, Sergipe, São Paulo, Tocantins
+tzsetup-udeb	tzsetup/country/BR	select	America/Sao_Paulo
+# Volume group name:
+# Failure of key exchange and association
+netcfg	netcfg/wpa_supplicant_failed	note	
+# Encryption method for this partition:
+# Choices: 
+# for internal use only
+clock-setup	clock-setup/system-time-changed	boolean	true
+# Software RAID not available
+# Identical mount points for two file systems
+# Keep current partition layout and configure RAID?
+# Really delete the volume group?
+# for internal use; can be preseeded
+d-i	preseed/include	string	
+# Allow login as root?
+user-setup-udeb	passwd/root-login	boolean	true
+# Load missing firmware from removable media?
+d-i	hw-detect/load_firmware	boolean	true
+# Web server started, but network not running
+d-i	save-logs/no_network	note	
+# iSCSI configuration actions
+# Choices: Log into iSCSI targets, Finish
+# Software RAID device to be deleted:
+# Choices: 
+# for internal use
+d-i	espeakup/card	string	
+# Kernel to install:
+# Choices: linux-image-4.9.0-9-amd64,linux-image-amd64, none
+bootstrap-base	base-installer/kernel/image	select	linux-image-amd64
+# Bad archive mirror
+choose-mirror-bin	mirror/bad	error	
+# 
+# Choices: Belize, Costa Rica, El Salvador, Guatemala, Honduras, Nicaragua, Panama
+d-i	localechooser/countrylist/Central_America	select	
+# Do you want to return to the partitioning menu?
+# No volume group name entered
+# Debootstrap warning
+bootstrap-base	base-installer/debootstrap/fallback-warning	error	
+# Volume group name already in use
+# 
+# Choices: Cyprus, Turkey, other
+d-i	localechooser/shortlist/tr	select	
+# Debian archive mirror directory:
+choose-mirror-bin	mirror/ftp/directory	string	/debian/
+# Install the GRUB boot loader to the Serial ATA RAID disk?
+# for internal use only
+d-i	cdrom-detect/hybrid	boolean	true
+# Error while deleting the logical volume
+# No volume group found
+# LILO configured to use a serial console
+lilo-installer	lilo-installer/serial-console	note	
+# Load missing drivers from removable media?
+d-i	hw-detect/load_media	boolean	false
+# for internal use; can be preseeded
+d-i	debian-installer/country	string	US
+# No devices selected
+# Load CD-ROM drivers from removable media?
+d-i	cdrom-detect/load_media	boolean	true
+# Failed to load installer component
+d-i	anna/install_failed	error	
+# location
+# Choices: Auckland, Chatham Islands
+tzsetup-udeb	tzsetup/country/NZ	select	Pacific/Auckland
+# Setting firmware variables for automatic boot
+nobootloader	nobootloader/confirmation_powerpc_chrp_pegasos	note	
+# Write the changes to disk and configure encrypted volumes?
+# Invalid username
+user-setup-udeb	passwd/username-bad	error	
+# Continue with the installation?
+# Debootstrap Error
+bootstrap-base	base-installer/debootstrap/error/nogetrel	error	
+# The size entered is too small
+# for internal use; can be preseeded
+d-i	anna/standard_modules	boolean	true
+# Force GRUB installation to the EFI removable media path?
+# Keyfile creation failure
+# Write the changes to disks?
+# Unexpected error while creating volume group
+# Logical volume:
+# Choices: 
+# Driver needed by your Ethernet card:
+# Choices: no ethernet card, , none of the above
+ethdetect	ethdetect/module_select	select	no ethernet card
+# city
+# Choices: Almaty, Qyzylorda, Aqtobe, Atyrau, Oral
+tzsetup-udeb	tzsetup/country/KZ	select	Asia/Almaty
+# Downloading local repository key failed:
+# Choices: Retry, Ignore
+apt-setup-udeb	apt-setup/local/key-error	select	Retry
+# for internal use only
+d-i	cdrom-detect/usb-hdd	boolean	false
+# 
+# Choices: Bouvet Island, Falkland Islands (Malvinas), Saint Helena\, Ascension and Tristan da Cunha, South Georgia and the South Sandwich Islands
+d-i	localechooser/countrylist/Atlantic_Ocean	select	
+# Modules to load:
+# Choices: 
+d-i	hw-detect/select_modules	multiselect	
+# Additional locales:
+# Choices: aa_DJ.UTF-8, aa_DJ, aa_ER, aa_ER@saaho, aa_ET, af_ZA.UTF-8, af_ZA, ak_GH, am_ET, an_ES.UTF-8, an_ES, anp_IN, ar_AE.UTF-8, ar_AE, ar_BH.UTF-8, ar_BH, ar_DZ.UTF-8, ar_DZ, ar_EG.UTF-8, ar_EG, ar_IN, ar_IQ.UTF-8, ar_IQ, ar_JO.UTF-8, ar_JO, ar_KW.UTF-8, ar_KW, ar_LB.UTF-8, ar_LB, ar_LY.UTF-8, ar_LY, ar_MA.UTF-8, ar_MA, ar_OM.UTF-8, ar_OM, ar_QA.UTF-8, ar_QA, ar_SA.UTF-8, ar_SA, ar_SD.UTF-8, ar_SD, ar_SS, ar_SY.UTF-8, ar_SY, ar_TN.UTF-8, ar_TN, ar_YE.UTF-8, ar_YE, ayc_PE, az_AZ, as_IN, ast_ES.UTF-8, ast_ES, be_BY.UTF-8, be_BY, be_BY@latin, bem_ZM, ber_DZ, ber_MA, bg_BG.UTF-8, bg_BG, bhb_IN.UTF-8, bho_IN, bn_BD, bn_IN, bo_CN, bo_IN, br_FR.UTF-8, br_FR, br_FR@euro, brx_IN, bs_BA.UTF-8, bs_BA, byn_ER, ca_AD.UTF-8, ca_AD, ca_ES.UTF-8, ca_ES, ca_ES@euro, ca_ES.UTF-8@valencia, ca_ES@valencia, ca_FR.UTF-8, ca_FR, ca_IT.UTF-8, ca_IT, ce_RU, chr_US, cmn_TW, crh_UA, cs_CZ.UTF-8, cs_CZ, csb_PL, cv_RU, cy_GB.UTF-8, cy_GB, da_DK.UTF-8, da_DK, de_AT.UTF-8, de_AT, de_AT@euro, de_BE.UTF-8, de_BE, de_BE@euro, de_CH.UTF-8, de_CH, de_DE.UTF-8, de_DE, de_DE@euro, de_IT.UTF-8, de_IT, de_LI.UTF-8, de_LU.UTF-8, de_LU, de_LU@euro, doi_IN, dv_MV, dz_BT, el_GR.UTF-8, el_GR, el_CY.UTF-8, el_CY, en_AG, en_AU.UTF-8, en_AU, en_BW.UTF-8, en_BW, en_CA.UTF-8, en_CA, en_DK.UTF-8, en_DK.ISO-8859-15, en_DK, en_GB.UTF-8, en_GB, en_GB.ISO-8859-15, en_HK.UTF-8, en_HK, en_IE.UTF-8, en_IE, en_IE@euro, en_IL, en_IN, en_NG, en_NZ.UTF-8, en_NZ, en_PH.UTF-8, en_PH, en_SG.UTF-8, en_SG, en_US, en_US.ISO-8859-15, en_ZA.UTF-8, en_ZA, en_ZM, en_ZW.UTF-8, en_ZW, eo, es_AR.UTF-8, es_AR, es_BO.UTF-8, es_BO, es_CL.UTF-8, es_CL, es_CO.UTF-8, es_CO, es_CR.UTF-8, es_CR, es_CU, es_DO.UTF-8, es_DO, es_EC.UTF-8, es_EC, es_ES.UTF-8, es_ES, es_ES@euro, es_GT.UTF-8, es_GT, es_HN.UTF-8, es_HN, es_MX.UTF-8, es_MX, es_NI.UTF-8, es_NI, es_PA.UTF-8, es_PA, es_PE.UTF-8, es_PE, es_PR.UTF-8, es_PR, es_PY.UTF-8, es_PY, es_SV.UTF-8, es_SV, es_US.UTF-8, es_US, es_UY.UTF-8, es_UY, es_VE.UTF-8, es_VE, et_EE.UTF-8, et_EE, et_EE.ISO-8859-15, eu_ES.UTF-8, eu_ES, eu_ES@euro, eu_FR.UTF-8, eu_FR, eu_FR@euro, fa_IR, ff_SN, fi_FI.UTF-8, fi_FI, fi_FI@euro, fil_PH, fo_FO.UTF-8, fo_FO, fr_BE.UTF-8, fr_BE, fr_BE@euro, fr_CA.UTF-8, fr_CA, fr_CH.UTF-8, fr_CH, fr_FR.UTF-8, fr_FR, fr_FR@euro, fr_LU.UTF-8, fr_LU, fr_LU@euro, fur_IT, fy_NL, fy_DE, ga_IE.UTF-8, ga_IE, ga_IE@euro, gd_GB.UTF-8, gd_GB, gez_ER, gez_ER@abegede, gez_ET, gez_ET@abegede, gl_ES.UTF-8, gl_ES, gl_ES@euro, gu_IN, gv_GB.UTF-8, gv_GB, ha_NG, hak_TW, he_IL.UTF-8, he_IL, hi_IN, hne_IN, hr_HR.UTF-8, hr_HR, hsb_DE.UTF-8, hsb_DE, ht_HT, hu_HU.UTF-8, hu_HU, hy_AM, hy_AM.ARMSCII-8, ia_FR, id_ID.UTF-8, id_ID, ig_NG, ik_CA, is_IS.UTF-8, is_IS, it_CH.UTF-8, it_CH, it_IT.UTF-8, it_IT, it_IT@euro, iu_CA, ja_JP.UTF-8, ja_JP.EUC-JP, ka_GE.UTF-8, ka_GE, kk_KZ.UTF-8, kk_KZ, kl_GL.UTF-8, kl_GL, km_KH, kn_IN, ko_KR.UTF-8, ko_KR.EUC-KR, kok_IN, ks_IN, ks_IN@devanagari, ku_TR.UTF-8, ku_TR, kw_GB.UTF-8, kw_GB, ky_KG, lb_LU, lg_UG.UTF-8, lg_UG, li_BE, li_NL, lij_IT, ln_CD, lo_LA, lt_LT.UTF-8, lt_LT, lv_LV.UTF-8, lv_LV, lzh_TW, mag_IN, mai_IN, mg_MG.UTF-8, mg_MG, mhr_RU, mi_NZ.UTF-8, mi_NZ, mk_MK.UTF-8, mk_MK, ml_IN, mn_MN, mni_IN, mr_IN, ms_MY.UTF-8, ms_MY, mt_MT.UTF-8, mt_MT, my_MM, nan_TW, nan_TW@latin, nb_NO.UTF-8, nb_NO, nds_DE, nds_NL, ne_NP, nhn_MX, niu_NU, niu_NZ, nl_AW, nl_BE.UTF-8, nl_BE, nl_BE@euro, nl_NL.UTF-8, nl_NL, nl_NL@euro, nn_NO.UTF-8, nn_NO, nr_ZA, nso_ZA, oc_FR.UTF-8, oc_FR, om_ET, om_KE.UTF-8, om_KE, or_IN, os_RU, pa_IN, pa_PK, pap_AW, pap_CW, pl_PL.UTF-8, pl_PL, ps_AF, pt_BR.UTF-8, pt_BR, pt_PT.UTF-8, pt_PT, pt_PT@euro, quz_PE, raj_IN, ro_RO.UTF-8, ro_RO, ru_RU.UTF-8, ru_RU.KOI8-R, ru_RU, ru_RU.CP1251, ru_UA.UTF-8, ru_UA, rw_RW, sa_IN, sat_IN, sc_IT, sd_IN, sd_IN@devanagari, se_NO, sgs_LT, shs_CA, si_LK, sid_ET, sk_SK.UTF-8, sk_SK, sl_SI.UTF-8, sl_SI, so_DJ.UTF-8, so_DJ, so_ET, so_KE.UTF-8, so_KE, so_SO.UTF-8, so_SO, sq_AL.UTF-8, sq_AL, sq_MK, sr_ME, sr_RS, sr_RS@latin, ss_ZA, st_ZA.UTF-8, st_ZA, sv_FI.UTF-8, sv_FI, sv_FI@euro, sv_SE.UTF-8, sv_SE, sv_SE.ISO-8859-15, sw_KE, sw_TZ, szl_PL, ta_IN, ta_LK, tcy_IN.UTF-8, te_IN, tg_TJ.UTF-8, tg_TJ, th_TH.UTF-8, th_TH, the_NP, ti_ER, ti_ET, tig_ER, tk_TM, tl_PH.UTF-8, tl_PH, tn_ZA, tr_CY.UTF-8, tr_CY, tr_TR.UTF-8, tr_TR, ts_ZA, tt_RU, tt_RU@iqtelif, ug_CN, uk_UA.UTF-8, uk_UA, unm_US, ur_IN, ur_PK, uz_UZ.UTF-8, uz_UZ, uz_UZ@cyrillic, ve_ZA, vi_VN, wa_BE.UTF-8, wa_BE, wa_BE@euro, wae_CH, wal_ET, wo_SN, xh_ZA.UTF-8, xh_ZA, yi_US.UTF-8, yi_US, yo_NG, yue_HK, zh_CN.UTF-8, zh_CN.GB18030, zh_CN.GBK, zh_CN, zh_HK.UTF-8, zh_HK, zh_SG.UTF-8, zh_SG.GBK, zh_SG, zh_TW.UTF-8, zh_TW.EUC-TW, zh_TW, zu_ZA.UTF-8, zu_ZA
+d-i	localechooser/supported-locales	multiselect	
+# Install the GRUB boot loader to the master boot record?
+# country code or "manual" (for internal use)
+choose-mirror-bin	mirror/country	string	US
+# location
+# Choices: Madrid, Ceuta, Canary Islands
+tzsetup-udeb	tzsetup/country/ES	select	Europe/Madrid
+# No file system mounted on /target
+base-installer	base-installer/no_target_mounted	error	
+# for internal use; can be preseeded
+netcfg	netcfg/enable	boolean	true
+# Return to the menu to set the bootable flag?
+# 
+# Choices: Andorra, Spain, France, Italy, other
+d-i	localechooser/shortlist/ca	select	
+# 
+# Choices: Anguilla, Antigua and Barbuda, Aruba, Bahamas, Barbados, Bermuda, Bonaire\, Sint Eustatius and Saba, Cayman Islands, Cuba, Dominica, Dominican Republic, Grenada, Guadeloupe, Haiti, Jamaica, Martinique, Montserrat, Puerto Rico, Saint Barthélemy, Saint Kitts and Nevis, Saint Lucia, Saint Martin (French part), Saint Vincent and the Grenadines, Sint Maarten (Dutch part), Trinidad and Tobago, Turks and Caicos Islands, Virgin Islands\, British, Virgin Islands\, U.S.
+d-i	localechooser/countrylist/Caribbean	select	
+# Volume group name overlaps with device name
+# Keymap to use:
+# Choices: American English, Albanian, Arabic, Asturian, Bangladesh, Belarusian, Bengali, Belgian, Bosnian, Brazilian, British English, Bulgarian (BDS layout), Bulgarian (phonetic layout), Burmese, Canadian French, Canadian Multilingual, Catalan, Chinese, Croatian, Czech, Danish, Dutch, Dvorak, Dzongkha, Esperanto, Estonian, Ethiopian, Finnish, French, Georgian, German, Greek, Gujarati, Gurmukhi, Hebrew, Hindi, Hungarian, Icelandic, Irish, Italian, Japanese, Kannada, Kazakh, Khmer, Kirghiz, Korean, Kurdish (F layout), Kurdish (Q layout), Lao, Latin American, Latvian, Lithuanian, Macedonian, Malayalam, Nepali, Northern Sami, Norwegian, Persian, Philippines, Polish, Portuguese, Punjabi, Romanian, Russian, Serbian (Cyrillic), Sindhi, Sinhala, Slovak, Slovenian, Spanish, Swedish, Swiss French, Swiss German, Tajik, Tamil, Telugu, Thai, Tibetan, Turkish (F layout), Turkish (Q layout), Ukrainian, Uyghur, Vietnamese
+d-i	keyboard-configuration/xkb-keymap	select	us
+# Failed to retrieve the preconfiguration file
+d-i	preseed/retrieve_error	error	
+# Go back to the menu and resume partitioning?
+# for internal use; can be preseeded
+d-i	mouse/device	string	
+# This is an overview of your currently configured partitions and mount points. Select a partition to modify its settings (file system, mount point, etc.), a free space to create partitions, or a device to initialize its partition table.
+# Choices: Guided partitioning, Configure software RAID, Configure the Logical Volume Manager, Configure encrypted volumes, Configure iSCSI volumes, , SCSI1 (0\,0\,0) (sda) - 250.1 GB ATA Samsung SSD 860, >   ${!TAB}${!TAB}${!TAB}${!ALIGN=RIGHT}1.0 MB${!TAB}${!TAB}${!TAB}FREE SPACE${!TAB}${!TAB}${!TAB}, >   ${!TAB}${!ALIGN=RIGHT}#1${!TAB}${!TAB}${!ALIGN=RIGHT}536.9 MB${!TAB}B${!TAB}F${!TAB}ESP${!TAB}${!TAB}${!TAB}, >   ${!TAB}${!ALIGN=RIGHT}#2${!TAB}${!TAB}${!ALIGN=RIGHT}245.4 GB${!TAB}${!TAB}f${!TAB}ext4${!TAB}${!TAB}/${!TAB}, >   ${!TAB}${!ALIGN=RIGHT}#3${!TAB}${!TAB}${!ALIGN=RIGHT}4.1 GB${!TAB}${!TAB}f${!TAB}swap${!TAB}${!TAB}swap${!TAB}, >   ${!TAB}${!TAB}${!TAB}${!ALIGN=RIGHT}171.5 kB${!TAB}${!TAB}${!TAB}FREE SPACE${!TAB}${!TAB}${!TAB}, SCSI3 (0\,0\,0) (sdb) - 1.1 GB Generic Flash Disk, , Undo changes to partitions, Finish partitioning and write changes to disk
+# 
+# Choices: Africa, Antarctica, Asia, Atlantic Ocean, Caribbean, Central America, Europe, Indian Ocean, North America, Oceania, South America, other
+d-i	localechooser/continentlist	select	
+# How to use this partition:
+# Choices: 
+# Go back to the menu?
+# Directory in which to save debug logs:
+d-i	save-logs/directory	string	/mnt
+# Number of spare devices for the RAID array:
+# Location of initial preconfiguration file:
+network-preseed	preseed/url	string	
+# for internal use; can be preseeded
+netcfg	netcfg/dhcp_timeout	string	25
+# Do you want to return to the partitioning menu?
+# Error while creating volume group
+# IPv6 unsupported on point-to-point links
+netcfg	netcfg/no_ipv6_pointopoint	error	
+# zone
+# Choices: Asia/Nicosia (Cyprus (most areas)), Asia/Famagusta (Northern Cyprus)
+tzsetup-udeb	tzsetup/country/CY	select	
+# for internal use only
+# Cannot install kernel
+bootstrap-base	base-installer/kernel/no-kernels-found	error	
+# for internal use; can be preseeded
+d-i	mouse/left	boolean	false
+# for internal use; can be preseeded
+d-i	preseed/late_command	string	
+# 
+# Choices: Afghanistan, Bahrain, Bangladesh, Bhutan, Brunei Darussalam, Cambodia, China, Hong Kong, India, Indonesia, Iran\, Islamic Republic of, Iraq, Israel, Japan, Jordan, Kazakhstan, Korea\, Democratic People's Republic of, Korea\, Republic of, Kuwait, Kyrgyzstan, Lao People's Democratic Republic, Lebanon, Macao, Malaysia, Mongolia, Myanmar, Nepal, Oman, Pakistan, Palestine\, State of, Philippines, Qatar, Saudi Arabia, Singapore, Sri Lanka, Syrian Arab Republic, Taiwan, Tajikistan, Thailand, Timor-Leste, Turkey, Turkmenistan, United Arab Emirates, Uzbekistan, Viet Nam, Yemen
+d-i	localechooser/countrylist/Asia	select	
+# Invalid partition name
+lilo-installer	lilo-installer/manual_bootdev_error	error	
+# FTP proxy information (blank for none):
+choose-mirror-bin	mirror/ftp/proxy	string	
+# Debootstrap Error
+bootstrap-base	base-installer/debootstrap/error/unknownrelsig	error	
+# Debian version to install:
+# Choices: stretch${!TAB}-${!TAB}stable
+choose-mirror-bin	mirror/suite	select	stable
+# Go back and try a different mirror?
+choose-mirror-bin	mirror/no-default	boolean	true
+# No iSCSI targets discovered
+# Invalid ESSID
+netcfg	netcfg/invalid_essid	error	
+# Start PC card services?
+d-i	hw-detect/start_pcmcia	boolean	true
+# Type of encryption key hash for this partition:
+# Choices: 
+# Failed to create a swap space
+# location
+# Choices: Tahiti (Society Islands), Marquesas Islands, Gambier Islands
+tzsetup-udeb	tzsetup/country/PF	select	Pacific/Tahiti
+# zone
+# Choices: Moscow-01 - Kaliningrad, Moscow+00 - Moscow, Moscow+01 - Samara, Moscow+02 - Yekaterinburg, Moscow+03 - Omsk, Moscow+04 - Krasnoyarsk, Moscow+05 - Irkutsk, Moscow+06 - Yakutsk, Moscow+07 - Vladivostok, Moscow+08 - Magadan
+tzsetup-udeb	tzsetup/country/RU	select	Europe/Moscow
+# city
+# Choices: Western (Sumatra\, Jakarta\, Java\, West and Central Kalimantan), Central (Sulawesi\, Bali\, Nusa Tenggara\, East and South Kalimantan), Eastern (Maluku\, Papua)
+tzsetup-udeb	tzsetup/country/ID	select	Asia/Jakarta
+# Go back to the menu and correct errors?
+# Use a network mirror?
+apt-mirror-setup	apt-setup/use_mirror	boolean	true
+# Type of wireless network:
+# Choices: Infrastructure (Managed) network, Ad-hoc network (Peer to peer)
+netcfg	netcfg/wireless_adhoc_managed	select	Infrastructure (Managed) network
+# Insert formatted floppy in drive
+d-i	save-logs/insert_floppy	note	
+# for internal use; can be preseeded
+d-i	directfb/hw-accel	boolean	false
+# Failed to open checksum file
+d-i	cdrom-checker/md5file_failed	error	
+# Encryption for this partition:
+# Choices: 
+# Debootstrap Error
+bootstrap-base	base-installer/debootstrap/error/invalidrel	error	
+# location
+# Choices: Johnston Atoll, Midway Islands, Wake Island
+tzsetup-udeb	tzsetup/country/UM	select	Pacific/Midway
+# How to use this free space:
+# Choices: 
+# for internal use; can be preseeded
+# Choices: none, safe-upgrade, full-upgrade
+pkgsel	pkgsel/upgrade	select	safe-upgrade
+# DHCP hostname:
+netcfg	netcfg/dhcp_hostname	string	
+# for internal use; can be preseeded (deprecated)
+netcfg	netcfg/disable_dhcp	boolean	false
+# Install the GRUB boot loader to the multipath device?
+# Partition name:
+# Reserved username
+user-setup-udeb	passwd/username-reserved	error	
+# for internal use
+bootstrap-base	base-installer/kernel/linux/initramfs-tools/driver-policy	string	most
+# Device in use
+# LILO installation failed. Continue anyway?
+lilo-installer	lilo-installer/apt-install-failed	boolean	true
+# for internal use; can be preseeded
+network-preseed	auto-install/defaultroot	string	d-i/stretch/./preseed.cfg
+# Continue with partitioning?
+# for internal use; can be preseeded
+# Mount point for this partition:
+# Use weak passphrase?
+# Check the integrity of another CD-ROM?
+d-i	cdrom-checker/nextcd	boolean	false
+# Keep current partition layout and configure encrypted volumes?
+# Proceed with installation to unclean target?
+base-installer	base-installer/use_unclean_target	boolean	true
+# Would you like to make this partition active?
+lilo-installer	lilo-installer/activate-part	boolean	true
+# Tool to use to generate boot initrd:
+# Choices: 
+bootstrap-base	base-installer/initramfs/generator	select	
+# Base system installation error
+bootstrap-base	base-installer/debootstrap/error-exitcode	error	
+# for internal use only
+user-setup-udeb	passwd/user-default-groups	string	audio cdrom dip floppy video plugdev netdev scanner bluetooth debian-tor lpadmin
+# Installer components to load:
+# Choices: 
+d-i	anna/choose_modules_lowmem	multiselect	
+# 
+# Choices: China, India, other
+d-i	localechooser/shortlist/bo	select	
+# Insert a Debian CD-ROM
+d-i	cdrom-checker/askmount	note	
+# Erasing data on  failed
+# Really erase the data on ?
+# Mount options:
+# Choices: 
+# How should the debug logs be saved or transferred?
+# Choices: floppy, web, mounted file system
+d-i	save-logs/menu	select	
+# Debian archive mirror hostname:
+d-i	mirror/https/hostname	string	mirror
+# 
+# Continue with partitioning?
+# The free space starts from  and ends at .
+# Choose the next step in the install process:
+# Choices: Choose language, Access software for a blind person using a braille display, Configure the speech synthesizer voice, Configure the keyboard, Detect and mount CD-ROM, Load installer components from CD, Detect network hardware, Configure the network, Set up users and passwords, Configure the clock, Detect disks, Partition disks, Install the base system, Configure the package manager, Select and install software, Install the GRUB boot loader on a hard disk, Continue without boot loader, Finish the installation, Change debconf priority, Check the CD-ROM(s) integrity, Save debug logs, Execute a shell, Eject a CD from the drive, Abort the installation
+d-i	debian-installer/main-menu	select	Finish the installation
+# location
+# Choices: Godthab, Danmarkshavn, Scoresbysund, Thule
+tzsetup-udeb	tzsetup/country/GL	select	America/Godthab
+# for internal use; can be preseeded
+# Choices: Network Manager, ifupdown (/etc/network/interfaces), No network configuration
+netcfg	netcfg/target_network_config	select	loopback
+# 
+# Choices: Antarctica
+d-i	localechooser/countrylist/Antarctica	select	
+# Base system installation error
+bootstrap-base	base-installer/debootstrap/error-abnormal	error	
+# Unreachable gateway
+netcfg	netcfg/gateway_unreachable	error	
+# New partition size:
+# Volume group to extend:
+# Choices: 
+# Check CD-ROM integrity?
+d-i	cdrom-checker/start	boolean	false
+# Installation step failed
+d-i	debian-installer/main-menu/item-failure	error	
+# for internal use
+d-i	espeakup/voice	string	
+# The size entered is too large
+# Failed to install the base system
+bootstrap-base	base-installer/debootstrap-failed	error	
+# Keep current partition layout and configure LVM?
+# Incorrect CD-ROM detected
+d-i	cdrom-detect/wrong-cd	error	
+# Force UEFI installation?
+# for internal use; can be preseeded
+disk-detect	disk-detect/dmraid/enable	boolean	false
+# for internal use; can be preseeded
+d-i	preseed/file/checksum	string	
+# EFI partition too small
+# Remove existing logical volume data?
+# No volume group found
+# Flags for the new partition:
+# Choices: 
+# Language:
+# Choices: C${!TAB}-${!TAB}No localization, Albanian${!TAB}-${!TAB}Shqip, Amharic${!TAB}-${!TAB}አማርኛ, Arabic${!TAB}-${!TAB}عربي, Asturian${!TAB}-${!TAB}Asturianu, Bangla${!TAB}-${!TAB}বাংলা, Basque${!TAB}-${!TAB}Euskara, Belarusian${!TAB}-${!TAB}Беларуская, Bosnian${!TAB}-${!TAB}Bosanski, Bulgarian${!TAB}-${!TAB}Български, Burmese${!TAB}-${!TAB} ﻿မြန်မာစာ, Catalan${!TAB}-${!TAB}Català, Chinese (Simplified)${!TAB}-${!TAB}中文(简体), Chinese (Traditional)${!TAB}-${!TAB}中文(繁體), Croatian${!TAB}-${!TAB}Hrvatski, Czech${!TAB}-${!TAB}Čeština, Danish${!TAB}-${!TAB}Dansk, Dutch${!TAB}-${!TAB}Nederlands, Dzongkha${!TAB}-${!TAB}རྫོང་ཁ།, English${!TAB}-${!TAB}English, Esperanto${!TAB}-${!TAB}Esperanto, Estonian${!TAB}-${!TAB}Eesti, Finnish${!TAB}-${!TAB}Suomi, French${!TAB}-${!TAB}Français, Galician${!TAB}-${!TAB}Galego, Georgian${!TAB}-${!TAB}ქართული, German${!TAB}-${!TAB}Deutsch, Greek${!TAB}-${!TAB}Ελληνικά, Gujarati${!TAB}-${!TAB}ગુજરાતી, Hebrew${!TAB}-${!TAB}עברית, Hindi${!TAB}-${!TAB}हिन्दी , Hungarian${!TAB}-${!TAB}Magyar, Icelandic${!TAB}-${!TAB}Íslenska, Indonesian${!TAB}-${!TAB}Bahasa Indonesia, Irish${!TAB}-${!TAB}Gaeilge, Italian${!TAB}-${!TAB}Italiano, Japanese${!TAB}-${!TAB}日本語, Kannada${!TAB}-${!TAB}ಕನ್ನಡ, Kazakh${!TAB}-${!TAB}Қазақ, Khmer${!TAB}-${!TAB}﻿ខ្មែរ, Korean${!TAB}-${!TAB}한국어, Kurdish${!TAB}-${!TAB}Kurdî, Lao${!TAB}-${!TAB}﻿ລາວ, Latvian${!TAB}-${!TAB}Latviski, Lithuanian${!TAB}-${!TAB}Lietuviškai, Macedonian${!TAB}-${!TAB}Македонски, Malayalam${!TAB}-${!TAB}മലയാളം, Marathi${!TAB}-${!TAB}मराठी, Nepali${!TAB}-${!TAB}नेपाली , Northern Sami${!TAB}-${!TAB}Sámegillii, Norwegian Bokmaal${!TAB}-${!TAB}Norsk bokmål, Norwegian Nynorsk${!TAB}-${!TAB}Norsk nynorsk, Persian${!TAB}-${!TAB}فارسی, Polish${!TAB}-${!TAB}Polski, Portuguese${!TAB}-${!TAB}Português, Portuguese (Brazil)${!TAB}-${!TAB}Português do Brasil, Punjabi (Gurmukhi)${!TAB}-${!TAB}ਪੰਜਾਬੀ, Romanian${!TAB}-${!TAB}Română, Russian${!TAB}-${!TAB}Русский, Serbian (Cyrillic)${!TAB}-${!TAB}Српски, Sinhala${!TAB}-${!TAB}සිංහල, Slovak${!TAB}-${!TAB}Slovenčina, Slovenian${!TAB}-${!TAB}Slovenščina, Spanish${!TAB}-${!TAB}Español, Swedish${!TAB}-${!TAB}Svenska, Tagalog${!TAB}-${!TAB}Tagalog, Tajik${!TAB}-${!TAB}Тоҷикӣ, Tamil${!TAB}-${!TAB}தமிழ், Telugu${!TAB}-${!TAB}తెలుగు, Thai${!TAB}-${!TAB}ภาษาไทย, Tibetan${!TAB}-${!TAB}བོད་ཡིག, Turkish${!TAB}-${!TAB}Türkçe, Ukrainian${!TAB}-${!TAB}Українська, Uyghur${!TAB}-${!TAB}ئۇيغۇرچە, Vietnamese${!TAB}-${!TAB}Tiếng Việt, Welsh${!TAB}-${!TAB}Cymraeg
+d-i	localechooser/languagelist	select	en
+# No logical volume found
+# for internal use; can be preseeded
+bootstrap-base	base-installer/includes	string	
+# LILO installation failed
+lilo-installer	lilo-installer/failed	error	
+# Set the clock using NTP?
+clock-setup	clock-setup/ntp	boolean	true
+# Continue the installation in the selected language?
+d-i	localechooser/translation/warn-severe	boolean	false
+# 
+# Choices: Italy, Switzerland, other
+d-i	localechooser/shortlist/it	select	
+# Scan another CD or DVD?
+apt-cdrom-setup	apt-setup/cdrom/set-next	boolean	false
+# 
+# Choices: China, Taiwan, Singapore, Hong Kong, other
+d-i	localechooser/shortlist/zh_CN	select	
+# Wait another 30 seconds for hwclock to set the clock?
+clock-setup	clock-setup/hwclock-wait	boolean	false
+# Downloading a file failed:
+# Choices: Retry, Change mirror, Ignore
+apt-mirror-setup	apt-setup/mirror/error	select	Retry
+# Failed to run preseeded command
+d-i	preseed/command_failed	error	
+# Additional parameters for module :
+d-i	hw-detect/retry_params	string	
+# No DHCP client found
+netcfg	netcfg/no_dhcp_client	error	
+# Go back to the menu and correct errors?
+# 
+# Choices: Spain, France, other
+d-i	localechooser/shortlist/eu	select	
+# state
+# Choices: Australian Capital Territory, New South Wales, Victoria, Northern Territory, Queensland, South Australia, Tasmania, Western Australia, Eyre Highway, Yancowinna County, Lord Howe Island
+tzsetup-udeb	tzsetup/country/AU	select	Australia/Canberra
+# Name of the volume group for the new system:
+# Unusable free space
+# Debootstrap Error
+bootstrap-base	base-installer/debootstrap/error/nogetrelsig	error	
+# 
+# Choices: Greece, Cyprus, other
+d-i	localechooser/shortlist/el	select	
+# for internal use; can be preseeded
+# Choose software to install:
+# Choices: Debian desktop environment, ... GNOME, ... Xfce, ... KDE, ... Cinnamon, ... MATE, ... LXDE, web server, print server, SSH server, standard system utilities
+#d-i	tasksel/first	multiselect	SSH server, standard system utilities
+# Checksum error
+d-i	preseed/checksum_error	error	
+# Initialization vector generation algorithm for this partition:
+# Choices: 
+# Scan another CD or DVD?
+apt-cdrom-setup	apt-setup/cdrom/set-first	boolean	false
+# What to do with this device:
+# Choices: 
+# Proceed to install crypto components despite insufficient memory?
+# iSCSI login failed
+# for internal use; can be preseeded
+# Keep the current keyboard layout in the configuration file?
+d-i	keyboard-configuration/unsupported_config_layout	boolean	true
+# 
+# Choices: Brazil, Portugal, other
+d-i	localechooser/shortlist/pt_BR	select	
+# Non-existing physical volume
+# Module needed for accessing the CD-ROM:
+# Choices: 
+d-i	cdrom-detect/cdrom_module	select	none
+# for internal use; can be preseeded
+d-i	preseed/run	string	
+# No physical volumes selected
+# Invalid network link detection waiting time
+netcfg	netcfg/bad_link_wait_timeout	error	
+# Volume group to reduce:
+# Choices: 
+# Not enough RAID partitions available
+# for internal use; can be preseeded
+d-i	cdrom-detect/eject	boolean	true
+# Required encryption options missing
+# for internal use
+d-i	keyboard-configuration/store_defaults_in_debconf_db	boolean	true
+# zone
+# Choices: North-West, Pacific, Sonora, Central, South-East
+tzsetup-udeb	tzsetup/country/MX	select	Mexico/General
+# Partitioning method:
+# Choices: 
+# Wireless network:
+# Choices: The Enterprise, IPCZ6841706825978, , ATT69yVd75, IPCZ6841706822989, buffymisty 2.4ghz_EXT, oddity, buffymisty 2.4ghz, Trailer, CGNVM-3260, The Enterprise 5GHz, Bonview 2.4Ghz, XFINITY, xfinitywifi, Enter ESSID manually
+netcfg	netcfg/wireless_show_essids	select	The Enterprise
+# Keep default keyboard options ()?
+d-i	keyboard-configuration/unsupported_options	boolean	true
+# WEP key for wireless device :
+netcfg	netcfg/wireless_wep	string	
+# 
+# Choices: British Indian Ocean Territory, Christmas Island, Cocos (Keeling) Islands, Comoros, French Southern Territories, Heard Island and McDonald Islands, Madagascar, Maldives, Mauritius, Mayotte, Réunion, Seychelles
+d-i	localechooser/countrylist/Indian_Ocean	select	
+# Active devices for the RAID array:
+# Choices: 
+# Encryption configuration failure
+# Help on partitioning
+# Cannot save logs
+d-i	save-logs/bad_directory	error	
+# Go back to the menu and correct this problem?
+# Use unrecommended JFS root file system?
+# Type of encryption key for this partition:
+# Choices: 
+# Layout of the RAID10 array:
+# Debian archive mirror hostname:
+choose-mirror-bin	mirror/http/hostname	string	ftp.us.debian.org
+# Logical volume size:
+# for internal use; can be preseeded
+d-i	debian-installer/framebuffer	boolean	true
+# Insert Debian boot CD-ROM
+d-i	cdrom-checker/firstcd	note	
+# for internal use; can be preseeded
+d-i	debian-installer/theme	string	
+# 
+# Choices: Belgium, Germany, Italy, Liechtenstein, Luxembourg, Switzerland, Austria, other
+d-i	localechooser/shortlist/de	select	
+# UNetbootin media detected
+d-i	cdrom-detect/unetbootin_detected	note	
+# for internal use; can be preseeded
+# Mount point for this partition:
+# Choices: / - the root file system, /boot - static files of the boot loader, /home - user home directories, /tmp - temporary files, /usr - static data, /var - variable data, /srv - data for services provided by this system, /opt - add-on application software packages, /usr/local - local hierarchy, Enter manually, Do not mount it
+# iSCSI initiator username for :
+# System locale:
+# Choices: 
+d-i	debian-installer/locale	select	en_US.UTF-8
+# for internal use; can be preseeded
+# iSCSI targets on :
+# Choices: 
+# Use non-free software?
+apt-mirror-setup	apt-setup/non-free	boolean	true
+# for internal use only
+d-i	debconf/language	string	en
+# Do you want to resume partitioning?
+# for internal use; can be preseeded
+netcfg	netcfg/dhcpv6_timeout	string	15
+# for internal use; can be preseeded
+d-i	preseed/early_command	string	
+# for internal use; can be preseeded
+finish-install	finish-install/keep-consoles	boolean	false
+# for internal use; can be preseeded
+netcfg	netcfg/disable_autoconfig	boolean	false
+# Devices to remove from the volume group:
+# Choices: 
+# 
+# Choices: Argentina, Bolivia, Brazil, Chile, Colombia, Ecuador, French Guiana, Guyana, Paraguay, Peru, Suriname, Uruguay, Venezuela
+d-i	localechooser/countrylist/South_America	select	
+# for internal use only
+user-setup-udeb	passwd/user-uid	string	
+# Kill switch enabled on 
+netcfg	netcfg/kill_switch_enabled	note	
+# RAID configuration failure
+# 
+# Choices: Serbia, Montenegro, other
+d-i	localechooser/shortlist/sr	select	
+# Write the changes to disks and configure LVM?
+# Enable shadow passwords?
+user-setup-udeb	passwd/shadow	boolean	true
+# Key size for this partition:
+# Choices: 
+# Keyboard model:
+# Choices: 
+d-i	keyboard-configuration/model	select	
+# Interactive shell
+d-i	di-utils-shell/do-shell	note	
+# The encryption key for  is now being created.
+# for internal use; can be preseeded
+# Logical Volume Management
+# Manually select a CD-ROM module and device?
+d-i	cdrom-detect/manual_config	boolean	true
+# Failed to partition the selected disk
+# Failed to download crypto components
+# 
+d-i	debian-installer/shell-plugin	terminal	
+# Location for the new partition:
+# Choices: Beginning, End
+# Devices for the new volume group:
+# Choices: 
+# Remove existing software RAID partitions?
+# for internal use only
+d-i	cdrom/codename	string	stretch
+# Error while deleting volume group
+# Password input error
+user-setup-udeb	user-setup/password-mismatch	error	
+# 
+# Choices: Aruba, Belgium, Netherlands, other
+d-i	localechooser/shortlist/nl	select	
+# for internal use; can be preseeded
+d-i	preseed/file	string	
+# for internal use; can be preseeded
+# Not enough RAID partitions specified
+# Failed to mount /target/proc
+nobootloader	nobootloader/mounterr	error	
+# Wireless ESSID for :
+netcfg	netcfg/wireless_essid	string	
+# Debootstrap Error
+bootstrap-base	base-installer/debootstrap/fallback-error	error	
+# Logical Volume Manager not available
+# iSCSI target username for :
+# zone
+# Choices: Eastern, Central, Mountain, Pacific, Alaska, Hawaii, Arizona, East Indiana, Samoa
+tzsetup-udeb	tzsetup/country/US	select	US/Eastern
+# Continue without a network mirror?
+apt-mirror-setup	apt-setup/no_mirror	boolean	false
+# Error while creating a new logical volume
+# NTP server to use:
+clock-setup	clock-setup/ntp-server	string	0.debian.pool.ntp.org
+# Unable to install GRUB in 
+# Debian archive mirror:
+# Choices: ftp.us.debian.org, debian.csail.mit.edu, debian.osuosl.org, debian.cc.lehigh.edu, debian.gtisc.gatech.edu, mirror.cc.columbia.edu, deb.debian.org, debian-archive.trafficmanager.net, mirrors.lug.mtu.edu, debian.cse.msu.edu, mirror.us.oneandone.net, mirrors.bloomu.edu, mirrors.cat.pdx.edu, mirrors.namecheap.com, mirrors.ocf.berkeley.edu, debian.mirror.constant.com, mirrors.advancedhosters.com, mirror.cogentco.com, mirrors.syringanetworks.net, mirrors.gigenet.com, mirror.us.leaseweb.net, debian.ec.as6453.net, mirrors.accretive-networks.net, debian.cs.binghamton.edu, ftp.utexas.edu, mirror.steadfast.net, debian.mirrors.pair.com, mirrors.xmission.com, mirror.keystealth.org, debian.uchicago.edu, www.gtlib.gatech.edu, mirror.math.princeton.edu, mirrors.wikimedia.org, mirror.sjc02.svwh.net, mirrors.edge.kernel.org, repo.ialab.dsu.edu, ftp.naz.com, mirror.siena.edu
+choose-mirror-bin	mirror/http/mirror	select	ftp.us.debian.org
+# Wireless ESSID for :
+netcfg	netcfg/wireless_essid_again	string	
+# for internal use; can be preseeded
+d-i	debian-installer/add-kernel-opts	string	
+# for internal use; can be preseeded
+bootstrap-base	base-installer/debootstrap_script	string	
+# for internal use; can be preseeded
+# for internal use only
+bootstrap-base	base-installer/kernel/linux/link_in_boot	boolean	false
+# Country, territory or area:
+# Choices: Antigua and Barbuda, Australia, Botswana, Canada, Hong Kong, India, Ireland, Israel, New Zealand, Nigeria, Philippines, Singapore, South Africa, United Kingdom, United States, Zambia, Zimbabwe, other
+d-i	localechooser/shortlist	select	US
+# Country of origin for the keyboard:
+# Choices: 
+d-i	keyboard-configuration/layout	select	
+# Unable to configure GRUB
+# Partition settings:
+# Choices: 
+# Invalid size
+# Go back to the menu and correct this problem?
+# 
+# Choices: Curaçao
+d-i	localechooser/countrylist/other	select	
+# location
+# Choices: McMurdo, Rothera, Palmer, Mawson, Davis, Casey, Vostok, Dumont-d'Urville, Syowa
+tzsetup-udeb	tzsetup/country/AQ	select	
+# for internal use; can be preseeded
+apt-cdrom-setup	apt-setup/disable-cdrom-entries	boolean	false
+# Really erase the data on ?
+# for internal use only
+# Choices: stable, testing, unstable
+d-i	cdrom/suite	select	stable
+# 
+# Choices: Pakistan, India, other
+d-i	localechooser/shortlist/pa	select	
+# Spare devices for the RAID array:
+# Choices: 
+# Unable to install 
+bootstrap-base	base-installer/kernel/failed-package-install	error	
+# Debian archive mirror hostname:
+choose-mirror-bin	mirror/ftp/hostname	string	mirror
+# New partition size:
+# Typical usage of this partition:
+# Choices: 
+# zone
+# Choices: Santiago, Easter Island
+tzsetup-udeb	tzsetup/country/CL	select	America/Santiago
+# Username for your account:
+user-setup-udeb	passwd/username	string	buendia
+# Debootstrap Error
+bootstrap-base	base-installer/debootstrap/error/missingrelentry	error	
+# Volume group name already in use
+# location
+# Choices: Guayaquil, Galapagos
+tzsetup-udeb	tzsetup/country/EC	select	America/Guayaquil
+# btrfs file system not supported for /boot
+# Error while setting up RAID
+# Label for the file system in this partition:
+# for internal use; can be preseeded
+netcfg	netcfg/hostname	string	
+# for internal use only
+d-i	debconf/translations-dropped	boolean	false
+# Do you intend to use FireWire Ethernet?
+ethdetect	ethdetect/use_firewire_ethernet	boolean	false
+# for internal use only
+d-i	debian-installer/language	string	en
+# for internal use; can be preseeded
+apt-setup-udeb	apt-setup/security_host	string	security.debian.org
+# Encryption configuration actions
+# Choices: Create encrypted volumes, Finish
+# 
+# Choices: 
+# Resize operation failure
+# for internal use; can be preseeded
+d-i	preseed/include/checksum	string	
+# The resize operation is impossible
+# zone
+# Choices: Tarawa (Gilbert Islands), Enderbury (Phoenix Islands), Kiritimati (Line Islands)
+tzsetup-udeb	tzsetup/country/KI	select	Pacific/Tarawa
+# Ignore questions with a priority less than:
+# Choices: critical, high, medium, low
+d-i	debconf/priority	select	high
+# Debian archive mirror country:
+# Choices: enter information manually, Argentina, Armenia, Australia, Austria, Belarus, Belgium, Brazil, Bulgaria, Canada, Chile, China, Costa Rica, Croatia, Czechia, Denmark, El Salvador, Estonia, Finland, France, French Polynesia, Georgia, Germany, Greece, Hong Kong, Hungary, India, Indonesia, Iran\, Islamic Republic of, Israel, Italy, Japan, Kazakhstan, Kenya, Korea\, Republic of, Latvia, Lithuania, Luxembourg, Macedonia\, Republic of, Mexico, Moldova, Netherlands, New Caledonia, New Zealand, Norway, Philippines, Poland, Portugal, Romania, Russian Federation, Réunion, Serbia, Singapore, Slovakia, Slovenia, South Africa, Spain, Sweden, Switzerland, Taiwan, Thailand, Turkey, Ukraine, United Kingdom, United States, Uruguay, Vietnam
+choose-mirror-bin	mirror/http/countries	select	US
+# for internal use; can be preseeded
+d-i	preseed/include_command	string	
+# LVM configuration action:
+# Choices: 
+# HTTP proxy information (blank for none):
+choose-mirror-bin	mirror/http/proxy	string	
+# Web server started
+d-i	save-logs/httpd_running	note	
+# Integrity test failed
+d-i	cdrom-checker/mismatch	error	
+# zone
+# Choices: Newfoundland, Atlantic, Eastern, Central, East Saskatchewan, Saskatchewan, Mountain, Pacific
+tzsetup-udeb	tzsetup/country/CA	select	Canada/Eastern
+# Retry mounting the CD-ROM?
+d-i	cdrom-detect/retry	boolean	true
+# 
+# Choices: South Sudan, Jordan, United Arab Emirates, Bahrain, Algeria, Syrian Arab Republic, Saudi Arabia, Sudan, Iraq, Kuwait, Morocco, India, Yemen, Tunisia, Oman, Qatar, Lebanon, Libya, Egypt, other
+d-i	localechooser/shortlist/ar	select	
+# Failed to create a file system
+# Use contrib software?
+apt-mirror-setup	apt-setup/contrib	boolean	true
+# Terminal plugin not available
+d-i	debian-installer/terminal-plugin-unavailable	error	
+# Partition table type:
+# Choices: atari, aix, amiga, bsd, dvh, gpt, mac, msdos, pc98, sun, loop
+# Malformed IP address
+netcfg	netcfg/bad_ipaddress	error	
+# Error
+netcfg	netcfg/error	error	
+# Continue the install without loading kernel modules?
+d-i	anna/no_kernel_modules	boolean	false
+# Dummy template for preseeding unavailable questions
+d-i	debian-installer/dummy	string	
+# Devices to add to the volume group:
+# Choices: 
+# Separate file system not allowed here
+# for internal use; can be preseeded
+# Invalid hostname
+netcfg	netcfg/invalid_hostname	error	
+# Translations temporarily not available
+d-i	localechooser/translation/none-yet	note	
+# 
+# Choices: Antigua and Barbuda, Australia, Botswana, Canada, Hong Kong, India, Ireland, Israel, New Zealand, Nigeria, Philippines, Singapore, South Africa, United Kingdom, United States, Zambia, Zimbabwe, other
+d-i	localechooser/shortlist/en	select	
+# for internal use; can be preseeded
+lilo-installer	lilo-installer/skip	boolean	false
+# Invalid passphrase
+netcfg	netcfg/invalid_pass	error	
+# No physical volumes selected
+# Error while running ''
+d-i	hw-detect/modprobe_error	error	
+# for internal use only
+d-i	cdrom-detect/cdrom_fs	string	iso9660
+# for internal use; can be preseeded
+base-installer	base-installer/install-recommends	boolean	true
+# for internal use; can be preseeded
+d-i	preseed/interactive	boolean	false
+# 
+# Choices: Finland, Sweden, other
+d-i	localechooser/shortlist/sv	select	
+# for internal use; can be preseeded
+d-i	debian-installer/allow_unauthenticated	boolean	false
+# for internal use; can be preseeded
+d-i	rescue/enable	boolean	false
+# Keep current keyboard options in the configuration file?
+d-i	keyboard-configuration/unsupported_config_options	boolean	true
+# The partition starts from  and ends at .
+# Name of the volume group for the new system:
+# Required programs missing
+# 
+# Choices: Brazil, Portugal, other
+d-i	localechooser/shortlist/pt	select	
+# Full name for the new user:
+user-setup-udeb	passwd/user-fullname	string	Project Buendia
+# for internal use; can be preseeded
+network-preseed	preseed/url/checksum	string	
+# Entering low memory mode
+d-i	lowmem/low	note	
+# Unable to install the selected kernel
+bootstrap-base	base-installer/kernel/failed-install	error	
+# Active devices for the RAID0 array:
+# Choices: 
+# Services to use:
+# Choices: security updates (from security.debian.org), release updates, backported software
+apt-setup-udeb	apt-setup/services-select	multiselect	security, updates
+# Device for boot loader installation:
+# Choices: Enter device manually, 
+# Create a normal user account now?
+user-setup-udeb	passwd/make-user	boolean	true
+# No physical volume defined in volume group
+# for internal use; can be preseeded
+# The size entered is invalid
+# Write the changes to disks?
+# Invalid WEP key
+netcfg	netcfg/invalid_wep	error	
+# Encryption package installation failure
+# Unable to configure GRUB
+# Setting firmware variables for automatic boot
+nobootloader	nobootloader/confirmation_powerpc_pasemi	note	
+# Failed to partition the selected disk
+# for internal use; can be preseeded
+d-i	debian-installer/allow_unauthenticated_ssl	boolean	false
+# 
+# Choices: Bangladesh, India, other
+d-i	localechooser/shortlist/bn	select	
+# for internal use; can be preseeded
+d-i	preseed/boot_command	string	
+# Country to base default locale settings on:
+# Choices: Antigua and Barbuda${!TAB}-${!TAB}en_AG, Australia${!TAB}-${!TAB}en_AU.UTF-8, Botswana${!TAB}-${!TAB}en_BW.UTF-8, Canada${!TAB}-${!TAB}en_CA.UTF-8, Hong Kong${!TAB}-${!TAB}en_HK.UTF-8, India${!TAB}-${!TAB}en_IN, Ireland${!TAB}-${!TAB}en_IE.UTF-8, Israel${!TAB}-${!TAB}en_IL, New Zealand${!TAB}-${!TAB}en_NZ.UTF-8, Nigeria${!TAB}-${!TAB}en_NG, Philippines${!TAB}-${!TAB}en_PH.UTF-8, Singapore${!TAB}-${!TAB}en_SG.UTF-8, South Africa${!TAB}-${!TAB}en_ZA.UTF-8, United Kingdom${!TAB}-${!TAB}en_GB.UTF-8, United States${!TAB}-${!TAB}en_US.UTF-8, Zambia${!TAB}-${!TAB}en_ZM, Zimbabwe${!TAB}-${!TAB}en_ZW.UTF-8
+d-i	localechooser/preferred-locale	select	en_US.UTF-8
+# Auto-configure networking?
+netcfg	netcfg/use_autoconfig	boolean	true
+# city
+# Choices: Ulaanbaatar, Hovd, Choibalsan
+tzsetup-udeb	tzsetup/country/MN	select	Asia/Ulaanbaatar
+# Driver needed for your disk drive:
+# Choices: continue with no disk drive, , none of the above
+disk-detect	disk-detect/module_select	select	continue with no disk drive
+# iSCSI target portal address:
+# 
+# Choices: Canada, Mexico, Saint Pierre and Miquelon, United States
+d-i	localechooser/countrylist/North_America	select	
+# for internal use; can be preseeded
+bootstrap-base	base-installer/kernel/linux/extra-packages-2.6	string	
+# Volume group:
+# Choices: 
+# for internal use; can be preseeded
+d-i	hw-detect/load-ide	boolean	false
+# for internal use only
+bootstrap-base	base-installer/kernel/linux/initrd-2.6	boolean	true
+# for internal use; can be preseeded
+# Choices: cylinder, minimal, optimal
+# Use unrecommended JFS /boot file system?
+# for internal use only
+d-i	debconf/showold	boolean	false
+# Failed to mount CD-ROM
+d-i	cdrom-checker/mntfailed	error	
+# for internal use; can be preseeded
+d-i	mouse/protocol	string	
+# CD-ROM detected
+d-i	cdrom-detect/success	note	
+# Create new empty partition table on this device?
+# Failed to mount the floppy
+d-i	save-logs/floppy_mount_failed	error	
+# for internal use
+d-i	keyboard-configuration/optionscode	string	
+# Do you want to return to the partitioning menu?
+# apt configuration problem
+apt-cdrom-setup	apt-setup/cdrom/failed	error	
+# Type for the new partition:
+# Choices: Primary, Logical
+# WPA/WPA2 passphrase for wireless device wlp2s0:
+netcfg	netcfg/wireless_wpa	string	kirkpicard
+# Are you sure you want a bootable logical partition?
+# Error while creating a new logical volume
+# Password input error
+# Method for temporarily toggling between national and Latin input:
+# Choices: No temporary switch, Both Logo keys, Right Alt (AltGr), Right Logo key, Left Alt, Left Logo key
+d-i	keyboard-configuration/switch	select	No temporary switch
+# Cannot install base system
+bootstrap-base	base-installer/cannot_install	error	
+# Keep default keyboard layout ()?
+d-i	keyboard-configuration/unsupported_layout	boolean	true
+# Hostname:
+netcfg	netcfg/get_hostname	string	buendia
+# Compose key:
+# Choices: No compose key, Right Alt (AltGr), Right Control, Right Logo key, Menu key, Left Logo key, Caps Lock
+d-i	keyboard-configuration/compose	select	No compose key
+# city
+# Choices: Kinshasa, Lubumbashi
+tzsetup-udeb	tzsetup/country/CD	select	Africa/Kinshasa
+# Continue the installation in the selected language?
+d-i	localechooser/translation/warn-light	boolean	true
+# Netmask:
+netcfg	netcfg/get_netmask	string	
+# Continue without a default route?
+netcfg	netcfg/no_default_route	boolean	
+# Choose an installation step:
+# Choices: 
+d-i	debian-installer/missing-provide	select	${DEFAULT}
+# Partitioning scheme:
+# Choices: All files in one partition (recommended for new users), Separate /home partition, Separate /home\, /var\, and /tmp partitions
+# location
+# Choices: Yap, Truk, Pohnpei, Kosrae
+tzsetup-udeb	tzsetup/country/FM	select	Pacific/Ponape
+# for internal use only
+d-i	debian-installer/exit/always_halt	boolean	false
+# 
+# Choices: Belgium, Canada, France, Luxembourg, Switzerland, other
+d-i	localechooser/shortlist/fr	select	
+# Encryption configuration failure
+# Protocol for file downloads:
+# Choices: http, https, ftp
+choose-mirror-bin	mirror/protocol	select	http
+# Current LVM configuration:
+# Cannot access repository
+apt-setup-udeb	apt-setup/service-failed	error	
+# Unsafe swap space detected
+# 
+# Choices: Russian Federation, Ukraine, other
+d-i	localechooser/shortlist/ru	select	
+# No network interfaces detected
+netcfg	netcfg/no_interfaces	error	
+# PCMCIA resource range options:
+d-i	hw-detect/pcmcia_resources	string	
+# Passphrase input error
+# No usable physical volumes found
+# No software RAID devices available
+# btrfs root file system not supported without separate /boot
+# for internal use; can be preseeded
+# Failed to delete the software RAID device
+# No partitionable media
+disk-detect	disk-detect/cannot_find	error	
+# Select disk to partition:
+# Choices: SCSI1 (0\,0\,0) (sda) - 250.1 GB ATA Samsung SSD 860, SCSI3 (0\,0\,0) (sdb) - 1.1 GB Generic Flash Disk
+# Failed to process the preconfiguration file
+d-i	preseed/load_error	error	
+# Erasing data on  failed
+# Gateway:
+netcfg	netcfg/get_gateway	string	
+# Are you sure you want to use a random key?
+# for internal use
+d-i	keyboard-configuration/layoutcode	string	us
+# location
+# Choices: Lisbon, Madeira Islands, Azores
+tzsetup-udeb	tzsetup/country/PT	select	Europe/Lisbon
+# Architecture not supported
+choose-mirror-bin	mirror/noarch	error	
+# Identical labels for two file systems
+# Is the system clock set to UTC?
+clock-setup	clock-setup/utc	boolean	true
+# Debian archive mirror directory:
+d-i	mirror/https/directory	string	/debian/
+# Unable to automatically remove LVM data
+# Language selection no longer possible
+d-i	localechooser/translation/no-select	note	
+# Go back to the menu and correct this problem?
+# 
+# Choices: China, Singapore, Taiwan, Hong Kong, other
+d-i	localechooser/shortlist/zh_TW	select	
+# HTTP proxy information (blank for none):
+d-i	mirror/https/proxy	string	
+# for internal use; can be preseeded
+disk-detect	disk-detect/multipath/enable	boolean	false
+# Invalid file system for this mount point
+# 
+# Choices: Macedonia\, Republic of, Albania, other
+d-i	localechooser/shortlist/sq	select	
+# Percentage of the file system blocks reserved for the super-user:
+# Failed to partition the selected disk
+# Wireless network type for wlp2s0:
+# Choices: WEP/Open Network, WPA/WPA2 PSK
+netcfg	netcfg/wireless_security_type	select	wpa
+# Primary network interface:
+# Choices: enp3s0: Realtek Semiconductor Co.\, Ltd. RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller, wlp2s0: Intel Corporation Device 24fb (wireless)
+netcfg	netcfg/choose_interface	select	wlp2s0: Intel Corporation Device 24fb (wireless)
+# 
+# Choices: India, Sri Lanka, other
+d-i	localechooser/shortlist/ta	select	
+# Scan another CD or DVD?
+apt-cdrom-setup	apt-setup/cdrom/set-failed	boolean	true
+# Mount point for this partition:
+# Choices: /dos, /windows, Enter manually, Do not mount it
+# Partition in use
+# Write a new empty partition table?
+# Is this information correct?
+netcfg	netcfg/confirm_static	boolean	true
+# Write the changes to disks and configure LVM?
+# Partitioning method:
+# Choices: Guided - use the largest continuous free space, Guided - use entire disk, Guided - use entire disk and set up LVM, Guided - use entire disk and set up encrypted LVM, Manual
+# No volume group found
+# Continue installation without /boot partition?
+# Really delete this software RAID device?
+# Drivers to include in the initrd:
+# Choices: generic: include all available drivers, targeted: only include drivers needed for this system
+bootstrap-base	base-installer/initramfs-tools/driver-policy	select	most
+# Domain name:
+netcfg	netcfg/get_domain	string	
+# IP address:
+netcfg	netcfg/get_ipaddress	string	
+# for internal use; can be preseeded
+network-preseed	auto-install/enable	boolean	false
+# Keyboard layout:
+# Choices: 
+d-i	keyboard-configuration/variant	select	
+# for internal use only
+choose-mirror-bin	mirror/codename	string	stretch
+# Continue without installing a kernel?
+bootstrap-base	base-installer/kernel/skip-install	boolean	false
+# Configuration of encrypted volumes failed
+# LILO installation target:
+# Choices: : software RAID array, Other choice (Advanced)
+lilo-installer	lilo-installer/bootdev_raid	select	
+# Empty password
+user-setup-udeb	user-setup/password-empty	error	
+# Device for boot loader installation:
+# for internal use; can be preseeded
+# Choices: traditional, label, uuid
+# Debian archive mirror:
+# Choices: 
+d-i	mirror/https/mirror	select	
+# Participate in the package usage survey?
+d-i	popularity-contest/participate	boolean	false
+# for internal use; can be preseeded
+d-i	debian-installer/exit/halt	boolean	false
+# for internal use; can be preseeded
+apt-setup-udeb	apt-setup/multiarch	string	
+# Ethernet card not found
+ethdetect	ethdetect/cannot_find	error	
+# Number of active devices for the RAID array:
+# Devices to encrypt:
+# Choices: 
+# for internal use
+d-i	keyboard-configuration/modelcode	string	pc105
+# Name server addresses:
+netcfg	netcfg/get_nameservers	string	
+# Software RAID device type:
+# Choices: RAID0, RAID1, RAID5, RAID6, RAID10
+# LILO installation target:
+# Choices: : Master Boot Record, : new Debian partition, Other choice (Advanced)
+lilo-installer	lilo-installer/bootdev	select	
+# Failed to copy file from CD-ROM. Retry?
+d-i	retriever/cdrom/error	boolean	true
+# Invalid logical volume or volume group name
+# for internal use only
+d-i	anna/retriever	string	cdrom-retriever
+# Write the changes to the storage devices and configure RAID?
+# Install GRUB?
+# Debian archive mirror country:
+# Choices: enter information manually
+choose-mirror-bin	mirror/https/countries	select	US
+# for internal use
+d-i	keyboard-configuration/variantcode	string	
+# No volume group found
+# for internal use; can be preseeded
+# Installer components to load:
+# Choices: choose-mirror: Choose mirror to install from (menu item), crypto-dm-modules-4.9.0-9-amd64-di: devicemapper crypto module, driver-injection-disk-detect: Detect OEM driver injection disks, fuse-modules-4.9.0-9-amd64-di: FUSE modules, load-media: Load installer components from removable media, lowmem: free memory for lowmem install, mbr-udeb: Master Boot Record for IBM-PC compatible computers, multipath-modules-4.9.0-9-amd64-di: Multipath support, nbd-modules-4.9.0-9-amd64-di: Network Block Device modules, network-console: Continue installation remotely using SSH, ntfs-modules-4.9.0-9-amd64-di: NTFS filesystem support, openssh-client-udeb: secure shell client for the Debian installer, parted-udeb: Manually partition a hard drive (parted), ppp-modules-4.9.0-9-amd64-di: PPP drivers, ppp-udeb: Point-to-Point Protocol (PPP) - package for Debian Installer, reiserfsprogs-udeb: User-level tools for ReiserFS filesystems, rescue-mode: mount requested partition and start a rescue shell, squashfs-modules-4.9.0-9-amd64-di: squashfs modules, udf-modules-4.9.0-9-amd64-di: UDF modules, virtio-modules-4.9.0-9-amd64-di: virtio modules
+d-i	anna/choose_modules	multiselect	
+# Key to function as AltGr:
+# Choices: The default for the keyboard layout, No AltGr key, Right Alt (AltGr), Right Control, Right Logo key, Menu key, Left Alt, Left Logo key, Keypad Enter key, Both Logo keys, Both Alt keys
+d-i	keyboard-configuration/altgr	select	The default for the keyboard layout
+# 
+# Choices: Albania, Andorra, Armenia, Austria, Azerbaijan, Belarus, Belgium, Bosnia and Herzegovina, Bulgaria, Croatia, Cyprus, Czech Republic, Denmark, Estonia, Faroe Islands, Finland, France, Georgia, Germany, Gibraltar, Greece, Greenland, Guernsey, Holy See (Vatican City State), Hungary, Iceland, Ireland, Isle of Man, Italy, Jersey, Latvia, Liechtenstein, Lithuania, Luxembourg, Macedonia\, Republic of, Malta, Moldova, Monaco, Montenegro, Netherlands, Norway, Poland, Portugal, Romania, Russian Federation, San Marino, Serbia, Slovakia, Slovenia, Spain, Svalbard and Jan Mayen, Sweden, Switzerland, Ukraine, United Kingdom, Åland Islands
+d-i	localechooser/countrylist/Europe	select	
+# for internal use; can be preseeded
+pkgsel	pkgsel/include	string	
+# for internal use; can be preseeded
+# Not installing to unclean target
+base-installer	base-installer/unclean_target_cancel	error	
+# 
+# Choices: American Samoa, Australia, Cook Islands, Fiji, French Polynesia, Guam, Kiribati, Marshall Islands, Micronesia\, Federated States of, Nauru, New Caledonia, New Zealand, Niue, Norfolk Island, Northern Mariana Islands, Palau, Papua New Guinea, Pitcairn, Samoa, Solomon Islands, Tokelau, Tonga, Tuvalu, United States Minor Outlying Islands, Vanuatu, Wallis and Futuna
+d-i	localechooser/countrylist/Oceania	select	
+# Insufficient memory
+d-i	lowmem/insufficient	error	
+# Installation complete
+# finish-install	finish-install/reboot_in_progress	note	
+# Point-to-point address:
+netcfg	netcfg/get_pointopoint	string	
+# for internal use; can be preseeded
+d-i	debian-installer/exit/poweroff	boolean	false
+# Install the GRUB boot loader to the master boot record?
+# Are you sure you want to exit now?
+#d-i	di-utils-reboot/really_reboot	boolean	false
+# Logical volume name:
+# Error while extending volume group
+# 
+# Choices: Algeria, Angola, Benin, Botswana, Burkina Faso, Burundi, Cabo Verde, Cameroon, Central African Republic, Chad, Congo, Congo\, The Democratic Republic of the, Côte d'Ivoire, Djibouti, Egypt, Equatorial Guinea, Eritrea, Ethiopia, Gabon, Gambia, Ghana, Guinea, Guinea-Bissau, Kenya, Lesotho, Liberia, Libya, Malawi, Mali, Mauritania, Morocco, Mozambique, Namibia, Niger, Nigeria, Rwanda, Sao Tome and Principe, Senegal, Sierra Leone, Somalia, South Africa, South Sudan, Sudan, Swaziland, Tanzania, Togo, Tunisia, Uganda, Western Sahara, Zambia, Zimbabwe
+d-i	localechooser/countrylist/Africa	select	
+# No root file system
+# Error reading Release file
+d-i	cdrom-detect/no-release	error	
+# Debian archive mirror directory:
+choose-mirror-bin	mirror/http/directory	string	/debian/
+# Debootstrap Error
+bootstrap-base	base-installer/no_codename	error	
+# Scan another CD or DVD?
+apt-cdrom-setup	apt-setup/cdrom/set-double	boolean	true
+# Method for toggling between national and Latin mode:
+# Choices: Caps Lock, Right Alt (AltGr), Right Control, Right Shift, Right Logo key, Menu key, Alt+Shift, Control+Shift, Control+Alt, Alt+Caps Lock, Left Control+Left Shift, Left Alt, Left Control, Left Shift, Left Logo key, Scroll Lock key, No toggling
+d-i	keyboard-configuration/toggle	select	No toggling
+# No RAID partitions available
+# Unsupported initrd generator
+bootstrap-base	base-installer/initramfs/unsupported	error	
+# Invalid mount point
+# No physical volumes selected
+# No logical volume name entered
+# Software RAID configuration actions
+# Choices: Create MD device, Delete MD device, Finish
+# Empty password
+# GRUB installation failed
+# Error while initializing physical volume
+# Network configuration method:
+# Choices: Retry network autoconfiguration, Retry network autoconfiguration with a DHCP hostname, Configure network manually, , Do not configure the network at this time
+netcfg	netcfg/dhcp_options	select	Configure network manually
+# locale
+d-i	localechooser/help/locale	note	
+# Use Control+Alt+Backspace to terminate the X server?
+d-i	keyboard-configuration/ctrl_alt_bksp	boolean	false
+# Write the changes to the storage devices and configure RAID?
+# Debootstrap Error
+bootstrap-base	base-installer/debootstrap/error/couldntdl	error	
+# zone
+# Choices: Port Moresby, Bougainville
+tzsetup-udeb	tzsetup/country/PG	select	
+# Initialisation of encrypted volume failed
+# for internal use; can be preseeded
+bootstrap-base	base-installer/excludes	string	
+# Empty passphrase
+# Integrity test successful
+d-i	cdrom-checker/passed	note	
+# for internal use; can be preseeded
+bootstrap-base	base-installer/kernel/linux/extra-packages	string	
+# Failed to mount /target/proc
+# for internal use only
+d-i	debconf/frontend	string	
+# Write the changes to disk and configure encrypted volumes?
+# for internal use only
+d-i	debian-installer/consoledisplay	string	console-setup
+# Waiting time (in seconds) for link detection:
+netcfg	netcfg/link_wait_timeout	string	3
+# LVM configuration failure
+# Unable to configure GRUB
+# Volume group to delete:
+# Choices: 
+# for internal use; can be preseeded
+ethdetect	ethdetect/prompt_missing_firmware	boolean	true
+# No valid Debian CD-ROM
+d-i	cdrom-checker/wrongcd	error	
+# Machines to relay mail for:
+exim4-config	exim4/dc_relay_nets	string	
+# kFreeBSD command line:
+# Disable SSH password authentication for root?
+openssh-server	openssh-server/permit-root-login	boolean	true
+# Trust new certificates from certificate authorities?
+# Choices: yes, no, ask
+ca-certificates	ca-certificates/trust_new_crts	select	yes
+# Failure restarting some services for PAM upgrade
+libpam0g:amd64	libpam0g/restart-failed	error	
+# Interface to use:
+# Choices: Dialog, Readline, Gnome, Kde, Editor, Noninteractive
+debconf	debconf/frontend	select	Dialog
+# /boot/grub/device.map has been regenerated
+# for internal use
+console-setup	console-setup/store_defaults_in_debconf_db	boolean	true
+# kFreeBSD default command line:
+# for internal use
+d-i	keyboard-configuration/variantcode	string	
+keyboard-configuration	keyboard-configuration/variantcode	string	
+# for internal use
+d-i	keyboard-configuration/layoutcode	string	us
+keyboard-configuration	keyboard-configuration/layoutcode	string	us
+# for internal use
+d-i	keyboard-configuration/optionscode	string	
+keyboard-configuration	keyboard-configuration/optionscode	string	
+# Key to function as AltGr:
+# Choices: The default for the keyboard layout, No AltGr key, Right Alt (AltGr), Right Control, Right Logo key, Menu key, Left Alt, Left Logo key, Keypad Enter key, Both Logo keys, Both Alt keys
+d-i	keyboard-configuration/altgr	select	The default for the keyboard layout
+keyboard-configuration	keyboard-configuration/altgr	select	The default for the keyboard layout
+# Keep default keyboard layout ()?
+d-i	keyboard-configuration/unsupported_layout	boolean	true
+keyboard-configuration	keyboard-configuration/unsupported_layout	boolean	true
+# Method for temporarily toggling between national and Latin input:
+# Choices: No temporary switch, Both Logo keys, Right Alt (AltGr), Right Logo key, Left Alt, Left Logo key
+d-i	keyboard-configuration/switch	select	No temporary switch
+keyboard-configuration	keyboard-configuration/switch	select	No temporary switch
+# Locales to be generated:
+# Choices: All locales, aa_DJ ISO-8859-1, aa_DJ.UTF-8 UTF-8, aa_ER UTF-8, aa_ER@saaho UTF-8, aa_ET UTF-8, af_ZA ISO-8859-1, af_ZA.UTF-8 UTF-8, ak_GH UTF-8, am_ET UTF-8, an_ES ISO-8859-15, an_ES.UTF-8 UTF-8, anp_IN UTF-8, ar_AE ISO-8859-6, ar_AE.UTF-8 UTF-8, ar_BH ISO-8859-6, ar_BH.UTF-8 UTF-8, ar_DZ ISO-8859-6, ar_DZ.UTF-8 UTF-8, ar_EG ISO-8859-6, ar_EG.UTF-8 UTF-8, ar_IN UTF-8, ar_IQ ISO-8859-6, ar_IQ.UTF-8 UTF-8, ar_JO ISO-8859-6, ar_JO.UTF-8 UTF-8, ar_KW ISO-8859-6, ar_KW.UTF-8 UTF-8, ar_LB ISO-8859-6, ar_LB.UTF-8 UTF-8, ar_LY ISO-8859-6, ar_LY.UTF-8 UTF-8, ar_MA ISO-8859-6, ar_MA.UTF-8 UTF-8, ar_OM ISO-8859-6, ar_OM.UTF-8 UTF-8, ar_QA ISO-8859-6, ar_QA.UTF-8 UTF-8, ar_SA ISO-8859-6, ar_SA.UTF-8 UTF-8, ar_SD ISO-8859-6, ar_SD.UTF-8 UTF-8, ar_SS UTF-8, ar_SY ISO-8859-6, ar_SY.UTF-8 UTF-8, ar_TN ISO-8859-6, ar_TN.UTF-8 UTF-8, ar_YE ISO-8859-6, ar_YE.UTF-8 UTF-8, as_IN UTF-8, ast_ES ISO-8859-15, ast_ES.UTF-8 UTF-8, ayc_PE UTF-8, az_AZ UTF-8, be_BY CP1251, be_BY.UTF-8 UTF-8, be_BY@latin UTF-8, bem_ZM UTF-8, ber_DZ UTF-8, ber_MA UTF-8, bg_BG CP1251, bg_BG.UTF-8 UTF-8, bhb_IN.UTF-8 UTF-8, bho_IN UTF-8, bn_BD UTF-8, bn_IN UTF-8, bo_CN UTF-8, bo_IN UTF-8, br_FR ISO-8859-1, br_FR.UTF-8 UTF-8, br_FR@euro ISO-8859-15, brx_IN UTF-8, bs_BA ISO-8859-2, bs_BA.UTF-8 UTF-8, byn_ER UTF-8, ca_AD ISO-8859-15, ca_AD.UTF-8 UTF-8, ca_ES ISO-8859-1, ca_ES.UTF-8 UTF-8, ca_ES.UTF-8@valencia UTF-8, ca_ES@euro ISO-8859-15, ca_ES@valencia ISO-8859-15, ca_FR ISO-8859-15, ca_FR.UTF-8 UTF-8, ca_IT ISO-8859-15, ca_IT.UTF-8 UTF-8, ce_RU UTF-8, chr_US UTF-8, cmn_TW UTF-8, crh_UA UTF-8, cs_CZ ISO-8859-2, cs_CZ.UTF-8 UTF-8, csb_PL UTF-8, cv_RU UTF-8, cy_GB ISO-8859-14, cy_GB.UTF-8 UTF-8, da_DK ISO-8859-1, da_DK.UTF-8 UTF-8, de_AT ISO-8859-1, de_AT.UTF-8 UTF-8, de_AT@euro ISO-8859-15, de_BE ISO-8859-1, de_BE.UTF-8 UTF-8, de_BE@euro ISO-8859-15, de_CH ISO-8859-1, de_CH.UTF-8 UTF-8, de_DE ISO-8859-1, de_DE.UTF-8 UTF-8, de_DE@euro ISO-8859-15, de_IT ISO-8859-1, de_IT.UTF-8 UTF-8, de_LI.UTF-8 UTF-8, de_LU ISO-8859-1, de_LU.UTF-8 UTF-8, de_LU@euro ISO-8859-15, doi_IN UTF-8, dv_MV UTF-8, dz_BT UTF-8, el_CY ISO-8859-7, el_CY.UTF-8 UTF-8, el_GR ISO-8859-7, el_GR.UTF-8 UTF-8, en_AG UTF-8, en_AU ISO-8859-1, en_AU.UTF-8 UTF-8, en_BW ISO-8859-1, en_BW.UTF-8 UTF-8, en_CA ISO-8859-1, en_CA.UTF-8 UTF-8, en_DK ISO-8859-1, en_DK.ISO-8859-15 ISO-8859-15, en_DK.UTF-8 UTF-8, en_GB ISO-8859-1, en_GB.ISO-8859-15 ISO-8859-15, en_GB.UTF-8 UTF-8, en_HK ISO-8859-1, en_HK.UTF-8 UTF-8, en_IE ISO-8859-1, en_IE.UTF-8 UTF-8, en_IE@euro ISO-8859-15, en_IL UTF-8, en_IN UTF-8, en_NG UTF-8, en_NZ ISO-8859-1, en_NZ.UTF-8 UTF-8, en_PH ISO-8859-1, en_PH.UTF-8 UTF-8, en_SG ISO-8859-1, en_SG.UTF-8 UTF-8, en_US ISO-8859-1, en_US.ISO-8859-15 ISO-8859-15, en_US.UTF-8 UTF-8, en_ZA ISO-8859-1, en_ZA.UTF-8 UTF-8, en_ZM UTF-8, en_ZW ISO-8859-1, en_ZW.UTF-8 UTF-8, eo UTF-8, es_AR ISO-8859-1, es_AR.UTF-8 UTF-8, es_BO ISO-8859-1, es_BO.UTF-8 UTF-8, es_CL ISO-8859-1, es_CL.UTF-8 UTF-8, es_CO ISO-8859-1, es_CO.UTF-8 UTF-8, es_CR ISO-8859-1, es_CR.UTF-8 UTF-8, es_CU UTF-8, es_DO ISO-8859-1, es_DO.UTF-8 UTF-8, es_EC ISO-8859-1, es_EC.UTF-8 UTF-8, es_ES ISO-8859-1, es_ES.UTF-8 UTF-8, es_ES@euro ISO-8859-15, es_GT ISO-8859-1, es_GT.UTF-8 UTF-8, es_HN ISO-8859-1, es_HN.UTF-8 UTF-8, es_MX ISO-8859-1, es_MX.UTF-8 UTF-8, es_NI ISO-8859-1, es_NI.UTF-8 UTF-8, es_PA ISO-8859-1, es_PA.UTF-8 UTF-8, es_PE ISO-8859-1, es_PE.UTF-8 UTF-8, es_PR ISO-8859-1, es_PR.UTF-8 UTF-8, es_PY ISO-8859-1, es_PY.UTF-8 UTF-8, es_SV ISO-8859-1, es_SV.UTF-8 UTF-8, es_US ISO-8859-1, es_US.UTF-8 UTF-8, es_UY ISO-8859-1, es_UY.UTF-8 UTF-8, es_VE ISO-8859-1, es_VE.UTF-8 UTF-8, et_EE ISO-8859-1, et_EE.ISO-8859-15 ISO-8859-15, et_EE.UTF-8 UTF-8, eu_ES ISO-8859-1, eu_ES.UTF-8 UTF-8, eu_ES@euro ISO-8859-15, eu_FR ISO-8859-1, eu_FR.UTF-8 UTF-8, eu_FR@euro ISO-8859-15, fa_IR UTF-8, ff_SN UTF-8, fi_FI ISO-8859-1, fi_FI.UTF-8 UTF-8, fi_FI@euro ISO-8859-15, fil_PH UTF-8, fo_FO ISO-8859-1, fo_FO.UTF-8 UTF-8, fr_BE ISO-8859-1, fr_BE.UTF-8 UTF-8, fr_BE@euro ISO-8859-15, fr_CA ISO-8859-1, fr_CA.UTF-8 UTF-8, fr_CH ISO-8859-1, fr_CH.UTF-8 UTF-8, fr_FR ISO-8859-1, fr_FR.UTF-8 UTF-8, fr_FR@euro ISO-8859-15, fr_LU ISO-8859-1, fr_LU.UTF-8 UTF-8, fr_LU@euro ISO-8859-15, fur_IT UTF-8, fy_DE UTF-8, fy_NL UTF-8, ga_IE ISO-8859-1, ga_IE.UTF-8 UTF-8, ga_IE@euro ISO-8859-15, gd_GB ISO-8859-15, gd_GB.UTF-8 UTF-8, gez_ER UTF-8, gez_ER@abegede UTF-8, gez_ET UTF-8, gez_ET@abegede UTF-8, gl_ES ISO-8859-1, gl_ES.UTF-8 UTF-8, gl_ES@euro ISO-8859-15, gu_IN UTF-8, gv_GB ISO-8859-1, gv_GB.UTF-8 UTF-8, ha_NG UTF-8, hak_TW UTF-8, he_IL ISO-8859-8, he_IL.UTF-8 UTF-8, hi_IN UTF-8, hne_IN UTF-8, hr_HR ISO-8859-2, hr_HR.UTF-8 UTF-8, hsb_DE ISO-8859-2, hsb_DE.UTF-8 UTF-8, ht_HT UTF-8, hu_HU ISO-8859-2, hu_HU.UTF-8 UTF-8, hy_AM UTF-8, hy_AM.ARMSCII-8 ARMSCII-8, ia_FR UTF-8, id_ID ISO-8859-1, id_ID.UTF-8 UTF-8, ig_NG UTF-8, ik_CA UTF-8, is_IS ISO-8859-1, is_IS.UTF-8 UTF-8, it_CH ISO-8859-1, it_CH.UTF-8 UTF-8, it_IT ISO-8859-1, it_IT.UTF-8 UTF-8, it_IT@euro ISO-8859-15, iu_CA UTF-8, ja_JP.EUC-JP EUC-JP, ja_JP.UTF-8 UTF-8, ka_GE GEORGIAN-PS, ka_GE.UTF-8 UTF-8, kk_KZ PT154, kk_KZ.RK1048 RK1048, kk_KZ.UTF-8 UTF-8, kl_GL ISO-8859-1, kl_GL.UTF-8 UTF-8, km_KH UTF-8, kn_IN UTF-8, ko_KR.EUC-KR EUC-KR, ko_KR.UTF-8 UTF-8, kok_IN UTF-8, ks_IN UTF-8, ks_IN@devanagari UTF-8, ku_TR ISO-8859-9, ku_TR.UTF-8 UTF-8, kw_GB ISO-8859-1, kw_GB.UTF-8 UTF-8, ky_KG UTF-8, lb_LU UTF-8, lg_UG ISO-8859-10, lg_UG.UTF-8 UTF-8, li_BE UTF-8, li_NL UTF-8, lij_IT UTF-8, ln_CD UTF-8, lo_LA UTF-8, lt_LT ISO-8859-13, lt_LT.UTF-8 UTF-8, lv_LV ISO-8859-13, lv_LV.UTF-8 UTF-8, lzh_TW UTF-8, mag_IN UTF-8, mai_IN UTF-8, mg_MG ISO-8859-15, mg_MG.UTF-8 UTF-8, mhr_RU UTF-8, mi_NZ ISO-8859-13, mi_NZ.UTF-8 UTF-8, mk_MK ISO-8859-5, mk_MK.UTF-8 UTF-8, ml_IN UTF-8, mn_MN UTF-8, mni_IN UTF-8, mr_IN UTF-8, ms_MY ISO-8859-1, ms_MY.UTF-8 UTF-8, mt_MT ISO-8859-3, mt_MT.UTF-8 UTF-8, my_MM UTF-8, nan_TW UTF-8, nan_TW@latin UTF-8, nb_NO ISO-8859-1, nb_NO.UTF-8 UTF-8, nds_DE UTF-8, nds_NL UTF-8, ne_NP UTF-8, nhn_MX UTF-8, niu_NU UTF-8, niu_NZ UTF-8, nl_AW UTF-8, nl_BE ISO-8859-1, nl_BE.UTF-8 UTF-8, nl_BE@euro ISO-8859-15, nl_NL ISO-8859-1, nl_NL.UTF-8 UTF-8, nl_NL@euro ISO-8859-15, nn_NO ISO-8859-1, nn_NO.UTF-8 UTF-8, nr_ZA UTF-8, nso_ZA UTF-8, oc_FR ISO-8859-1, oc_FR.UTF-8 UTF-8, om_ET UTF-8, om_KE ISO-8859-1, om_KE.UTF-8 UTF-8, or_IN UTF-8, os_RU UTF-8, pa_IN UTF-8, pa_PK UTF-8, pap_AW UTF-8, pap_CW UTF-8, pl_PL ISO-8859-2, pl_PL.UTF-8 UTF-8, ps_AF UTF-8, pt_BR ISO-8859-1, pt_BR.UTF-8 UTF-8, pt_PT ISO-8859-1, pt_PT.UTF-8 UTF-8, pt_PT@euro ISO-8859-15, quz_PE UTF-8, raj_IN UTF-8, ro_RO ISO-8859-2, ro_RO.UTF-8 UTF-8, ru_RU ISO-8859-5, ru_RU.CP1251 CP1251, ru_RU.KOI8-R KOI8-R, ru_RU.UTF-8 UTF-8, ru_UA KOI8-U, ru_UA.UTF-8 UTF-8, rw_RW UTF-8, sa_IN UTF-8, sat_IN UTF-8, sc_IT UTF-8, sd_IN UTF-8, sd_IN@devanagari UTF-8, se_NO UTF-8, sgs_LT UTF-8, shs_CA UTF-8, si_LK UTF-8, sid_ET UTF-8, sk_SK ISO-8859-2, sk_SK.UTF-8 UTF-8, sl_SI ISO-8859-2, sl_SI.UTF-8 UTF-8, so_DJ ISO-8859-1, so_DJ.UTF-8 UTF-8, so_ET UTF-8, so_KE ISO-8859-1, so_KE.UTF-8 UTF-8, so_SO ISO-8859-1, so_SO.UTF-8 UTF-8, sq_AL ISO-8859-1, sq_AL.UTF-8 UTF-8, sq_MK UTF-8, sr_ME UTF-8, sr_RS UTF-8, sr_RS@latin UTF-8, ss_ZA UTF-8, st_ZA ISO-8859-1, st_ZA.UTF-8 UTF-8, sv_FI ISO-8859-1, sv_FI.UTF-8 UTF-8, sv_FI@euro ISO-8859-15, sv_SE ISO-8859-1, sv_SE.ISO-8859-15 ISO-8859-15, sv_SE.UTF-8 UTF-8, sw_KE UTF-8, sw_TZ UTF-8, szl_PL UTF-8, ta_IN UTF-8, ta_LK UTF-8, tcy_IN.UTF-8 UTF-8, te_IN UTF-8, tg_TJ KOI8-T, tg_TJ.UTF-8 UTF-8, th_TH TIS-620, th_TH.UTF-8 UTF-8, the_NP UTF-8, ti_ER UTF-8, ti_ET UTF-8, tig_ER UTF-8, tk_TM UTF-8, tl_PH ISO-8859-1, tl_PH.UTF-8 UTF-8, tn_ZA UTF-8, tr_CY ISO-8859-9, tr_CY.UTF-8 UTF-8, tr_TR ISO-8859-9, tr_TR.UTF-8 UTF-8, ts_ZA UTF-8, tt_RU UTF-8, tt_RU@iqtelif UTF-8, ug_CN UTF-8, uk_UA KOI8-U, uk_UA.UTF-8 UTF-8, unm_US UTF-8, ur_IN UTF-8, ur_PK UTF-8, uz_UZ ISO-8859-1, uz_UZ.UTF-8 UTF-8, uz_UZ@cyrillic UTF-8, ve_ZA UTF-8, vi_VN UTF-8, wa_BE ISO-8859-1, wa_BE.UTF-8 UTF-8, wa_BE@euro ISO-8859-15, wae_CH UTF-8, wal_ET UTF-8, wo_SN UTF-8, xh_ZA ISO-8859-1, xh_ZA.UTF-8 UTF-8, yi_US CP1255, yi_US.UTF-8 UTF-8, yo_NG UTF-8, yue_HK UTF-8, zh_CN GB2312, zh_CN.GB18030 GB18030, zh_CN.GBK GBK, zh_CN.UTF-8 UTF-8, zh_HK BIG5-HKSCS, zh_HK.UTF-8 UTF-8, zh_SG GB2312, zh_SG.GBK GBK, zh_SG.UTF-8 UTF-8, zh_TW BIG5, zh_TW.EUC-TW EUC-TW, zh_TW.UTF-8 UTF-8, zu_ZA ISO-8859-1, zu_ZA.UTF-8 UTF-8
+locales	locales/locales_to_be_generated	multiselect	
+# Do you want to change the GID of group ?
+base-passwd	base-passwd/group-change-gid	boolean	true
+# Do you want to add the user ?
+base-passwd	base-passwd/user-add	boolean	true
+# Invalid configuration value for default dictionary
+dictionaries-common	dictionaries-common/invalid_debconf_value	error	
+# Time zone:
+# Choices: Alaska, Aleutian, Arizona, Central, Eastern, Hawaii, Starke County (Indiana), Michigan, Mountain, Pacific Ocean, Pacific-New, Samoa
+tzdata	tzdata/Zones/US	select	
+# Do you want to move the group ?
+base-passwd	base-passwd/group-move	boolean	true
+# IP-addresses to listen on for incoming SMTP connections:
+exim4-config	exim4/dc_local_interfaces	string	127.0.0.1 ; ::1
+# Kernel version not supported
+libc6	glibc/kernel-not-supported	note	
+libc6:amd64	glibc/kernel-not-supported	note	
+# Override local changes to /etc/pam.d/common-*?
+libpam-runtime	libpam-runtime/override	boolean	false
+# Time zone:
+# Choices: Adak, Anchorage, Anguilla, Antigua, Araguaina, Buenos Aires (Argentina), Catamarca (Argentina), Cordoba (Argentina), Jujuy (Argentina), La Rioja (Argentina), Mendoza (Argentina), Rio Gallegos (Argentina), Salta (Argentina), San Juan (Argentina), San Luis (Argentina), Tucuman (Argentina), Ushuaia (Argentina), Aruba, Asuncion, Atikokan, Atka, Bahia, Bahia_Banderas, Barbados, Belem, Belize, Blanc-Sablon, Boa Vista, Bogota, Boise, Cambridge Bay, Campo Grande, Cancun, Caracas, Cayenne, Cayman, Chicago, Chihuahua, Coral Harbour, Costa Rica, Creston, Cuiaba, Curaçao, Danmarkshavn, Dawson, Dawson Creek, Denver, Detroit, Dominica, Edmonton, Eirunepe, El Salvador, Ensenada, Fort_Nelson, Fortaleza, Glace Bay, Godthab, Goose Bay, Grand Turk, Grenada, Guadeloupe, Guatemala, Guayaquil, Guyana, Halifax, Havana, Hermosillo, Indianapolis (Indiana), Knox (Indiana), Marengo (Indiana), Petersburg (Indiana), Tell City (Indiana), Vevay (Indiana), Vincennes (Indiana), Winamac (Indiana), Inuvik, Iqaluit, Jamaica, Juneau, Louisville (Kentucky), Monticello (Kentucky), Kralendijk, La Paz, Lima, Los Angeles, Lower Princes, Maceio, Managua, Manaus, Marigot, Martinique, Matamoros, Mazatlan, Menominee, Merida, Metlakatla, Mexico City, Miquelon, Moncton, Monterrey, Montevideo, Montreal, Montserrat, Nassau, New York, Nipigon, Nome, Fernando de Noronha, Beulah (North Dakota), Center (North Dakota), New Salem (North Dakota), Ojinaga, Panama, Pangnirtung, Paramaribo, Phoenix, Port-au-Prince, Port of Spain, Porto Acre, Porto Velho, Puerto Rico, Punta_Arenas, Rainy River, Rankin Inlet, Recife, Regina, Resolute, Rio Branco, Santa Isabel, Santarém, Santiago, Santo Domingo, São Paulo, Scoresbysund, Shiprock, Sitka, St Barthelemy, St Johns, St Kitts, St Lucia, St Thomas, St Vincent, Swift Current, Tegucigalpa, Thule, Thunder Bay, Tijuana, Toronto, Tortola, Vancouver, Virgin, Whitehorse, Winnipeg, Yakutat, Yellowknife
+tzdata	tzdata/Zones/America	select	
+# Keep the current keyboard layout in the configuration file?
+d-i	keyboard-configuration/unsupported_config_layout	boolean	true
+keyboard-configuration	keyboard-configuration/unsupported_config_layout	boolean	true
+# Time zone:
+# Choices: Amsterdam, Andorra, Astrakhan, Athens, Belfast, Belgrade, Berlin, Bratislava, Brussels, Bucharest, Budapest, Büsingen, Chisinau, Copenhagen, Dublin, Gibraltar, Guernsey, Helsinki, Isle of Man, Istanbul, Jersey, Kaliningrad, Kiev, Kirov, Lisbon, Ljubljana, London, Luxembourg, Madrid, Malta, Mariehamn, Minsk, Monaco, Moscow, Nicosia, Oslo, Paris, Podgorica, Prague, Riga, Rome, Samara, San Marino, Sarajevo, Saratov, Simferopol, Skopje, Sofia, Stockholm, Tallinn, Tirane, Tiraspol, Ulyanovsk, Uzhgorod, Vaduz, Vatican, Vienna, Vilnius, Volgograd, Warsaw, Zagreb, Zaporozhye, Zurich
+tzdata	tzdata/Zones/Europe	select	
+# Problems rebuilding an  hash file ()
+dictionaries-common	dictionaries-common/ispell-autobuildhash-message	note	
+# Do you want to change the shell of user ?
+base-passwd	base-passwd/user-change-shell	boolean	true
+# for internal use
+console-setup	console-setup/codesetcode	string	Lat15
+# Do you want to change the GECOS of user ?
+base-passwd	base-passwd/user-change-gecos	boolean	true
+# Default locale for the system environment:
+# Choices: None, C.UTF-8, 
+locales	locales/default_environment_locale	select	None
+# Time zone:
+# Choices: Apia, Auckland, Bougainville, Chatham, Chuuk, Easter, Efate, Enderbury, Fakaofo, Fiji, Funafuti, Galapagos, Gambier, Guadalcanal, Guam, Honolulu, Johnston, Kiritimati, Kosrae, Kwajalein, Majuro, Marquesas, Midway, Nauru, Niue, Norfolk, Noumea, Pago Pago, Palau, Pitcairn, Pohnpei, Pohnpei, Port Moresby, Rarotonga, Saipan, Samoa, Tahiti, Tarawa, Tongatapu, Truk, Wake, Wallis, Yap
+tzdata	tzdata/Zones/Pacific	select	
+# Time zone:
+# Choices: Adelaide, Brisbane, Broken Hill, Canberra, Currie, Darwin, Eucla, Hobart, Lindeman, Lord Howe, Melbourne, Perth, Sydney, Yancowinna
+tzdata	tzdata/Zones/Australia	select	
+# Should apt-listchanges skip changes that have already been seen?
+apt-listchanges	apt-listchanges/save-seen	boolean	true
+# Update NVRAM variables to automatically boot into Debian?
+# xscreensaver and xlockmore must be restarted before upgrading
+libpam-modules	libpam-modules/disable-screensaver	error	
+# Really leave the mail system unconfigured?
+exim4-config	exim4/no_config	boolean	true
+# Possible debconf database corruption
+dictionaries-common	dictionaries-common/debconf_database_corruption	error	
+# Failure restarting some services for OpenSSL upgrade
+libssl1.0.2	libssl1.0.2/restart-failed	error	
+libssl1.0.2:amd64	libssl1.0.2/restart-failed	error	
+# Username for your account:
+user-setup-udeb	passwd/username	string	buendia
+# Visible domain name for local users:
+exim4-config	exim4/dc_readhost	string	
+# Abort kernel removal?
+linux-base	linux-base/removing-running-kernel	boolean	true
+# Reconfigure exim4-config instead of this package
+exim4-base	exim4-base/drec	error	
+# Do you want to remove the user ?
+base-passwd	base-passwd/user-remove	boolean	true
+# Compose key:
+# Choices: No compose key, Right Alt (AltGr), Right Control, Right Logo key, Menu key, Left Logo key, Caps Lock
+d-i	keyboard-configuration/compose	select	No compose key
+keyboard-configuration	keyboard-configuration/compose	select	No compose key
+# Root and postmaster mail recipient:
+exim4-config	exim4/dc_postmaster	string	buendia
+# Changes displayed with APT:
+# Choices: news, changelogs, both
+apt-listchanges	apt-listchanges/which	select	news
+# Default values for ispell dictionary/wordlist not set
+dictionaries-common	dictionaries-common/selecting_ispell_wordlist_default	note	
+# for internal use
+d-i	keyboard-configuration/store_defaults_in_debconf_db	boolean	true
+keyboard-configuration	keyboard-configuration/store_defaults_in_debconf_db	boolean	true
+# Country of origin for the keyboard:
+# Choices: 
+d-i	keyboard-configuration/layout	select	
+keyboard-configuration	keyboard-configuration/layout	select	
+# Time zone:
+# Choices: Casey, Davis, Dumont d'Urville, Macquarie, Mawson, McMurdo (South Pole), Palmer, Rothera, Syowa, Troll, Vostok
+tzdata	tzdata/Zones/Antarctica	select	
+# for internal use; can be preseeded
+man-db	man-db/auto-update	boolean	true
+# Time zone:
+# Choices: Abidjan, Accra, Addis Ababa, Algiers, Asmara, Bamako, Bangui, Banjul, Bissau, Blantyre, Brazzaville, Bujumbura, Cairo, Casablanca, Ceuta, Conakry, Dakar, Dar es Salaam, Djibouti, Douala, El-Aaiún, Freetown, Gaborone, Harare, Johannesburg, Juba, Kampala, Khartoum, Kigali, Kinshasa, Lagos, Libreville, Lome, Luanda, Lubumbashi, Lusaka, Malabo, Maputo, Maseru, Mbabane, Mogadishu, Monrovia, Nairobi, Ndjamena, Niamey, Nouakchott, Ouagadougou, Porto-Novo, Sao Tome, Timbuktu, Tripoli, Tunis, Windhoek
+tzdata	tzdata/Zones/Africa	select	
+# Encoding to use on the console:
+# Choices: ARMSCII-8, CP1251, CP1255, CP1256, GEORGIAN-ACADEMY, GEORGIAN-PS, IBM1133, ISIRI-3342, ISO-8859-1, ISO-8859-10, ISO-8859-11, ISO-8859-13, ISO-8859-14, ISO-8859-15, ISO-8859-16, ISO-8859-2, ISO-8859-3, ISO-8859-4, ISO-8859-5, ISO-8859-6, ISO-8859-7, ISO-8859-8, ISO-8859-9, KOI8-R, KOI8-U, TIS-620, UTF-8, VISCII
+console-setup	console-setup/charmap47	select	UTF-8
+# Should man and mandb be installed 'setuid man'?
+man-db	man-db/install-setuid	boolean	false
+# Delivery method for local mail:
+# Choices: mbox format in /var/mail/, Maildir format in home directory
+exim4-config	exim4/dc_localdelivery	select	mbox format in /var/mail/
+# Failure restarting some services for GNU libc upgrade
+libc6	glibc/restart-failed	error	
+libc6:amd64	glibc/restart-failed	error	
+# Choose software to install:
+# Choices: Debian desktop environment, ... GNOME, ... Xfce, ... KDE, ... Cinnamon, ... MATE, ... LXDE, web server, print server, SSH server, standard system utilities
+tasksel	tasksel/first	multiselect	ssh-server, standard
+# Time zone:
+# Choices: Aden, Almaty, Amman, Anadyr, Aqtau, Aqtobe, Ashgabat, Atyrau, Baghdad, Bahrain, Baku, Bangkok, Barnaul, Beirut, Bishkek, Brunei, Chita, Choibalsan, Chongqing, Colombo, Damascus, Dhaka, Dili, Dubai, Dushanbe, Famagusta, Gaza, Harbin, Hebron, Ho Chi Minh City, Hong Kong, Hovd, Irkutsk, Istanbul, Jakarta, Jayapura, Jerusalem, Kabul, Kamchatka, Karachi, Kashgar, Katmandu, Khandyga, Kolkata, Krasnoyarsk, Kuala Lumpur, Kuching, Kuwait, Macau, Magadan, Makassar, Manila, Muscat, Nicosia, Novokuznetsk, Novosibirsk, Omsk, Oral, Phnom Penh, Pontianak, Pyongyang, Qatar, Qostanay, Qyzylorda, Rangoon, Riyadh, Sakhalin, Samarkand, Seoul, Shanghai, Singapore, Srednekolymsk, Taipei, Tashkent, Tbilisi, Tehran, Tel Aviv, Thimphu, Tokyo, Tomsk, Ujung Pandang, Ulaanbaatar, Urumqi, Ust-Nera, Vientiane, Vladivostok, Yakutsk, Yangon, Yekaterinburg, Yerevan
+tzdata	tzdata/Zones/Asia	select	
+# Do you want to change the UID of user ?
+base-passwd	base-passwd/user-change-uid	boolean	true
+# Linux default command line:
+# Linux command line:
+# Services to restart to make them use the new libraries:
+libssl1.1	libssl1.1/restart-services	string	
+libssl1.1:amd64	libssl1.1/restart-services	string	
+# Font size:
+# Choices: 
+console-setup	console-setup/fontsize-text47	select	8x16
+# Font size:
+# Choices: 8x13, 8x14, 8x15, 8x16, 8x18
+console-setup	console-setup/fontsize-fb47	select	8x16
+# Other destinations for which mail is accepted:
+exim4-config	exim4/dc_other_hostnames	string	buendia
+# This can be preseeded to override the default desktop.
+# Choices: gnome, kde, xfce, lxde, cinnamon, mate, lxqt
+tasksel	tasksel/desktop	multiselect	
+# Use Control+Alt+Backspace to terminate the X server?
+d-i	keyboard-configuration/ctrl_alt_bksp	boolean	false
+keyboard-configuration	keyboard-configuration/ctrl_alt_bksp	boolean	false
+# What do you want to do about modified configuration file ?
+# Choices: install the package maintainer's version, keep the local version currently installed, show the differences between the versions, show a side-by-side difference between the versions, start a new shell to examine the situation
+ucf	ucf/changeprompt	select	keep_current
+# Keep number of DNS-queries minimal (Dial-on-Demand)?
+exim4-config	exim4/dc_minimaldns	boolean	false
+# Remove obsolete /etc/dictionary link?
+dictionaries-common	dictionaries-common/old_wordlist_link	boolean	true
+# Remove undelivered messages in spool directory?
+exim4-base	exim4/purge_spool	boolean	false
+# Keep current keyboard options in the configuration file?
+d-i	keyboard-configuration/unsupported_config_options	boolean	true
+keyboard-configuration	keyboard-configuration/unsupported_config_options	boolean	true
+# Time zone:
+# Choices: Longyearbyen
+tzdata	tzdata/Zones/Arctic	select	
+# Reconfigure exim4-config instead of this package
+exim4-daemon-light	exim4-daemon-light/drec	error	
+# Choose software to install:
+# Choices: 
+tasksel	tasksel/tasks	multiselect	
+# Do you want to add the group ?
+base-passwd	base-passwd/group-add	boolean	true
+# Incompatible PAM profiles selected.
+libpam-runtime	libpam-runtime/conflicts	error	
+# Certificates to activate:
+# Choices: mozilla/ACCVRAIZ1.crt, mozilla/AC_Raíz_Certicámara_S.A..crt, mozilla/AC_RAIZ_FNMT-RCM.crt, mozilla/Actalis_Authentication_Root_CA.crt, mozilla/AddTrust_External_Root.crt, mozilla/AddTrust_Low-Value_Services_Root.crt, mozilla/AffirmTrust_Commercial.crt, mozilla/AffirmTrust_Networking.crt, mozilla/AffirmTrust_Premium.crt, mozilla/AffirmTrust_Premium_ECC.crt, mozilla/Amazon_Root_CA_1.crt, mozilla/Amazon_Root_CA_2.crt, mozilla/Amazon_Root_CA_3.crt, mozilla/Amazon_Root_CA_4.crt, mozilla/Atos_TrustedRoot_2011.crt, mozilla/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.crt, mozilla/Baltimore_CyberTrust_Root.crt, mozilla/Buypass_Class_2_Root_CA.crt, mozilla/Buypass_Class_3_Root_CA.crt, mozilla/CA_Disig_Root_R2.crt, mozilla/Camerfirma_Chambers_of_Commerce_Root.crt, mozilla/Camerfirma_Global_Chambersign_Root.crt, mozilla/Certigna.crt, mozilla/Certinomis_-_Root_CA.crt, mozilla/Certplus_Class_2_Primary_CA.crt, mozilla/Certplus_Root_CA_G1.crt, mozilla/Certplus_Root_CA_G2.crt, mozilla/certSIGN_ROOT_CA.crt, mozilla/Certum_Root_CA.crt, mozilla/Certum_Trusted_Network_CA_2.crt, mozilla/Certum_Trusted_Network_CA.crt, mozilla/CFCA_EV_ROOT.crt, mozilla/Chambers_of_Commerce_Root_-_2008.crt, mozilla/Comodo_AAA_Services_root.crt, mozilla/COMODO_Certification_Authority.crt, mozilla/COMODO_ECC_Certification_Authority.crt, mozilla/COMODO_RSA_Certification_Authority.crt, mozilla/ComSign_CA.crt, mozilla/Cybertrust_Global_Root.crt, mozilla/Deutsche_Telekom_Root_CA_2.crt, mozilla/DigiCert_Assured_ID_Root_CA.crt, mozilla/DigiCert_Assured_ID_Root_G2.crt, mozilla/DigiCert_Assured_ID_Root_G3.crt, mozilla/DigiCert_Global_Root_CA.crt, mozilla/DigiCert_Global_Root_G2.crt, mozilla/DigiCert_Global_Root_G3.crt, mozilla/DigiCert_High_Assurance_EV_Root_CA.crt, mozilla/DigiCert_Trusted_Root_G4.crt, mozilla/DST_Root_CA_X3.crt, mozilla/D-TRUST_Root_CA_3_2013.crt, mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt, mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt, mozilla/EC-ACC.crt, mozilla/EE_Certification_Centre_Root_CA.crt, mozilla/Entrust.net_Premium_2048_Secure_Server_CA.crt, mozilla/Entrust_Root_Certification_Authority.crt, mozilla/Entrust_Root_Certification_Authority_-_EC1.crt, mozilla/Entrust_Root_Certification_Authority_-_G2.crt, mozilla/ePKI_Root_Certification_Authority.crt, mozilla/E-Tugra_Certification_Authority.crt, mozilla/GDCA_TrustAUTH_R5_ROOT.crt, mozilla/GeoTrust_Global_CA.crt, mozilla/GeoTrust_Primary_Certification_Authority.crt, mozilla/GeoTrust_Primary_Certification_Authority_-_G2.crt, mozilla/GeoTrust_Primary_Certification_Authority_-_G3.crt, mozilla/GeoTrust_Universal_CA_2.crt, mozilla/GeoTrust_Universal_CA.crt, mozilla/Global_Chambersign_Root_-_2008.crt, mozilla/GlobalSign_ECC_Root_CA_-_R4.crt, mozilla/GlobalSign_ECC_Root_CA_-_R5.crt, mozilla/GlobalSign_Root_CA.crt, mozilla/GlobalSign_Root_CA_-_R2.crt, mozilla/GlobalSign_Root_CA_-_R3.crt, mozilla/Go_Daddy_Class_2_CA.crt, mozilla/Go_Daddy_Root_Certificate_Authority_-_G2.crt, mozilla/Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.crt, mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2011.crt, mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2015.crt, mozilla/Hongkong_Post_Root_CA_1.crt, mozilla/IdenTrust_Commercial_Root_CA_1.crt, mozilla/IdenTrust_Public_Sector_Root_CA_1.crt, mozilla/ISRG_Root_X1.crt, mozilla/Izenpe.com.crt, mozilla/LuxTrust_Global_Root_2.crt, mozilla/Microsec_e-Szigno_Root_CA_2009.crt, mozilla/NetLock_Arany_=Class_Gold=_Főtanúsítvány.crt, mozilla/Network_Solutions_Certificate_Authority.crt, mozilla/OISTE_WISeKey_Global_Root_GA_CA.crt, mozilla/OISTE_WISeKey_Global_Root_GB_CA.crt, mozilla/OpenTrust_Root_CA_G1.crt, mozilla/OpenTrust_Root_CA_G2.crt, mozilla/OpenTrust_Root_CA_G3.crt, mozilla/QuoVadis_Root_CA_1_G3.crt, mozilla/QuoVadis_Root_CA_2.crt, mozilla/QuoVadis_Root_CA_2_G3.crt, mozilla/QuoVadis_Root_CA_3.crt, mozilla/QuoVadis_Root_CA_3_G3.crt, mozilla/QuoVadis_Root_CA.crt, mozilla/Secure_Global_CA.crt, mozilla/SecureSign_RootCA11.crt, mozilla/SecureTrust_CA.crt, mozilla/Security_Communication_RootCA2.crt, mozilla/Security_Communication_Root_CA.crt, mozilla/Sonera_Class_2_Root_CA.crt, mozilla/SSL.com_EV_Root_Certification_Authority_ECC.crt, mozilla/SSL.com_EV_Root_Certification_Authority_RSA_R2.crt, mozilla/SSL.com_Root_Certification_Authority_ECC.crt, mozilla/SSL.com_Root_Certification_Authority_RSA.crt, mozilla/Staat_der_Nederlanden_EV_Root_CA.crt, mozilla/Staat_der_Nederlanden_Root_CA_-_G2.crt, mozilla/Staat_der_Nederlanden_Root_CA_-_G3.crt, mozilla/Starfield_Class_2_CA.crt, mozilla/Starfield_Root_Certificate_Authority_-_G2.crt, mozilla/Starfield_Services_Root_Certificate_Authority_-_G2.crt, mozilla/S-TRUST_Universal_Root_CA.crt, mozilla/Swisscom_Root_CA_2.crt, mozilla/SwissSign_Gold_CA_-_G2.crt, mozilla/SwissSign_Platinum_CA_-_G2.crt, mozilla/SwissSign_Silver_CA_-_G2.crt, mozilla/Symantec_Class_1_Public_Primary_Certification_Authority_-_G4.crt, mozilla/Symantec_Class_1_Public_Primary_Certification_Authority_-_G6.crt, mozilla/Symantec_Class_2_Public_Primary_Certification_Authority_-_G4.crt, mozilla/Symantec_Class_2_Public_Primary_Certification_Authority_-_G6.crt, mozilla/SZAFIR_ROOT_CA2.crt, mozilla/Taiwan_GRCA.crt, mozilla/TC_TrustCenter_Class_3_CA_II.crt, mozilla/TeliaSonera_Root_CA_v1.crt, mozilla/thawte_Primary_Root_CA.crt, mozilla/thawte_Primary_Root_CA_-_G2.crt, mozilla/thawte_Primary_Root_CA_-_G3.crt, mozilla/TrustCor_ECA-1.crt, mozilla/TrustCor_RootCert_CA-1.crt, mozilla/TrustCor_RootCert_CA-2.crt, mozilla/Trustis_FPS_Root_CA.crt, mozilla/T-TeleSec_GlobalRoot_Class_2.crt, mozilla/T-TeleSec_GlobalRoot_Class_3.crt, mozilla/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.crt, mozilla/TÜRKTRUST_Elektronik_Sertifika_Hizmet_Sağlayıcısı_H5.crt, mozilla/TWCA_Global_Root_CA.crt, mozilla/TWCA_Root_Certification_Authority.crt, mozilla/USERTrust_ECC_Certification_Authority.crt, mozilla/USERTrust_RSA_Certification_Authority.crt, mozilla/UTN_USERFirst_Email_Root_CA.crt, mozilla/Verisign_Class_1_Public_Primary_Certification_Authority_-_G3.crt, mozilla/Verisign_Class_2_Public_Primary_Certification_Authority_-_G3.crt, mozilla/Verisign_Class_3_Public_Primary_Certification_Authority_-_G3.crt, mozilla/VeriSign_Class_3_Public_Primary_Certification_Authority_-_G4.crt, mozilla/VeriSign_Class_3_Public_Primary_Certification_Authority_-_G5.crt, mozilla/VeriSign_Universal_Root_Certification_Authority.crt, mozilla/Visa_eCommerce_Root.crt, mozilla/XRamp_Global_CA_Root.crt
+ca-certificates	ca-certificates/enable_crts	multiselect	mozilla/ACCVRAIZ1.crt, mozilla/AC_Raíz_Certicámara_S.A..crt, mozilla/AC_RAIZ_FNMT-RCM.crt, mozilla/Actalis_Authentication_Root_CA.crt, mozilla/AddTrust_External_Root.crt, mozilla/AddTrust_Low-Value_Services_Root.crt, mozilla/AffirmTrust_Commercial.crt, mozilla/AffirmTrust_Networking.crt, mozilla/AffirmTrust_Premium.crt, mozilla/AffirmTrust_Premium_ECC.crt, mozilla/Amazon_Root_CA_1.crt, mozilla/Amazon_Root_CA_2.crt, mozilla/Amazon_Root_CA_3.crt, mozilla/Amazon_Root_CA_4.crt, mozilla/Atos_TrustedRoot_2011.crt, mozilla/Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.crt, mozilla/Baltimore_CyberTrust_Root.crt, mozilla/Buypass_Class_2_Root_CA.crt, mozilla/Buypass_Class_3_Root_CA.crt, mozilla/CA_Disig_Root_R2.crt, mozilla/Camerfirma_Chambers_of_Commerce_Root.crt, mozilla/Camerfirma_Global_Chambersign_Root.crt, mozilla/Certigna.crt, mozilla/Certinomis_-_Root_CA.crt, mozilla/Certplus_Class_2_Primary_CA.crt, mozilla/Certplus_Root_CA_G1.crt, mozilla/Certplus_Root_CA_G2.crt, mozilla/certSIGN_ROOT_CA.crt, mozilla/Certum_Root_CA.crt, mozilla/Certum_Trusted_Network_CA_2.crt, mozilla/Certum_Trusted_Network_CA.crt, mozilla/CFCA_EV_ROOT.crt, mozilla/Chambers_of_Commerce_Root_-_2008.crt, mozilla/Comodo_AAA_Services_root.crt, mozilla/COMODO_Certification_Authority.crt, mozilla/COMODO_ECC_Certification_Authority.crt, mozilla/COMODO_RSA_Certification_Authority.crt, mozilla/ComSign_CA.crt, mozilla/Cybertrust_Global_Root.crt, mozilla/Deutsche_Telekom_Root_CA_2.crt, mozilla/DigiCert_Assured_ID_Root_CA.crt, mozilla/DigiCert_Assured_ID_Root_G2.crt, mozilla/DigiCert_Assured_ID_Root_G3.crt, mozilla/DigiCert_Global_Root_CA.crt, mozilla/DigiCert_Global_Root_G2.crt, mozilla/DigiCert_Global_Root_G3.crt, mozilla/DigiCert_High_Assurance_EV_Root_CA.crt, mozilla/DigiCert_Trusted_Root_G4.crt, mozilla/DST_Root_CA_X3.crt, mozilla/D-TRUST_Root_CA_3_2013.crt, mozilla/D-TRUST_Root_Class_3_CA_2_2009.crt, mozilla/D-TRUST_Root_Class_3_CA_2_EV_2009.crt, mozilla/EC-ACC.crt, mozilla/EE_Certification_Centre_Root_CA.crt, mozilla/Entrust.net_Premium_2048_Secure_Server_CA.crt, mozilla/Entrust_Root_Certification_Authority.crt, mozilla/Entrust_Root_Certification_Authority_-_EC1.crt, mozilla/Entrust_Root_Certification_Authority_-_G2.crt, mozilla/ePKI_Root_Certification_Authority.crt, mozilla/E-Tugra_Certification_Authority.crt, mozilla/GDCA_TrustAUTH_R5_ROOT.crt, mozilla/GeoTrust_Global_CA.crt, mozilla/GeoTrust_Primary_Certification_Authority.crt, mozilla/GeoTrust_Primary_Certification_Authority_-_G2.crt, mozilla/GeoTrust_Primary_Certification_Authority_-_G3.crt, mozilla/GeoTrust_Universal_CA_2.crt, mozilla/GeoTrust_Universal_CA.crt, mozilla/Global_Chambersign_Root_-_2008.crt, mozilla/GlobalSign_ECC_Root_CA_-_R4.crt, mozilla/GlobalSign_ECC_Root_CA_-_R5.crt, mozilla/GlobalSign_Root_CA.crt, mozilla/GlobalSign_Root_CA_-_R2.crt, mozilla/GlobalSign_Root_CA_-_R3.crt, mozilla/Go_Daddy_Class_2_CA.crt, mozilla/Go_Daddy_Root_Certificate_Authority_-_G2.crt, mozilla/Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.crt, mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2011.crt, mozilla/Hellenic_Academic_and_Research_Institutions_RootCA_2015.crt, mozilla/Hongkong_Post_Root_CA_1.crt, mozilla/IdenTrust_Commercial_Root_CA_1.crt, mozilla/IdenTrust_Public_Sector_Root_CA_1.crt, mozilla/ISRG_Root_X1.crt, mozilla/Izenpe.com.crt, mozilla/LuxTrust_Global_Root_2.crt, mozilla/Microsec_e-Szigno_Root_CA_2009.crt, mozilla/NetLock_Arany_=Class_Gold=_Főtanúsítvány.crt, mozilla/Network_Solutions_Certificate_Authority.crt, mozilla/OISTE_WISeKey_Global_Root_GA_CA.crt, mozilla/OISTE_WISeKey_Global_Root_GB_CA.crt, mozilla/OpenTrust_Root_CA_G1.crt, mozilla/OpenTrust_Root_CA_G2.crt, mozilla/OpenTrust_Root_CA_G3.crt, mozilla/QuoVadis_Root_CA_1_G3.crt, mozilla/QuoVadis_Root_CA_2.crt, mozilla/QuoVadis_Root_CA_2_G3.crt, mozilla/QuoVadis_Root_CA_3.crt, mozilla/QuoVadis_Root_CA_3_G3.crt, mozilla/QuoVadis_Root_CA.crt, mozilla/Secure_Global_CA.crt, mozilla/SecureSign_RootCA11.crt, mozilla/SecureTrust_CA.crt, mozilla/Security_Communication_RootCA2.crt, mozilla/Security_Communication_Root_CA.crt, mozilla/Sonera_Class_2_Root_CA.crt, mozilla/SSL.com_EV_Root_Certification_Authority_ECC.crt, mozilla/SSL.com_EV_Root_Certification_Authority_RSA_R2.crt, mozilla/SSL.com_Root_Certification_Authority_ECC.crt, mozilla/SSL.com_Root_Certification_Authority_RSA.crt, mozilla/Staat_der_Nederlanden_EV_Root_CA.crt, mozilla/Staat_der_Nederlanden_Root_CA_-_G2.crt, mozilla/Staat_der_Nederlanden_Root_CA_-_G3.crt, mozilla/Starfield_Class_2_CA.crt, mozilla/Starfield_Root_Certificate_Authority_-_G2.crt, mozilla/Starfield_Services_Root_Certificate_Authority_-_G2.crt, mozilla/S-TRUST_Universal_Root_CA.crt, mozilla/Swisscom_Root_CA_2.crt, mozilla/SwissSign_Gold_CA_-_G2.crt, mozilla/SwissSign_Platinum_CA_-_G2.crt, mozilla/SwissSign_Silver_CA_-_G2.crt, mozilla/Symantec_Class_1_Public_Primary_Certification_Authority_-_G4.crt, mozilla/Symantec_Class_1_Public_Primary_Certification_Authority_-_G6.crt, mozilla/Symantec_Class_2_Public_Primary_Certification_Authority_-_G4.crt, mozilla/Symantec_Class_2_Public_Primary_Certification_Authority_-_G6.crt, mozilla/SZAFIR_ROOT_CA2.crt, mozilla/Taiwan_GRCA.crt, mozilla/TC_TrustCenter_Class_3_CA_II.crt, mozilla/TeliaSonera_Root_CA_v1.crt, mozilla/thawte_Primary_Root_CA.crt, mozilla/thawte_Primary_Root_CA_-_G2.crt, mozilla/thawte_Primary_Root_CA_-_G3.crt, mozilla/TrustCor_ECA-1.crt, mozilla/TrustCor_RootCert_CA-1.crt, mozilla/TrustCor_RootCert_CA-2.crt, mozilla/Trustis_FPS_Root_CA.crt, mozilla/T-TeleSec_GlobalRoot_Class_2.crt, mozilla/T-TeleSec_GlobalRoot_Class_3.crt, mozilla/TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.crt, mozilla/TÜRKTRUST_Elektronik_Sertifika_Hizmet_Sağlayıcısı_H5.crt, mozilla/TWCA_Global_Root_CA.crt, mozilla/TWCA_Root_Certification_Authority.crt, mozilla/USERTrust_ECC_Certification_Authority.crt, mozilla/USERTrust_RSA_Certification_Authority.crt, mozilla/UTN_USERFirst_Email_Root_CA.crt, mozilla/Verisign_Class_1_Public_Primary_Certification_Authority_-_G3.crt, mozilla/Verisign_Class_2_Public_Primary_Certification_Authority_-_G3.crt, mozilla/Verisign_Class_3_Public_Primary_Certification_Authority_-_G3.crt, mozilla/VeriSign_Class_3_Public_Primary_Certification_Authority_-_G4.crt, mozilla/VeriSign_Class_3_Public_Primary_Certification_Authority_-_G5.crt, mozilla/VeriSign_Universal_Root_Certification_Authority.crt, mozilla/Visa_eCommerce_Root.crt, mozilla/XRamp_Global_CA_Root.crt
+# for internal use
+d-i	keyboard-configuration/modelcode	string	pc105
+keyboard-configuration	keyboard-configuration/modelcode	string	pc105
+# Services to restart for GNU libc library upgrade:
+libc6	glibc/restart-services	string	
+libc6:amd64	glibc/restart-services	string	
+# Keyboard model:
+# Choices: A4Tech KB-21, A4Tech KBS-8, A4Tech Wireless Desktop RFKB-23, Acer AirKey V, Acer C300, Acer Ferrari 4000, Acer Laptop, Advance Scorpius KI, Amiga, Apple, Apple Aluminium Keyboard (ANSI), Apple Aluminium Keyboard (ISO), Apple Aluminium Keyboard (JIS), Apple Laptop, Asus Laptop, Atari TT, Azona RF2300 wireless Internet Keyboard, BenQ X-Touch, BenQ X-Touch 730, BenQ X-Touch 800, Brother Internet Keyboard, BTC 5090, BTC 5113RF Multimedia, BTC 5126T, BTC 6301URF, BTC 9000, BTC 9000A, BTC 9001AH, BTC 9019U, BTC 9116U Mini Wireless Internet and Gaming, Cherry Blue Line CyBo@rd, Cherry Blue Line CyBo@rd (alternate option), Cherry B.UNLIMITED, Cherry CyBo@rd USB-Hub, Cherry CyMotion Expert, Cherry CyMotion Master Linux, Cherry CyMotion Master XPress, Chicony Internet Keyboard, Chicony KB-9885, Chicony KU-0108, Chicony KU-0420, Classmate PC, Compaq Easy Access Keyboard, Compaq Internet Keyboard (13 keys), Compaq Internet Keyboard (18 keys), Compaq Internet Keyboard (7 keys), Compaq iPaq Keyboard, Creative Desktop Wireless 7000, Dell, Dell 101-key PC, Dell Laptop/notebook Inspiron 6xxx/8xxx, Dell Laptop/notebook Precision M series, Dell Latitude series laptop, Dell Precision M65, Dell SK-8125, Dell SK-8135, Dell USB Multimedia Keyboard, Dexxa Wireless Desktop Keyboard, Diamond 9801 / 9802 series, DTK2000, Ennyah DKB-1008, Everex STEPnote, FL90, Fujitsu-Siemens Computers AMILO laptop, Generic 101-key PC, Generic 102-key (Intl) PC, Generic 104-key PC, Generic 105-key (Intl) PC, Genius Comfy KB-12e, Genius Comfy KB-16M / Genius MM Keyboard KWD-910, Genius Comfy KB-21e-Scroll, Genius KB-19e NB, Genius KKB-2050HS, Gyration, Happy Hacking Keyboard, Happy Hacking Keyboard for Mac, Hewlett-Packard Internet Keyboard, Hewlett-Packard Mini 110 Notebook, Hewlett-Packard nx9020, Hewlett-Packard Omnibook 500 FA, Hewlett-Packard Omnibook 5xx, Hewlett-Packard Omnibook 6000/6100, Hewlett-Packard Omnibook XE3 GC, Hewlett-Packard Omnibook XE3 GF, Hewlett-Packard Omnibook XT1000, Hewlett-Packard Pavilion dv5, Hewlett-Packard Pavilion ZT11xx, Hewlett-Packard SK-250x Multimedia Keyboard, Honeywell Euroboard, HTC Dream, Htc Dream phone, IBM Rapid Access, IBM Rapid Access II, IBM Space Saver, IBM ThinkPad 560Z/600/600E/A22E, IBM ThinkPad R60/T60/R61/T61, IBM ThinkPad Z60m/Z60t/Z61m/Z61t, Keytronic FlexPro, Kinesis, Laptop/notebook Compaq (eg. Armada) Laptop Keyboard, Laptop/notebook Compaq (eg. Presario) Internet Keyboard, Laptop/notebook eMachines m68xx, Logitech Access Keyboard, Logitech Cordless Desktop, Logitech Cordless Desktop (alternate option), Logitech Cordless Desktop EX110, Logitech Cordless Desktop iTouch, Logitech Cordless Desktop LX-300, Logitech Cordless Desktop Navigator, Logitech Cordless Desktop Optical, Logitech Cordless Desktop Pro (alternate option 2), Logitech Cordless Freedom/Desktop Navigator, Logitech diNovo Edge Keyboard, Logitech diNovo Keyboard, Logitech G15 extra keys via G15daemon, Logitech Generic Keyboard, Logitech Internet 350 Keyboard, Logitech Internet Keyboard, Logitech Internet Navigator Keyboard, Logitech iTouch, Logitech iTouch Cordless Keyboard (model Y-RB6), Logitech iTouch Internet Navigator Keyboard SE, Logitech iTouch Internet Navigator Keyboard SE (USB), Logitech Media Elite Keyboard, Logitech Ultra-X Cordless Media Desktop Keyboard, Logitech Ultra-X Keyboard, MacBook/MacBook Pro, MacBook/MacBook Pro (Intl), Macintosh, Macintosh Old, Memorex MX1998, Memorex MX2500 EZ-Access Keyboard, Memorex MX2750, Microsoft Comfort Curve Keyboard 2000, Microsoft Internet Keyboard, Microsoft Internet Keyboard Pro\, Swedish, Microsoft Natural, Microsoft Natural Ergonomic Keyboard 4000, Microsoft Natural Keyboard Elite, Microsoft Natural Keyboard Pro OEM, Microsoft Natural Keyboard Pro / Microsoft Internet Keyboard Pro, Microsoft Natural Keyboard Pro USB / Microsoft Internet Keyboard Pro, Microsoft Natural Wireless Ergonomic Keyboard 7000, Microsoft Office Keyboard, Microsoft Wireless Multimedia Keyboard 1.0A, Northgate OmniKey 101, OLPC, Ortek MCK-800 MM/Internet keyboard, PC-98xx Series, Propeller Voyager (KTEZ-1000), QTronix Scorpius 98N+, Samsung SDM 4500P, Samsung SDM 4510P, Sanwa Supply SKB-KG3, SILVERCREST Multimedia Wireless Keyboard, SK-1300, SK-2500, SK-6200, SK-7100, Sun Type 4, Sun Type 5, Sun Type 6 (Japanese layout), Sun Type 6/7 USB, Sun Type 6/7 USB (European layout), Sun Type 6 USB (Japanese layout), Sun Type 6 USB (Unix layout), Sun Type 7 USB, Sun Type 7 USB (European layout), Sun Type 7 USB (Japanese layout) / Japanese 106-key, Sun Type 7 USB (Unix layout), Super Power Multimedia Keyboard, SVEN Ergonomic 2500, SVEN Slim 303, Symplon PaceBook (tablet PC), Targa Visionary 811, Toshiba Satellite S3000, Truly Ergonomic Computer Keyboard Model 227 (Wide Alt keys), Truly Ergonomic Computer Keyboard Model 229 (Standard sized Alt keys\, additional Super and Menu key), Trust Direct Access Keyboard, Trust Slimline, Trust Wireless Keyboard Classic, TypeMatrix EZ-Reach 2020, TypeMatrix EZ-Reach 2030 PS2, TypeMatrix EZ-Reach 2030 USB, TypeMatrix EZ-Reach 2030 USB (102/105:EU mode), TypeMatrix EZ-Reach 2030 USB (106:JP mode), Unitek KB-1925, ViewSonic KU-306 Internet Keyboard, Winbook Model XP5, Yahoo! Internet Keyboard
+d-i	keyboard-configuration/model	select	Generic 105-key (Intl) PC
+keyboard-configuration	keyboard-configuration/model	select	Generic 105-key (Intl) PC
+# Kernel must be upgraded
+libc6	glibc/kernel-too-old	error	
+libc6:amd64	glibc/kernel-too-old	error	
+# Reconfigure exim4-config instead of this package
+exim4	exim4/drec	error	
+# What do you want to do about modified configuration file ?
+# Choices: install the package maintainer's version, keep the local version currently installed, show the differences between the versions, show a side-by-side difference between the versions, show a 3-way difference between available versions, do a 3-way merge between available versions (experimental), start a new shell to examine the situation
+ucf	ucf/changeprompt_threeway	select	keep_current
+# General type of mail configuration:
+# Choices: internet site; mail is sent and received directly using SMTP, mail sent by smarthost; received via SMTP or fetchmail, mail sent by smarthost; no local mail, local delivery only; not on a network, no configuration at this time
+exim4-config	exim4/dc_eximconfig_configtype	select	local delivery only; not on a network
+# xscreensaver and xlockmore must be restarted before upgrading
+libc6	glibc/disable-screensaver	error	
+libc6:amd64	glibc/disable-screensaver	error	
+# Font for the console:
+# Choices: Fixed, Terminus, TerminusBold, TerminusBoldVGA, VGA, Do not change the boot/kernel font, Let the system select a suitable font
+console-setup	console-setup/fontface47	select	Fixed
+# Time zone:
+# Choices: Azores, Bermuda, Canary, Cape Verde, Faroe, Jan Mayen, Madeira, Reykjavik, South Georgia, St. Helena, Stanley
+tzdata	tzdata/Zones/Atlantic	select	
+# Keymap to use:
+# Choices: American English, Albanian, Arabic, Asturian, Bangladesh, Belarusian, Bengali, Belgian, Bosnian, Brazilian, British English, Bulgarian (BDS layout), Bulgarian (phonetic layout), Burmese, Canadian French, Canadian Multilingual, Catalan, Chinese, Croatian, Czech, Danish, Dutch, Dvorak, Dzongkha, Esperanto, Estonian, Ethiopian, Finnish, French, Georgian, German, Greek, Gujarati, Gurmukhi, Hebrew, Hindi, Hungarian, Icelandic, Irish, Italian, Japanese, Kannada, Kazakh, Khmer, Kirghiz, Korean, Kurdish (F layout), Kurdish (Q layout), Lao, Latin American, Latvian, Lithuanian, Macedonian, Malayalam, Nepali, Northern Sami, Norwegian, Persian, Philippines, Polish, Portuguese, Punjabi, Romanian, Russian, Serbian (Cyrillic), Sindhi, Sinhala, Slovak, Slovenian, Spanish, Swedish, Swiss French, Swiss German, Tajik, Tamil, Telugu, Thai, Tibetan, Turkish (F layout), Turkish (Q layout), Ukrainian, Uyghur, Vietnamese
+d-i	keyboard-configuration/xkb-keymap	select	us
+keyboard-configuration	keyboard-configuration/xkb-keymap	select	us
+# Services to restart to make them use the new libraries:
+libssl1.0.2	libssl1.0.2/restart-services	string	
+libssl1.0.2:amd64	libssl1.0.2/restart-services	string	
+# Prompt for confirmation after displaying changes?
+apt-listchanges	apt-listchanges/confirm	boolean	false
+# Keep default keyboard options ()?
+d-i	keyboard-configuration/unsupported_options	boolean	true
+keyboard-configuration	keyboard-configuration/unsupported_options	boolean	true
+# PAM profiles to enable:
+# Choices: Unix authentication, Register user sessions in the systemd control group hierarchy
+libpam-runtime	libpam-runtime/profiles	multiselect	unix, systemd
+# Time zone:
+# Choices: GMT, GMT+0, GMT+1, GMT+10, GMT+11, GMT+12, GMT+2, GMT+3, GMT+4, GMT+5, GMT+6, GMT+7, GMT+8, GMT+9, GMT-0, GMT-1, GMT-10, GMT-11, GMT-12, GMT-13, GMT-14, GMT-2, GMT-3, GMT-4, GMT-5, GMT-6, GMT-7, GMT-8, GMT-9, GMT0, Greenwich, UCT, UTC, Universal, Zulu
+tzdata	tzdata/Zones/Etc	select	UTC
+# System default wordlist:
+# Choices: american (American English), Manual symlink setting
+dictionaries-common	dictionaries-common/default-wordlist	select	american (American English)
+# Character set to support:
+# Choices: . Arabic, # Armenian, # Cyrillic - KOI8-R and KOI8-U, # Cyrillic - non-Slavic languages, # Cyrillic - Slavic languages (also Bosnian and Serbian Latin), . Ethiopic, # Georgian, # Greek, # Hebrew, # Lao, # Latin1 and Latin5 - western Europe and Turkic languages, # Latin2 - central Europe and Romanian, # Latin3 and Latin8 - Chichewa; Esperanto; Irish; Maltese and Welsh, # Latin7 - Lithuanian; Latvian; Maori and Marshallese, . Latin - Vietnamese, # Thai, . Combined - Latin; Slavic Cyrillic; Hebrew; basic Arabic, . Combined - Latin; Slavic Cyrillic; Greek, . Combined - Latin; Slavic and non-Slavic Cyrillic, Guess optimal character set
+console-setup	console-setup/codeset47	select	# Latin1 and Latin5 - western Europe and Turkic languages
+# for internal use only
+d-i	debian-installer/language	string	en
+# Failure restarting some services for OpenSSL upgrade
+libssl1.1	libssl1.1/restart-failed	error	
+libssl1.1:amd64	libssl1.1/restart-failed	error	
+# Hide local mail name in outgoing mail?
+exim4-config	exim4/hide_mailname	boolean	
+# Do you want to remove the group ?
+base-passwd	base-passwd/group-remove	boolean	true
+# System mail name:
+exim4-config	exim4/mailname	string	buendia
+# Conflicts found in three-way merge
+ucf	ucf/conflicts_found	error	
+# Method for toggling between national and Latin mode:
+# Choices: Caps Lock, Right Alt (AltGr), Right Control, Right Shift, Right Logo key, Menu key, Alt+Shift, Control+Shift, Control+Alt, Alt+Caps Lock, Left Control+Left Shift, Left Alt, Left Control, Left Shift, Left Logo key, Scroll Lock key, No toggling
+d-i	keyboard-configuration/toggle	select	No toggling
+keyboard-configuration	keyboard-configuration/toggle	select	No toggling
+# Packages to install:
+# Choices: 
+discover	discover/install_hw_packages	multiselect	
+# Time zone:
+# Choices: AST4, AST4ADT, CST6, CST6CDT, EST5, EST5EDT, HST10, MST7, MST7MDT, PST8, PST8PDT, YST9, YST9YDT
+tzdata	tzdata/Zones/SystemV	select	
+# Domains to relay mail for:
+exim4-config	exim4/dc_relay_domains	string	
+# Do you want to change the home directory of user ?
+base-passwd	base-passwd/user-change-home	boolean	true
+# System default ispell dictionary:
+# Choices: american (American English), british (British English), Manual symlink setting
+dictionaries-common	dictionaries-common/default-ispell	select	american (American English)
+# Services to restart for PAM library upgrade:
+libpam0g:amd64	libpam0g/restart-services	string	
+# Line by line differences between versions
+ucf	ucf/show_diff	note	
+# IP address or host name of the outgoing smarthost:
+exim4-config	exim4/dc_smarthost	string	
+# Method to be used to display changes:
+# Choices: pager, browser, xterm-pager, xterm-browser, gtk, text, mail, none
+apt-listchanges	apt-listchanges/frontend	select	pager
+# Ignore questions with a priority less than:
+# Choices: critical, high, medium, low
+debconf	debconf/priority	select	high
+# Use dash as the default system shell (/bin/sh)?
+dash	dash/sh	boolean	true
+# for internal use; can be preseeded
+d-i	debian-installer/country	string	US
+# Restart services during package upgrades without asking?
+libc6	libraries/restart-without-asking	boolean	false
+libc6:amd64	libraries/restart-without-asking	boolean	false
+libpam0g:amd64	libraries/restart-without-asking	boolean	false
+# Time zone:
+# Choices: Antananarivo, Chagos, Christmas, Cocos, Comoro, Kerguelen, Mahe, Maldives, Mauritius, Mayotte, Reunion
+tzdata	tzdata/Zones/Indian	select	
+# Display manager must be restarted manually
+libpam0g:amd64	libpam0g/xdm-needs-restart	error	
+# Do you want system-wide readable home directories?
+adduser	adduser/homedir-permission	boolean	true
+# for internal use
+console-setup	console-setup/fontsize	string	8x16
+# Do you want to move the user ?
+base-passwd	base-passwd/user-move	boolean	true
+# Force extra installation to the EFI removable media path?
+# No PAM profiles have been selected.
+libpam-runtime	libpam-runtime/no_profiles_chosen	error	
+# Do you want to upgrade glibc now?
+libc6	glibc/upgrade	boolean	true
+libc6:amd64	glibc/upgrade	boolean	true
+# Split configuration into small files?
+exim4-config	exim4/use_split_config	boolean	false
+# Keyboard layout:
+# Choices: English (US), English (US) - Cherokee, English (US) - English (classic Dvorak), English (US) - English (Colemak), English (US) - English (Dvorak), English (US) - English (Dvorak alternative international no dead keys), English (US) - English (Dvorak\, international with dead keys), English (US) - English (international AltGr dead keys), English (US) - English (left handed Dvorak), English (US) - English (Macintosh), English (US) - English (Programmer Dvorak), English (US) - English (right handed Dvorak), English (US) - English (the divide/multiply keys toggle the layout), English (US) - English (US\, alternative international), English (US) - English (US\, international with dead keys), English (US) - English (US\, with euro on 5), English (US) - English (Workman), English (US) - English (Workman\, international with dead keys), English (US) - Russian (US\, phonetic), English (US) - Serbo-Croatian (US), Other
+d-i	keyboard-configuration/variant	select	English (US)
+keyboard-configuration	keyboard-configuration/variant	select	English (US)
+# Do you want to change the GID of user ?
+base-passwd	base-passwd/user-change-gid	boolean	true
+# New certificates to activate:
+# Choices: 
+ca-certificates	ca-certificates/new_crts	multiselect	
+# E-mail address(es) which will receive changes:
+apt-listchanges	apt-listchanges/email-address	string	root
+# Geographic area:
+# Choices: Africa, America, Antarctica, Australia, Arctic Ocean, Asia, Atlantic Ocean, Europe, Indian Ocean, Pacific Ocean, System V timezones, US, None of the above
+tzdata	tzdata/Areas	select	Etc
+d-i passwd/root-password-crypted password $6$R/Jihdz0q$f2uQ7btizMXbhLhrVoqZRP17S.aHCpybPTh6wgDB1/3ShAbolz8833IFZBvm5yYvfr6XepS/3xXdVBxiKsKkT0
+d-i passwd/user-password-crypted password $6$R/Jihdz0q$f2uQ7btizMXbhLhrVoqZRP17S.aHCpybPTh6wgDB1/3ShAbolz8833IFZBvm5yYvfr6XepS/3xXdVBxiKsKkT0
+# https://debian-boot.debian.narkive.com/0rQzZ4OM/bug-636145-debian-installer-installer-does-not-proceed-at-apt-setup-udeb-on-powerpc-with-preseed-cfg
+# https://forum.openmediavault.org/index.php/Thread/1265-Problem-installing-from-USB-stick/?postID=5797#post5797
+d-i apt-setup/use/netinst string
+
+# Uncertain if these options will work on the NUC
+#grub-installer  grub-installer/only_debian	boolean	true
+#grub-installer  grub-installer/choose_bootdev    select    /dev/sda
+#grub-installer  grub-installer/make_active    boolean    true
+
+# https://www.debian.org/releases/stretch/example-preseed.txt
+d-i apt-setup/local0/repository string [trusted=yes] https://projectbuendia.github.io/builds/packages unstable main java
+d-i apt-setup/local0/comment string Buendia Packages
+d-i pkgsel/include string apt-transport-https
+d-i preseed/late_command string bash /cdrom/install-buendia

--- a/tools/iso/preseed.cfg
+++ b/tools/iso/preseed.cfg
@@ -777,7 +777,7 @@ apt-cdrom-setup	apt-setup/cdrom/failed	error
 # Type for the new partition:
 # Choices: Primary, Logical
 # WPA/WPA2 passphrase for wireless device wlp2s0:
-netcfg	netcfg/wireless_wpa	string	kirkpicard
+# netcfg	netcfg/wireless_wpa	string	password
 # Are you sure you want a bootable logical partition?
 # Error while creating a new logical volume
 # Password input error
@@ -1406,8 +1406,248 @@ partman-base    partman/confirm              boolean    true
 # https://www.debian.org/releases/stretch/example-preseed.txt
 d-i apt-setup/local0/repository string [trusted=yes] https://projectbuendia.github.io/builds/packages unstable main java
 d-i apt-setup/local0/comment string Buendia Packages
+
+# Add any packages you want installed in the final installer stage here:
 d-i pkgsel/include string buendia-server buendia-site-test buendia-networking buendia-dashboard
+
 # Placing an executable command in /usr/lib/pre-pkgsel.d ensures that the
 # command is run after the chroot is set up but before any packages are
 # installed.
 d-i preseed/early_command string sh -c 'echo "touch /target/etc/buendia-defer-reconfigure" > /usr/lib/pre-pkgsel.d/90buendia; chmod +x /usr/lib/pre-pkgsel.d/90buendia'
+
+# FIXME: The following 230 options were removed from the original preseed file
+# as some of them were causing the installed image not to be bootable in a VM.
+# Probably most of them are fine, and adding at least some of them back would
+# remove some of the manual steps remaining in the current installer.
+#
+# d-i	di-utils-reboot/really_reboot	boolean	false
+# d-i	partman-crypto/confirm_nooverwrite	boolean	false
+# d-i	partman-lvm/confirm_nooverwrite	boolean	false
+# d-i	partman-md/confirm_nooverwrite	boolean	false
+# d-i	tasksel/first	multiselect	SSH server, standard system utilities
+# finish-install	finish-install/reboot_in_progress	note	
+# grub-efi-amd64	grub2/device_map_regenerated	note	
+# grub-efi-amd64	grub2/force_efi_extra_removable	boolean	false
+# grub-efi-amd64	grub2/kfreebsd_cmdline	string	
+# grub-efi-amd64	grub2/kfreebsd_cmdline_default	string	quiet
+# grub-efi-amd64	grub2/linux_cmdline	string	
+# grub-efi-amd64	grub2/linux_cmdline_default	string	quiet
+# grub-efi-amd64	grub2/update_nvram	boolean	true
+# grub-installer	grub-installer/apt-install-failed	error	
+# grub-installer	grub-installer/bootdev	string	
+# grub-installer	grub-installer/choose_bootdev	select	
+# grub-installer	grub-installer/force-efi-extra-removable	boolean	false
+# grub-installer	grub-installer/grub-install-failed	error	
+# grub-installer	grub-installer/grub2_instead_of_grub_legacy	boolean	true
+# grub-installer	grub-installer/grub_not_mature_on_this_platform	boolean	false
+# grub-installer	grub-installer/make_active	boolean	true
+# grub-installer	grub-installer/mounterr	error	
+# grub-installer	grub-installer/multipath	boolean	true
+# grub-installer	grub-installer/multipath-error	error	
+# grub-installer	grub-installer/only_debian	boolean	true
+# grub-installer	grub-installer/password-mismatch	error	
+# grub-installer	grub-installer/sataraid	boolean	true
+# grub-installer	grub-installer/sataraid-error	error	
+# grub-installer	grub-installer/skip	boolean	false
+# grub-installer	grub-installer/update-grub-failed	error	
+# grub-installer	grub-installer/with_other_os	boolean	true
+# partman-auto	partman-auto/automatically_partition	select	
+# partman-auto	partman-auto/autopartitioning_failed	error	
+# partman-auto	partman-auto/choose_recipe	select	/lib/partman/recipes-amd64-efi/30atomic
+# partman-auto	partman-auto/disk	string	
+# partman-auto	partman-auto/expert_recipe	string	
+# partman-auto	partman-auto/expert_recipe_file	string	
+# partman-auto	partman-auto/init_automatically_partition	select	50some_device__________regular
+# partman-auto	partman-auto/method	string	
+# partman-auto	partman-auto/no_recipe	error	
+# partman-auto	partman-auto/select_disk	select	/var/lib/partman/devices/=dev=sda
+# partman-auto	partman-auto/unusable_space	error	
+# partman-auto-crypto	partman-auto-crypto/erase_disks	boolean	true
+# partman-auto-lvm	partman-auto-lvm/new_vg_name	string	
+# partman-auto-lvm	partman-auto-lvm/new_vg_name_exists	string	
+# partman-auto-lvm	partman-auto-lvm/no_boot	boolean	
+# partman-auto-lvm	partman-auto-lvm/no_pv_in_vg	error	
+# partman-auto-lvm	partman-auto-lvm/no_such_pv	error	
+# partman-auto-lvm	partman-auto-lvm/unusable_recipe	error	
+# partman-auto-lvm	partman-auto-lvm/vg_create_error	error	
+# partman-auto-lvm	partman-auto-lvm/vg_exists	error	
+# partman-auto-raid	partman-auto-raid/error	error	
+# partman-auto-raid	partman-auto-raid/notenoughparts	error	
+# partman-auto-raid	partman-auto-raid/raidnum	string	
+# partman-auto-raid	partman-auto-raid/recipe	string	
+# partman-base	partman-base/devicelocked	error	
+# partman-base	partman-base/partlocked	error	
+# partman-base	partman/active_partition	select	
+# partman-base	partman/alignment	select	optimal
+# partman-base	partman/choose_partition	select	90finish__________finish
+# partman-base	partman/confirm	boolean	false
+# partman-base	partman/confirm_nochanges	boolean	false
+# partman-base	partman/confirm_nooverwrite	boolean	false
+# partman-base	partman/default_filesystem	string	ext4
+# partman-base	partman/early_command	string	
+# partman-base	partman/exception_handler	select	
+# partman-base	partman/exception_handler_note	note	
+# partman-base	partman/free_space	select	
+# partman-base	partman/show_free_chs	note	
+# partman-base	partman/show_partition_chs	note	
+# partman-base	partman/storage_device	select	
+# partman-basicfilesystems	partman-basicfilesystems/bad_mountpoint	error	
+# partman-basicfilesystems	partman-basicfilesystems/boot_not_ext2	boolean	
+# partman-basicfilesystems	partman-basicfilesystems/boot_not_first_partition	boolean	
+# partman-basicfilesystems	partman-basicfilesystems/check_failed	boolean	
+# partman-basicfilesystems	partman-basicfilesystems/choose_label	string	
+# partman-basicfilesystems	partman-basicfilesystems/create_failed	error	
+# partman-basicfilesystems	partman-basicfilesystems/create_swap_failed	error	
+# partman-basicfilesystems	partman-basicfilesystems/fat_mountpoint	select	
+# partman-basicfilesystems	partman-basicfilesystems/mountoptions	multiselect	
+# partman-basicfilesystems	partman-basicfilesystems/mountpoint	select	
+# partman-basicfilesystems	partman-basicfilesystems/mountpoint_manual	string	
+# partman-basicfilesystems	partman-basicfilesystems/no_mount_point	boolean	
+# partman-basicfilesystems	partman-basicfilesystems/no_swap	boolean	true
+# partman-basicfilesystems	partman-basicfilesystems/posix_filesystem_required	error	
+# partman-basicfilesystems	partman-basicfilesystems/specify_reserved	string	
+# partman-basicfilesystems	partman-basicfilesystems/specify_usage	select	
+# partman-basicfilesystems	partman-basicfilesystems/swap_check_failed	boolean	
+# partman-basicmethods	partman-basicmethods/method_only	boolean	
+# partman-btrfs	partman-btrfs/btrfs_boot	error	
+# partman-btrfs	partman-btrfs/btrfs_root	error	
+# partman-crypto	partman-crypto/cipher	select	
+# partman-crypto	partman-crypto/commit_failed	error	
+# partman-crypto	partman-crypto/confirm	boolean	false
+# partman-crypto	partman-crypto/confirm_nochanges	boolean	false
+# partman-crypto	partman-crypto/create/nosel	error	
+# partman-crypto	partman-crypto/create/partitions	multiselect	
+# partman-crypto	partman-crypto/crypto_boot_not_possible	error	
+# partman-crypto	partman-crypto/crypto_erase_failed	error	
+# partman-crypto	partman-crypto/crypto_root_needs_boot	error	
+# partman-crypto	partman-crypto/crypto_type	select	
+# partman-crypto	partman-crypto/crypto_warn_erase	boolean	false
+# partman-crypto	partman-crypto/entropy	entropy	
+# partman-crypto	partman-crypto/init_failed	error	
+# partman-crypto	partman-crypto/install_udebs_failure	error	
+# partman-crypto	partman-crypto/install_udebs_low_mem	boolean	
+# partman-crypto	partman-crypto/ivalgorithm	select	
+# partman-crypto	partman-crypto/keyfile-problem	error	
+# partman-crypto	partman-crypto/keyhash	select	
+# partman-crypto	partman-crypto/keysize	select	
+# partman-crypto	partman-crypto/keytype	select	
+# partman-crypto	partman-crypto/mainmenu	select	
+# partman-crypto	partman-crypto/module_package_missing	error	
+# partman-crypto	partman-crypto/nothing_to_setup	note	
+# partman-crypto	partman-crypto/options_missing	error	
+# partman-crypto	partman-crypto/passphrase-empty	error	
+# partman-crypto	partman-crypto/passphrase-mismatch	error	
+# partman-crypto	partman-crypto/plain_erase_failed	error	
+# partman-crypto	partman-crypto/plain_warn_erase	boolean	false
+# partman-crypto	partman-crypto/tools_missing	note	
+# partman-crypto	partman-crypto/unsafe_swap	error	
+# partman-crypto	partman-crypto/use_random_for_nonswap	boolean	false
+# partman-crypto	partman-crypto/weak_passphrase	boolean	false
+# partman-efi	partman-efi/no_efi	boolean	
+# partman-efi	partman-efi/non_efi_system	boolean	
+# partman-efi	partman-efi/too_small_efi	error	
+# partman-ext3	partman-ext3/bad_alignment	boolean	
+# partman-ext3	partman-ext3/boot_not_bootable	boolean	
+# partman-ext3	partman-ext3/boot_not_ext2_or_ext3	boolean	
+# partman-ext3	partman/boot_not_first_partition	boolean	
+# partman-iscsi	partman-iscsi/login/address	string	
+# partman-iscsi	partman-iscsi/login/all_targets	boolean	false
+# partman-iscsi	partman-iscsi/login/empty_password	error	
+# partman-iscsi	partman-iscsi/login/failed	error	
+# partman-iscsi	partman-iscsi/login/incoming_username	string	
+# partman-iscsi	partman-iscsi/login/no_targets	error	
+# partman-iscsi	partman-iscsi/login/targets	multiselect	
+# partman-iscsi	partman-iscsi/login/username	string	
+# partman-iscsi	partman-iscsi/mainmenu	select	
+# partman-jfs	partman-jfs/jfs_boot	boolean	false
+# partman-jfs	partman-jfs/jfs_root	boolean	false
+# partman-lvm	partman-lvm/badnamegiven	error	
+# partman-lvm	partman-lvm/commit_failed	error	
+# partman-lvm	partman-lvm/confirm	boolean	false
+# partman-lvm	partman-lvm/confirm_nochanges	boolean	false
+# partman-lvm	partman-lvm/device_remove_lvm	boolean	false
+# partman-lvm	partman-lvm/device_remove_lvm_span	error	
+# partman-lvm	partman-lvm/displayall	note	
+# partman-lvm	partman-lvm/help	note	
+# partman-lvm	partman-lvm/lvcreate_error	error	
+# partman-lvm	partman-lvm/lvcreate_exists	error	
+# partman-lvm	partman-lvm/lvcreate_name	string	
+# partman-lvm	partman-lvm/lvcreate_nofreevg	error	
+# partman-lvm	partman-lvm/lvcreate_nonamegiven	error	
+# partman-lvm	partman-lvm/lvcreate_size	string	
+# partman-lvm	partman-lvm/lvcreate_vgnames	select	
+# partman-lvm	partman-lvm/lvdelete_error	error	
+# partman-lvm	partman-lvm/lvdelete_lvnames	select	
+# partman-lvm	partman-lvm/lvdelete_nolv	error	
+# partman-lvm	partman-lvm/mainmenu	select	
+# partman-lvm	partman-lvm/nolvm	error	
+# partman-lvm	partman-lvm/nopartitions	error	
+# partman-lvm	partman-lvm/pvcreate_error	error	
+# partman-lvm	partman-lvm/vgcreate_devnameused	error	
+# partman-lvm	partman-lvm/vgcreate_error	error	
+# partman-lvm	partman-lvm/vgcreate_name	string	
+# partman-lvm	partman-lvm/vgcreate_nameused	error	
+# partman-lvm	partman-lvm/vgcreate_nonamegiven	error	
+# partman-lvm	partman-lvm/vgcreate_nosel	error	
+# partman-lvm	partman-lvm/vgcreate_parts	multiselect	
+# partman-lvm	partman-lvm/vgdelete_confirm	boolean	true
+# partman-lvm	partman-lvm/vgdelete_error	error	
+# partman-lvm	partman-lvm/vgdelete_names	select	
+# partman-lvm	partman-lvm/vgdelete_novg	error	
+# partman-lvm	partman-lvm/vgextend_error	error	
+# partman-lvm	partman-lvm/vgextend_names	select	
+# partman-lvm	partman-lvm/vgextend_nosel	error	
+# partman-lvm	partman-lvm/vgextend_novg	error	
+# partman-lvm	partman-lvm/vgextend_parts	multiselect	
+# partman-lvm	partman-lvm/vgreduce_error	error	
+# partman-lvm	partman-lvm/vgreduce_names	select	
+# partman-lvm	partman-lvm/vgreduce_nosel	error	
+# partman-lvm	partman-lvm/vgreduce_novg	error	
+# partman-lvm	partman-lvm/vgreduce_parts	multiselect	
+# partman-md	partman-md/commit_failed	error	
+# partman-md	partman-md/confirm	boolean	false
+# partman-md	partman-md/confirm_nochanges	boolean	false
+# partman-md	partman-md/createmain	select	
+# partman-md	partman-md/delete_no_md	error	
+# partman-md	partman-md/deletefailed	error	
+# partman-md	partman-md/deletemenu	select	
+# partman-md	partman-md/deleteverify	boolean	false
+# partman-md	partman-md/device_remove_md	boolean	false
+# partman-md	partman-md/mainmenu	select	
+# partman-md	partman-md/nomd	error	
+# partman-md	partman-md/noparts	error	
+# partman-md	partman-md/notenoughparts	error	
+# partman-md	partman-md/raid0devs	multiselect	
+# partman-md	partman-md/raid10layout	string	n2
+# partman-md	partman-md/raiddevcount	string	
+# partman-md	partman-md/raiddevs	multiselect	
+# partman-md	partman-md/raidsparecount	string	
+# partman-md	partman-md/raidsparedevs	multiselect	
+# partman-partitioning	partman-partitioning/bad_new_partition_size	error	
+# partman-partitioning	partman-partitioning/bad_new_size	error	
+# partman-partitioning	partman-partitioning/big_new_size	error	
+# partman-partitioning	partman-partitioning/bootable_logical	boolean	false
+# partman-partitioning	partman-partitioning/choose_label	select	
+# partman-partitioning	partman-partitioning/confirm_new_label	boolean	false
+# partman-partitioning	partman-partitioning/confirm_resize	boolean	
+# partman-partitioning	partman-partitioning/confirm_write_new_label	boolean	false
+# partman-partitioning	partman-partitioning/default_label	string	
+# partman-partitioning	partman-partitioning/impossible_resize	error	
+# partman-partitioning	partman-partitioning/new_partition_place	select	
+# partman-partitioning	partman-partitioning/new_partition_size	string	some number
+# partman-partitioning	partman-partitioning/new_partition_type	select	
+# partman-partitioning	partman-partitioning/new_size	string	some number
+# partman-partitioning	partman-partitioning/new_size_commit_failed	error	
+# partman-partitioning	partman-partitioning/set_flags	multiselect	
+# partman-partitioning	partman-partitioning/set_name	string	
+# partman-partitioning	partman-partitioning/small_new_size	error	
+# partman-partitioning	partman-partitioning/unknown_label	boolean	true
+# partman-partitioning	partman-partitioning/unsupported_label	boolean	false
+# partman-target	partman-target/choose_method	select	
+# partman-target	partman-target/help	note	
+# partman-target	partman-target/mount_failed	boolean	true
+# partman-target	partman-target/must_be_on_root	error	
+# partman-target	partman-target/no_root	error	
+# partman-target	partman-target/same_label	error	
+# partman-target	partman-target/same_mountpoint	error	
+# partman-target	partman/mount_style	select	uuid


### PR DESCRIPTION
This PR contains the components needed to construct a *mostly automated* network installer image for the Buendia server, suitable for burning to USB drive or CD-ROM. This PR depends on #144.

## Quick Start

1. Build the installer image as described below, or download it from (somewhere).
2. Write the installer image to bootable media, using e.g.
   [balenaEtcher](https://www.balena.io/etcher/) if you're on MacOS.
3. Boot an Intel NUC or other system from the USB media. Unless the machine is
   connected to Ethernet with a DHCP server on the network, you will probably
   be prompted for networking details. This is a network installer, after all.
3. Follow the prompts related to disk partitioning and boot loader. You can hit
   enter at any prompt to use the defaults. On the NUC, this is intended to
   result in a functioning system.
4. The installer will take ~5 minutes to run, maybe longer, depending on your
   network speed, and download 300-400 MB of additional software.
5. You will be prompted to remove the installer media. When the system reboots,
   it will take about a minute to finish configuring the system. A login prompt
   may be shown before the first configuration is complete.
6. After a couple minutes, the OpenMRS console will be available at
   `http://localhost:9000/openmrs/`. If you've installed to a NUC and have a
   `buendia` Wi-Fi network, the server will be available at
   `http://10.18.0.50:9000/openmrs/`.
7. You can log into the console as either `buendia` or `root`. The password is
   the same.

## Building the Installer

Building the installer image requires a Debian(-ish) Linux system. From the
current directory, run the following:

```
  $ build-buendia-iso
```

This produces a file called `buendia-install.iso` which is a bootable ISO
image. This image can be uploaded to a different machine, or installed directly
to USB media, for example:

```
  $ sudo bash -c `cat buendia-install.iso > /dev/<usb drive>`
```

## Details

The [`build-buendia-iso`](build-buendia-iso) constructs the image by starting
with a standard Debian 9.9 'stretch' ISO, which also contains the non-free
firmware needed by the Intel NUC wireless card.

The script adds `apt-transport-https` to the list of packages to add to the
base system, and then adds a [Debian preseed file](preseed.cfg) to seed most of
the netinst prompts. This preseed configuration adds our
projectbuendia.github.io _unstable_ repository to the list of apt sources, and
then appends the following packages to the default server installation:

* `buendia-site-test`
* `buendia-server`
* `buendia-networking`
* `buendia-dashboard`

Also, the preseed configuration triggers the creation of an empty file in
`/etc/buendia-defer-reconfigure` in the new system, which suppresses most of
the Buendia-specific configruation steps until after the system has booted for
the first time and both MySQL and Tomcat are running.

Finally, the installer sets the automated curses installer to be the default,
and then rebuilds the ISO image into a new file.
