### PR TITLE
Add a common means of searching for external block devices

### DIFF
--- a/packages/buendia-backup/data/etc/cron.d/buendia-backup
+++ b/packages/buendia-backup/data/etc/cron.d/buendia-backup
@@ -3,10 +3,10 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 MAILTO=""
 
 # Back up to the first /dev/sd* partition we can find.
-0 * * * * root . /usr/share/buendia/utils.sh; if bool "$BACKUP_EXTERNAL"; then for dev in /dev/sd?[0-9]*; do [ -e $dev ] && buendia-log buendia-backup $dev $BACKUP_EXTERNAL_LIMIT_PERCENT && break; done; fi
+0 * * * * root . /usr/share/buendia/utils.sh; if bool "$BACKUP_EXTERNAL"; then for dev in $(external_file_systems); do [ -e $dev ] && buendia-log buendia-backup $dev $BACKUP_EXTERNAL_LIMIT_PERCENT && break; done; fi
 
 # Back up to the internal directory.
 10 * * * * root . /usr/share/buendia/utils.sh; [ -n "$BACKUP_INTERNAL_DIR" ] && buendia-log buendia-backup $BACKUP_INTERNAL_DIR $BACKUP_INTERNAL_LIMIT_KB
 
 # Restore from a USB drive
-* * * * * root for dev in /dev/sd?[0-9]*; do [ -e $dev ] && buendia-log buendia-restore $dev && break; done;
+* * * * * root . /usr/share/buendia/utils.sh; for dev in $(external_file_systems); do [ -e $dev ] && buendia-log buendia-restore $dev && break; done;

--- a/packages/buendia-pkgserver/data/etc/cron.d/buendia-pkgserver
+++ b/packages/buendia-pkgserver/data/etc/cron.d/buendia-pkgserver
@@ -2,4 +2,4 @@ SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 MAILTO=""
 
-* * * * * root sleep 5; for i in $(seq 6); do for dev in /dev/sd?1; do [ -e $dev ] && buendia-log buendia-pkgserver-import $dev; done; sleep 10; done
+* * * * * root . /usr/share/buendia/utils.sh; sleep 5; for i in $(seq 6); do for dev in $(external_file_systems); do [ -e $dev ] && buendia-log buendia-pkgserver-import $dev; done; sleep 10; done

--- a/packages/buendia-utils/data/usr/share/buendia/utils.sh
+++ b/packages/buendia-utils/data/usr/share/buendia/utils.sh
@@ -39,5 +39,18 @@ function service_if_exists() {
     fi
 }
 
+# Print a list of external file systems. If $EXTERNAL_BLOCK_DEVICES is set in
+# /usr/share/buendia/site/*, list the partitions on those devices only.
+# Otherwise, default to listing partitions on all block devices connected via
+# USB.
+function external_file_systems() {
+    if [ -z "$EXTERNAL_BLOCK_DEVICES" ]; then
+        EXTERNAL_BLOCK_DEVICES=$(lsblk -Sno NAME,TRAN | grep usb | cut -d' ' -f1)
+    fi
+    for device in $EXTERNAL_BLOCK_DEVICES; do
+        ls /dev/${device}[0-9]
+    done
+}
+
 # A handy shortcut, just for typing convenience.
 usb=usr/share/buendia


### PR DESCRIPTION
Both `buendia-update` and `buendia-pkgserver` perform a more or less indiscriminate scan of `/dev/sd??`, looking for block devices that appear to be suitable for external sources for update/backup/restore operations. On a NUC, this results in, for example, an attempt to mount the root of the main system partition once a minute, looking for non-existent backups.

This PR uses [`lsblk`](http://man7.org/linux/man-pages/man8/lsblk.8.html) to provide a common means for Buendia packages to identify external USB block devices, as well as a user-configurable override as needed (e.g. for automated testing). 