### PR TITLE
Use UUIDs in the XForm for provider_id and location_id options

### DIFF
--- a/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilderEx.java
+++ b/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilderEx.java
@@ -605,10 +605,7 @@ public class BuendiaXformBuilderEx {
         addSelectOption(controlNode, getLabel(conceptService.getConcept(FEMALE_CONCEPT_ID)), "F");
     }
 
-    /**
-     * Populates a UI control node with providers.
-     * @param controlNode - the UI control node.
-     */
+    /** Populates a selection node with provider options. The labels are UUIDs, understood by the client. */
     private void populateProviders(Element controlNode) {
         includesProviders = true;
         for (Provider provider : Context.getProviderService().getAllProviders()) {
@@ -617,10 +614,7 @@ public class BuendiaXformBuilderEx {
         }
     }
 
-    /**
-     * Populates a UI control node with locations.
-     * @param controlNode - the UI control node.
-     */
+    /** Populates a selection node with location options. The labels are UUIDs, understood by the client. */
     private void populateLocations(Element controlNode) {
         includesLocations = true;
         List<Location> locations = customizer.getEncounterLocations();

--- a/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/XformCustomizer.java
+++ b/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/XformCustomizer.java
@@ -32,17 +32,17 @@ public class XformCustomizer {
     }
 
     public String getLabel(Location loc) {
-        return loc.getName() + " [" + loc.getLocationId() + "]";
+        // We make sure to hide the location question on the client side; the
+        // location labels are never shown to the user.  This lets us use the
+        // UUID as the label, so the client can identify the location options.
+        return loc.getUuid();
     }
 
     public String getLabel(Provider provider) {
-        String name = provider.getName();
-        if (name == null) {
-            Person person = provider.getPerson();
-            name = person.getPersonName().toString();
-        }
-        String identifier = provider.getIdentifier();
-        return name + " [" + identifier + "]";
+        // We make sure to hide the provider question on the client side; the
+        // provider labels are never shown to the user.  This lets us use the
+        // UUID as the label, so the client can identify the provider options.
+        return provider.getUuid();
     }
 
     public String getGroupLabel(FormField formField) {


### PR DESCRIPTION
This clears up an ongoing issue we have had, in which the encounter form can show a "Location" selection question, or a "Provider" selection question, or crash on an illegal typecast, or fail to submit because the location or provider information was invalid or missing.

By passing the UUIDs of the providers and locations in the form, the client can definitively select the correct provider and location, and always hide these two questions from the form.