### PR TITLE
Eliminate all internal database IDs from the API; clients need only to work with UUIDs.

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
@@ -83,8 +83,8 @@ public class Utils {
     }
 
     /** Formats a {@link Date} as an ISO 8601 string in the UTC timezone. */
-    public static String toIso8601(Date dateTime) {
-        return FORMAT.format(dateTime);
+    public static String toIso8601(Date datetime) {
+        return FORMAT.format(datetime);
     }
 
     /** Parses an ISO 8601-formatted date into a {@link Date}. */
@@ -208,7 +208,7 @@ public class Utils {
      * @param datetime The date and time of an encounter.
      * @return
      */
-    public static Date fixEncounterDateTime(Date datetime) {
+    public static Date fixEncounterDatetime(Date datetime) {
         Date now = new Date();
         if (datetime.after(now)) {
             datetime = now;
@@ -263,10 +263,10 @@ public class Utils {
         }
     }
 
-    public static void requireKeyAbsent(SimpleObject obj, String key) {
+    public static void requirePropertyAbsent(SimpleObject obj, String key) {
         if (obj.containsKey(key)) {
             throw new InvalidObjectDataException(String.format(
-                "\"%s\" key is specified but not allowed", key));
+                "Property \"%s\" is not allowed", key));
         }
     }
 
@@ -274,13 +274,13 @@ public class Utils {
         Object value = obj.get(key);
         if (obj == null) {
             throw new InvalidObjectDataException(String.format(
-                "Required key \"%s\" is missing", key));
+                "Required property \"%s\" is missing", key));
         }
         try {
             return (String) value;
         } catch (ClassCastException e) {
             throw new InvalidObjectDataException(String.format(
-                "Need a String value for key \"%s\", not %s", key, value.getClass()));
+                "Required property \"%s\" should be a String, not %s", key, value.getClass()));
         }
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/VisitObsValue.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/VisitObsValue.java
@@ -41,7 +41,7 @@ public class VisitObsValue {
         public T visitDate(Date value);
 
         /** Visits a datetime value. */
-        public T visitDateTime(Date value);
+        public T visitDatetime(Date value);
     }
 
     /** Applies a visitor to an observation (we can't retrofit to Obs). */
