### PR TITLE
Greatly accelerate startup by pointing /dev/random at /dev/urandom

### DIFF
--- a/packages/buendia-server/data/usr/share/buendia/config.d/70-server
+++ b/packages/buendia-server/data/usr/share/buendia/config.d/70-server
@@ -12,6 +12,16 @@
 
 set -e; . /usr/share/buendia/utils.sh
 
+# Ensure that /dev/random points to a fast source of entropy.  If it points
+# to the blocking device, Catalina may take 5-10 minutes to start up!
+if [ ! -L /dev/random ]; then
+    if [ -e /dev/random ]; then
+        mv -f /dev/random /dev/blocking-random
+    fi
+fi
+rm -f /dev/random
+ln -sf /dev/urandom /dev/random
+
 # Provide a randomly generated password for the Buendia user, if necessary.
 generated=/usr/share/buendia/site/20-server
 if [ ! -e $generated -o -z "$SERVER_OPENMRS_PASSWORD" ]; then


### PR DESCRIPTION
Previously, server startup would take anywhere from 2 minutes to 15 minutes, regardless of the speed of the CPU—it could take 5 minutes on the Raspberry Pi yet well in excess of 10 minutes on the Intel NUC.  I finally discovered that this was due to Catalina's use of `/dev/random` to collect entropy for generating random session IDs, and ultimately due to the unfortunate Java design decision to make `/dev/random` the default source of entropy.

Symlinking `/dev/random` to `/dev/urandom` brings startup time down to consistently 1 minute.