### PR TITLE
Enable the server to parse more than one XML document at a time

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
@@ -146,7 +146,7 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
         // seems
         // to do odd things... so instead, we import it into a new document.
         Document oldDoc = XmlUtil.parse(xml);
-        Document doc = XmlUtil.getDocumentBuilder().newDocument();
+        Document doc = XmlUtil.createDocumentBuilder().newDocument();
         Element root = (Element) doc.importNode(oldDoc.getDocumentElement(), true);
         root = (Element) doc.renameNode(root, HTML_NAMESPACE, "h:form");
         doc.appendChild(root);


### PR DESCRIPTION
Issues: Closes #148.
Scope: XForm builder

#### Visible changes

The server previously had only one static XML `DocumentBuilder` object, shared across all threads.  `DocumentBuilder` is not thread-safe, and will throw exceptions if run concurrently.  With this PR, the XForm builder runs reliably on multiple threads.

#### Verification performed

I was able to reliably replicate the issue with three processes running continuous requests for an XForm; this would produce a "parse may not be called while parsing" exception every ten seconds or so.

After making this change, I ran six processes simultaneously requesting XForms.  I left it running for 6 minutes, over 2700 requests were served, and there were no errors.