### PR TITLE
Move network interface configuration from config.d to site config

### DIFF
--- a/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
@@ -70,11 +70,20 @@ unindent <<< "
     iface lo inet loopback
 
     iface $NETWORKING_ETHERNET_INTERFACE inet dhcp
-
-    iface $NETWORKING_WIFI_INTERFACE inet static
-	    address $NETWORKING_IP_ADDRESS/24
-        wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
 " > /etc/network/interfaces
+
+if [ -n "$NETWORKING_IP_ADDRESS" ]; then
+    unindent <<< "
+        iface $NETWORKING_WIFI_INTERFACE inet static
+            address $NETWORKING_IP_ADDRESS/24
+            wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
+    " >> /etc/network/interfaces
+else
+    unindent <<< "
+        iface $NETWORKING_WIFI_INTERFACE inet dhcp
+            wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
+    " >> /etc/network/interfaces
+fi
 
 # Apply wpa_supplicant configuration.
 wpa_passphrase "$NETWORKING_SSID" "$NETWORKING_PASSWORD" > /etc/wpa_supplicant/wpa_supplicant.conf

--- a/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
@@ -57,8 +57,8 @@ fi
 # In case anything goes wrong, don't leave behind an indicator of success.
 rm -f $run_settings
 
-# Bring down the interface during reconfiguration
-ifdown $MAIN_INTERFACE
+# Bring down the interface during reconfiguration, but don't fail if we can't.
+ifdown $MAIN_INTERFACE || true
 
 cp $tmp_settings /etc/buendia-networking.settings
 . /etc/buendia-networking.settings

--- a/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
@@ -9,13 +9,11 @@
 # uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 # OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
 # specific language governing permissions and limitations under the License.
-WIFI_INTERFACE=wlp2s0
-ETHERNET_INTERFACE=enp3s0
 
-if [ -z $WIFI_INTERFACE ]; then
-  MAIN_INTERFACE=$ETHERNET_INTERFACE
+if [ -z $NETWORKING_WIFI_INTERFACE ]; then
+  MAIN_INTERFACE=$NETWORKING_ETHERNET_INTERFACE
 else
-  MAIN_INTERFACE=$WIFI_INTERFACE
+  MAIN_INTERFACE=$NETWORKING_WIFI_INTERFACE
 fi
 
 if ! ( ip a | grep -q " $MAIN_INTERFACE:" ); then
@@ -67,13 +65,13 @@ cp $tmp_settings /etc/buendia-networking.settings
 
 # Apply the settings to the Debian network interface configuration.
 unindent <<< "
-    auto lo $WIFI_INTERFACE
+    auto lo $NETWORKING_WIFI_INTERFACE
 
     iface lo inet loopback
 
-    iface $ETHERNET_INTERFACE inet dhcp
+    iface $NETWORKING_ETHERNET_INTERFACE inet dhcp
 
-    iface $WIFI_INTERFACE inet static
+    iface $NETWORKING_WIFI_INTERFACE inet static
 	    address $NETWORKING_IP_ADDRESS/24
         wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf
 " > /etc/network/interfaces
@@ -91,19 +89,19 @@ unindent <<< "
     profile static_wifi
     static ip_address=$NETWORKING_IP_ADDRESS/24
 
-    # fallback to static profile on $ETHERNET_INTERFACE
-    interface $ETHERNET_INTERFACE
+    # fallback to static profile on $NETWORKING_ETHERNET_INTERFACE
+    interface $NETWORKING_ETHERNET_INTERFACE
     fallback static_ethernet
 
-    # fallback to static profile on $WIFI_INTERFACE
-    interface $WIFI_INTERFACE
+    # fallback to static profile on $NETWORKING_WIFI_INTERFACE
+    interface $NETWORKING_WIFI_INTERFACE
     fallback static_wifi
 " > /etc/dhcpcd.conf
 
 # Apply hostadp configuration
 hostapd_conf=/etc/hostapd/hostapd.conf
 unindent <<< "
-    interface=$WIFI_INTERFACE
+    interface=$NETWORKING_WIFI_INTERFACE
     ssid=$NETWORKING_SSID
     wpa=2
     wpa_key_mgmt=WPA-PSK

--- a/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
@@ -77,7 +77,7 @@ unindent <<< "
 " > /etc/network/interfaces
 
 # Apply wpa_supplicant configuration.
-wpa_passphrase $NETWORKING_SSID $NETWORKING_PASSWORD > /etc/wpa_supplicant/wpa_supplicant.conf
+wpa_passphrase "$NETWORKING_SSID" "$NETWORKING_PASSWORD" > /etc/wpa_supplicant/wpa_supplicant.conf
 
 # Apply dhcpcd configuration
 unindent <<< "

--- a/packages/buendia-networking/data/usr/share/buendia/site/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/site/10-networking
@@ -1,6 +1,10 @@
 # 0 to join an existing wifi network; 1 to become an AP and create a network.
 NETWORKING_AP=0
 
+# Default network interfaces on the Intel NUC
+NETWORKING_WIFI_INTERFACE=wlp2s0
+NETWORKING_ETHERNET_INTERFACE=enp3s0
+
 # SSID and WPA password for the network to join or create.
 NETWORKING_SSID=buendia
 # Default password must be at least 8 characters for the client

--- a/packages/buendia-networking/data/usr/share/buendia/site/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/site/10-networking
@@ -17,5 +17,6 @@ NETWORKING_DHCP_DNS_SERVER=0
 # Set to provide DHCP (if NETWORKING_DHCP_DNS_SERVER is set); otherwise none is provided.
 NETWORKING_DHCP_RANGE=10.0.0.100,10.0.0.199,12h
 
-# This host's IP address.  Only used if NETWORKING_DHCP_DNS_SERVER is 1.
+# This host's wireless IP address. If unset, then DHCP is used to get an
+# address on the wireless interface.
 NETWORKING_IP_ADDRESS=10.0.0.50


### PR DESCRIPTION
This is a follow-up to PR #138 that moves the selection of network interfaces into `site/10-neworking` where it belong. Closes #142 .

Also, enables DHCP on the wireless interface if no static IP address is set.