@@ -62,7 +62,7 @@ public class VisitObsValue {
             case HL7Constants.HL7_DATE:
                 return visitor.visitDate(obs.getValueDate());
             case HL7Constants.HL7_DATETIME:
-                return visitor.visitDateTime(obs.getValueDatetime());
+                return visitor.visitDatetime(obs.getValueDatetime());
             default:
                 throw new IllegalArgumentException("Unexpected HL7 type: " + hl7Type + " for "
                     + "concept " + concept);

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/servlet/DataExportServlet.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/servlet/DataExportServlet.java
@@ -224,7 +224,7 @@ public class DataExportServlet extends HttpServlet {
                                 return null;
                             }
 
-                            @Override public Void visitDateTime(Date d) {
+                            @Override public Void visitDatetime(Date d) {
                                 String value;
                                 if (d == null) {
                                     value = "";

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/LocationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/LocationResource.java
@@ -14,10 +14,7 @@ package org.openmrs.projectbuendia.webservices.rest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Location;
-import org.openmrs.Patient;
-import org.openmrs.PersonAttribute;
 import org.openmrs.api.LocationService;
-import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -39,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * REST API for locations (places where patients can be located).
@@ -104,7 +100,7 @@ public class LocationResource implements
     }
 
     private Object createInner(SimpleObject request) throws ResponseException {
-        Utils.requireKeyAbsent(request, "uuid");
+        Utils.requirePropertyAbsent(request, "uuid");
         String parentUuid = Utils.getRequiredString(request, "parent_uuid");
         Location parent = locationService.getLocationByUuid(parentUuid);
         if (parent == null) {
@@ -239,7 +235,7 @@ public class LocationResource implements
     @Override public void delete(String uuid, String reason, RequestContext context)
         throws ResponseException {
         try {
-            logger.request(context, this, "delete", reason);
+            logger.request(context, this, "delete");
             deleteInner(uuid);
             logger.reply(context, this, "delete", null);
         } catch (Exception e) {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/Logger.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/Logger.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 /** Writes out timestamped HTTP request logs. */
 public class Logger {
-    private static final int MAX_STDERR_LINE_LENGTH = 240;
+    private static final int MAX_STDERR_LINE_LENGTH = 480;
     private Map<String, Date> startTimes = new HashMap<String, Date>();
     private String filename;
     private SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationUtils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationUtils.java
@@ -74,7 +74,7 @@ public class ObservationUtils {
                                          String encounterTypeName, String locationUuid) {
         // OpenMRS will reject the encounter if the time is in the past, even if
         // the client's clock is off by only one millisecond; work around this.
-        encounterTime = Utils.fixEncounterDateTime(encounterTime);
+        encounterTime = Utils.fixEncounterDatetime(encounterTime);
 
         EncounterService encounterService = Context.getEncounterService();
         Location location = null;
@@ -198,7 +198,7 @@ public class ObservationUtils {
                         return Utils.YYYYMMDD_UTC_FORMAT.format(value);
                     }
 
-                    @Override public String visitDateTime(Date value) {
+                    @Override public String visitDatetime(Date value) {
                         return Utils.toIso8601(value);
                     }
                 });

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
@@ -384,10 +384,10 @@ public class OrderResource implements
         return millis == null ? null : new Date(millis);
     }
 
-    private Encounter createEncounter(Patient patient, User creator, Date encounterDateTime) {
+    private Encounter createEncounter(Patient patient, User creator, Date encounterDatetime) {
         Encounter encounter = new Encounter();
         encounter.setCreator(creator);
-        encounter.setEncounterDatetime(encounterDateTime);
+        encounter.setEncounterDatetime(encounterDatetime);
         encounter.setPatient(patient);
         encounter.setLocation(Context.getLocationService().getDefaultLocation());
         encounter.setEncounterType(encounterService.getEncounterType("ADULTRETURN"));
@@ -505,7 +505,7 @@ public class OrderResource implements
         try {
             logger.request(context, this, "delete");
             deleteInner(uuid);
-            logger.reply(context, this, "delete", "returned");
+            logger.reply(context, this, "delete", null);
         } catch (Exception e) {
             logger.error(context, this, "delete", e);
             throw e;

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/RequestLogger.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/RequestLogger.java
@@ -107,7 +107,7 @@ public class RequestLogger {
         try {
             HttpServletRequest request = context.getRequest();
             String filename = request.getRemoteAddr();
-            end(filename, key, ExceptionUtils.getMessage(error) + ":\n"
+            end(filename, key, "\u001b[31m" + ExceptionUtils.getMessage(error) + "\u001b[0m:\n"
                 + ExceptionUtils.getStackTrace(error));
         } catch (Exception e) {
         }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XmlUtil.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XmlUtil.java
@@ -97,10 +97,13 @@ public class XmlUtil {
     public static Element getElementOrThrowNS(
         Element element, String namespaceURI, String localName) {
         NodeList elements = element.getElementsByTagNameNS(namespaceURI, localName);
+        if (elements.getLength() == 0) {
+            throw new IllegalPropertyException("Element " + element.getNodeName()
+                + " does not contain the expected " + localName + " element");
+        }
         if (elements.getLength() != 1) {
-            throw new IllegalPropertyException("Element "
-                + element.getNodeName() + " must have exactly one " + localName
-                + " element");
+            throw new IllegalPropertyException("Element " + element.getNodeName()
+                + " contains more than one " + localName + " element");
         }
         return (Element) elements.item(0);
     }

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/OrderResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/OrderResourceTest.java
@@ -140,6 +140,7 @@ public class OrderResourceTest extends MainResourceControllerTest {
             handle(request);
             fail("Expected handling this request to throw an exception");
         } catch (Exception ignored) {
+            System.err.println("Exception due to missing patient was expected: " + ignored);
         }
     }
 
@@ -155,6 +156,7 @@ public class OrderResourceTest extends MainResourceControllerTest {
             handle(request);
             fail("Expected handling this request to throw an exception");
         } catch (Exception ignored) {
+            System.err.println("Exception due to missing start date was expected: " + ignored);
         }
     }
 

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResourceTest.java
@@ -12,63 +12,50 @@ package org.openmrs.projectbuendia.webservices.rest;
 
 import org.junit.Test;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.projectbuendia.Utils;
+
+import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
 import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.assertXmlEqual;
 import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.readResourceAsString;
 
 public class XformInstanceResourceTest {
-    @Test
-    public void addForm() throws Exception {
+    @Test public void addForm() throws Exception {
         String input = readResourceAsString(getClass(), "original-instance-add.xml");
         String expected = readResourceAsString(getClass(), "expected-instance-add.xml");
-        SimpleObject post = new SimpleObject();
-        post.add("date_entered", "2014-11-15");
-        post.add("enterer_id", 1);
-        post.add("xml", input);
-        String actual = XformInstanceResource.completeXform(post);
+        Date dateEntered = Utils.fromIso8601("2014-11-15T12:34:56.789Z");
+        String actual = XformInstanceResource.completeXform(input, null, 1, dateEntered);
         assertXmlEqual(expected, actual);
     }
 
-    @Test
-    public void editForm() throws Exception {
+    @Test public void editForm() throws Exception {
         String input = readResourceAsString(getClass(), "original-instance-edit.xml");
         String expected = readResourceAsString(getClass(), "expected-instance-edit.xml");
-        SimpleObject post = new SimpleObject();
-        post.add("date_entered", "2014-11-15");
-        post.add("enterer_id", 1);
-        post.add("patient_id", 10);
-        post.add("xml", input);
-        String actual = XformInstanceResource.completeXform(post);
+        Date dateEntered = Utils.fromIso8601("2014-11-15T12:34:56.789Z");
+        String actual = XformInstanceResource.completeXform(input, 10, 1, dateEntered);
         assertXmlEqual(expected, actual);
     }
 
-    @Test
-    public void moveGroupsIntoObs() throws Exception {
+    @Test public void moveGroupsIntoObs() throws Exception {
         String input = readResourceAsString(getClass(), "original-grouped.xml");
         String expected = readResourceAsString(getClass(), "expected-grouped.xml");
-        SimpleObject post = new SimpleObject();
-        post.add("date_entered", "2014-11-15");
-        post.add("enterer_id", 1);
-        post.add("xml", input);
-        String actual = XformInstanceResource.completeXform(post);
+        Date dateEntered = Utils.fromIso8601("2014-11-15T12:34:56.789Z");
+        String actual = XformInstanceResource.completeXform(input, null, 1, dateEntered);
         assertXmlEqual(expected, actual);
     }
 
-    @Test
-    public void workAroundClientIssue_beforeFix() {
+    @Test public void parseNonstandardTimestamp() {
         String input = "20141120T092547.373Z";
         String expected = "2014-11-20T09:25:47.373Z";
-        String actual = XformInstanceResource.workAroundClientIssue(input);
+        String actual = Utils.toIso8601(XformInstanceResource.parseTimestamp(input));
         assertEquals(expected, actual);
     }
 
-    @Test
-    public void workAroundClientIssue_afterFix() {
-        // Nothing to fix
+    @Test public void parseStandardTimestamp() {
         String input = "2014-11-20T09:25:47.373Z";
         String expected = "2014-11-20T09:25:47.373Z";
-        String actual = XformInstanceResource.workAroundClientIssue(input);
+        String actual = Utils.toIso8601(XformInstanceResource.parseTimestamp(input));
         assertEquals(expected, actual);
     }
 }

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
     version="1">
   <header>
     <enterer>1^</enterer>
-    <date_entered>2014-11-15</date_entered>
+    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
     version="1">
   <header>
     <enterer>1^</enterer>
-    <date_entered>2014-11-15</date_entered>
+    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
     version="1">
   <header>
     <enterer>1^</enterer>
-    <date_entered>2014-11-15</date_entered>
+    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>


### PR DESCRIPTION
With this change, no more database IDs are visible or expected as input or output in the server API, with the one exception of the XForm submission interface, over which we don't have direct control.

There are also several small fixes and improvements to logging.