### PR TITLE
Eliminate the hardcoded chart UUID and establish a convention for other special UUIDs

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ChartResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ChartResource.java
@@ -13,10 +13,12 @@ package org.openmrs.projectbuendia.webservices.rest;
 
 import org.codehaus.jackson.map.ObjectMapper;
 import org.openmrs.Concept;
+import org.openmrs.EncounterType;
 import org.openmrs.Field;
 import org.openmrs.Form;
 import org.openmrs.FormField;
 import org.openmrs.api.ConceptService;
+import org.openmrs.api.EncounterService;
 import org.openmrs.api.FormService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -47,6 +49,7 @@ import java.util.regex.Pattern;
     supportedClass = Form.class, supportedOpenmrsVersions = "1.10.*,1.11.*")
 public class ChartResource extends AbstractReadOnlyResource<Form> {
     private static final Pattern COMPRESSIBLE_UUID = Pattern.compile("^([0-9]+)A+$");
+    private static final String CHART_ENCOUNTER_TYPE_NAME = "CHART";
     private final FormService formService;
     private final ConceptService conceptService;
 
@@ -171,15 +174,12 @@ public class ChartResource extends AbstractReadOnlyResource<Form> {
 
     public static List<Form> getCharts(FormService formService) {
         List<Form> charts = new ArrayList<>();
-        String[] uuids = Context.getAdministrationService()
-            .getGlobalProperty(GlobalProperties.CHART_UUIDS)
-            .split(",");
-        for (String uuid : uuids) {
-            Form form = formService.getFormByUuid(uuid);
-            if (form == null || form.isRetired()) {
-                continue;
+
+        for (Form form : formService.getAllForms()) {
+            if (form.isRetired()) continue;
+            if (form.getEncounterType().getName().equals(CHART_ENCOUNTER_TYPE_NAME)) {
+                charts.add(form);
             }
-            charts.add(form);
         }
         return charts;
     }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtil.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtil.java
@@ -112,8 +112,8 @@ public class DbUtil {
             "Order executed",
             // The OpenMRS "uuid" field is misnamed; OpenMRS uses the field for
             // arbitrary string IDs unrelated to RFC 4122.  Therefore, to prevent
-            // collisions, UUIDs specific to this module are prefixed "buendia-".
-            "buendia-concept-order_executed",
+            // collisions, UUIDs specific to this module are prefixed "buendia_".
+            "buendia_concept_order_executed",
             "N/A",
             "Finding");
     }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
@@ -111,7 +111,7 @@ public class OrderResource implements
     public static final String VOIDED = "voided";
     public static final String ORDERER_UUID = "orderer_uuid";
 
-    private static final String FREE_TEXT_ORDER_UUID = "buendia-concept-free_text_order";
+    private static final String FREE_TEXT_ORDER_UUID = "buendia_concept_free_text_order";
 
     private static final int MAX_ORDERS_PER_PAGE = 500;
 

--- a/tools/profile_apply
+++ b/tools/profile_apply
@@ -9,7 +9,8 @@ import sys
 import uuid
 import warnings
 
-CHART_UUID =  'ea43f213-66fb-4af6-8a49-70fd6b9ce5d4'
+# The UUID of the single OpenMRS form that defines all our charts.
+CHART_UUID = 'buendia_chart'
 LOCALE = 'en_GB_client'
 
 # This is a modified copy of the "OpenMRS FormEntry Form HL7 Translation" XSLT
@@ -138,6 +139,7 @@ def apply(tabs):
     concept_field_type = db.get('field_type_id', name='Concept')
     element_field_type = db.get('field_type_id', name='Database element')
     section_field_type = db.get('field_type_id', name='Section')
+    adult_return = db.get('encounter_type_id', name='ADULTRETURN')
 
     coded_datatype = db.get('concept_datatype_id', name='Coded')
     numeric_datatype = db.get('concept_datatype_id', name='Numeric')
@@ -160,7 +162,11 @@ def apply(tabs):
         if 'form' in tabs:
             apply_forms(tabs['form'])
         if 'chart' in tabs:
-            apply_chart(tabs['chart'], db.get('form_id', uuid=CHART_UUID))
+            chart_enctype = get_or_insert('encounter_type', name='CHART')
+            odb.update('encounter_type', chart_enctype, retired=1,
+                description='Reserved for patient chart definitions')
+            form_id = put_form(CHART_UUID, 'Chart definition', chart_enctype)
+            apply_chart(tabs['chart'], form_id)
         db.commit()
 
     def get_or_insert(table, **values):
@@ -264,9 +270,6 @@ def apply(tabs):
         set_concept_name(concept_id, name, locale)
 
     def apply_charts(rows):
-        chart_layout = get_or_insert(
-            'encounter_type', name='buendia-chart_layout',
-            description='Buendia: patient chart layout definition')
         for chart_rows in split_by_title(rows):
             put_chart(chart_rows)
 
@@ -365,7 +368,7 @@ def apply(tabs):
     def apply_forms(rows):
         db.execute('update form set published = 0')
         for form_rows in split_by_title(rows):
-            put_form(form_rows)
+            put_form_with_rows(form_rows)
 
     def normalize_name(name):
         return re.sub('[\W_]+', '_', (name or '').lower()).strip('_')
@@ -375,30 +378,34 @@ def apply(tabs):
         Construct a UUID from a form name, and issue a warning if we can't
         guarantee that the UUID will be unique.
         """
-        prefix = 'buendia-form-'
+        prefix = 'buendia_form_'
         max_uuid_len = 38
         max_name_len = max_uuid_len - len(prefix)
         if len(name) > max_name_len:
             warnings.warn(
-            "The form name '%s' has been clipped to create a unique form ID. "
-            "Note that if you have another form that starts with the same %d "
-            "characters as this form, the form IDs will collide and only one "
-            "form will be displayed. To fix this, ensure that the first %d "
-            "characters of each form name are unique."
-            % (name, max_name_len, max_name_len) )
+                "The form name '%s' has been clipped to create the UUID for "
+                "this form.  Note that if there is another form that starts "
+                "with the same %d characters as this form, the form UUIDs "
+                "will collide and only one of the forms will be available. "
+                "To fix this, ensure that the first %d characters of each "
+                "form name are unique." % (name, max_name_len, max_name_len)
+            )
         return prefix + normalize_name(name[:max_name_len])
 
-    def put_form(rows):
-        adult_return = db.get('encounter_type_id', name='ADULTRETURN')
+    def put_form(uuid, title, encounter_type):
+        form_id = db.get('form_id', uuid=uuid)
+        if form_id:
+            odb.update('form', form_id, name=title)
+        else:
+            form_id = odb.insert(
+                'form', name=title, version='1',
+                encounter_type=encounter_type, uuid=uuid)
+        return form_id
 
+    def put_form_with_rows(rows):
         title = rows[0]['title']
         uuid = create_uuid_from_form_name(title)
-        form_id = db.get('form_id', uuid=uuid)
-        if not form_id:
-            form_id = odb.insert('form', name=title, version='1',
-                                 encounter_type=adult_return, uuid=uuid)
-        else:
-            odb.update('form', form_id, name=title)
+        form_id = put_form(uuid, title, adult_return)
         apply_form(rows, form_id)
         init_form_xslt(form_id)
         db.execute('update form set published = 1 where form_id = %s', form_id)


### PR DESCRIPTION
Previously, the client requested the chart definition for a specific hardcoded UUID, and that same UUID had to exist on the server.  With this change, this is no longer the case; forms that serve as chart definitions are classified with a special "CHART" encounter type, so they can be discovered without the use of any magic numbers.

Previously as well, there was a global property named `projectbuendia.chartUuids` that purported to identify which forms were charts, but in reality there was nothing to keep it consistent with the rest of the system, resulting in fragility like the possibility of an exception thrown when listing the available charts.  This dependency is now also eliminated.

All Buendia-specific objects that have UUIDs now have UUIDs that follow a recognizable pattern: their names all begin with `buendia_<type>_` where `<type>` is the type of object.  So forms have UUIDs like `buendia_form_patient_attributes` and so on; the chart has the UUID `buendia_chart`, etc.  There are no longer any long strings of hex numbers that need to be correct.