### PR TITLE
Introduce BaseApiRequestTest; use it to clean up the unit tests.

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/Logger.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/Logger.java
@@ -25,6 +25,7 @@ public class Logger {
     private Map<String, Date> startTimes = new HashMap<String, Date>();
     private String filename;
     private SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    public static boolean SILENT = false;
 
     public Logger(String filename) {
         this.filename = filename;
@@ -37,6 +38,8 @@ public class Logger {
 
     /** Emits a message to the log, timestamped with the specified time. */
     public void log(Date time, String message) {
+        if (SILENT) return;
+
         try {
             PrintWriter w = new PrintWriter(new FileWriter(filename, true /* append */));
             w.println("\n\u001b[32m" + format.format(time) + "\u001b[0m " + message);

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/BaseApiRequestTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/BaseApiRequestTest.java
@@ -1,0 +1,91 @@
+package org.openmrs.projectbuendia.webservices.rest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.openmrs.test.SkipBaseSetup;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.junit.Assert.fail;
+
+/** Base class for resource tests that issue simulated REST API requests. */
+public abstract class BaseApiRequestTest extends MainResourceControllerTest {
+    private static boolean VERBOSE = false;
+
+    protected EncounterService encounterService;
+    protected LocationService locationService;
+    protected OrderService orderService;
+    protected PatientService patientService;
+    protected ProviderService providerService;
+
+    /** Returns the path of the resource, beginning with "/projectbuendia". */
+    public abstract String getURI();
+
+    /** The expected number of records returned by a GET request to the main resource path. */
+    public abstract long getAllCount();
+
+    /** Returns a UUID for testing basic GET queries (only to verify a non-error, non-null result). */
+    public abstract String getUuid();
+
+    /** A list of the data files to preload with executeDataSet() before every test. */
+    public abstract String[] getInitialDataFiles();
+
+    @Rule public TestRule watcher = new TestWatcher() {
+        protected void starting(Description description) {
+            if (VERBOSE) System.err.println("=== Starting " + description.getMethodName() + "()");
+        }
+        protected void succeeded(Description description) {
+            if (VERBOSE) System.out.println("\u001b[32;1m=== PASSED: " + description.getMethodName() + "()\u001b[0m");
+        }
+        protected void failed(Description description) {
+            if (VERBOSE) System.out.println("\u001b[31;1m=== FAILED: " + description.getMethodName() + "()\u001b[0m");
+        }
+    };
+
+    /**
+     * {@link BaseModuleContextSensitiveTest} does this initialization, but also pre-loads
+     * the database with a bunch of records. We don't want to load those records, because
+     * we'd then have to augment them with `buendia_[type]_sync_map` records, which would
+     * couple our test integrity to the records in OpenMRS' test data. For this reason, we disable
+     * {@link BaseModuleContextSensitiveTest}'s setup by putting the {@link SkipBaseSetup}
+     * annotation on the class, but then we've got to explicitly init the database and
+     * authenticate ourselves.
+     */
+    @Before public void setUp() throws Exception {
+        Logger.SILENT = !VERBOSE;
+
+        encounterService = Context.getEncounterService();
+        locationService = Context.getLocationService();
+        orderService = Context.getOrderService();
+        patientService = Context.getPatientService();
+        providerService = Context.getProviderService();
+
+        if (useInMemoryDatabase()) {
+            initializeInMemoryDatabase();
+            authenticate();
+        }
+        for (String path : getInitialDataFiles()) {
+            executeDataSet(path);
+        }
+    }
+
+    protected void assertExceptionOnRequest(HttpServletRequest request, String reason) {
+        try {
+            handle(request);
+            fail("Exception due to " + reason + " was not thrown as expected");
+        } catch (Exception expected) {
+            System.err.println(expected.getClass().getName() + " due to " + reason + " was thrown as expected");
+        }
+    }
+}

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/OrderResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/OrderResourceTest.java
@@ -13,46 +13,22 @@
 
 package org.openmrs.projectbuendia.webservices.rest;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Order;
-import org.openmrs.api.OrderService;
-import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.openmrs.test.SkipBaseSetup;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 import javax.annotation.Nullable;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-/**
- * Tests for {@link OrderResource}.
- *
- * This test class is unusual in that it has two purposes:
- * - it incorporates some smoke tests for querying as a result of inheriting from
- *   {@link MainResourceControllerTest}. We don't bother testing any further here; our main query
- *   tests are in {@code HibernateProjectBuendiaDAOTest} and subclasses.
- * - Testing that updates, deletions and revisions work correctly.
- */
-@SkipBaseSetup
-public class OrderResourceTest extends MainResourceControllerTest {
-
-    private static final String BASE_TEST_DATA =
-        "org/openmrs/projectbuendia/webservices/rest/base-test-data.xml";
-    private static final String ORDER_TEST_DATA =
-        "org/openmrs/projectbuendia/webservices/rest/order-test-data.xml";
-    private static final String SINGLE_ORDER_DATA =
-        "org/openmrs/projectbuendia/webservices/rest/single-order.xml";
-
-    private static final String BASE_URL = "/projectbuendia/orders";
+/** REST API tests for OrderResource */
+@SkipBaseSetup public class OrderResourceTest extends BaseApiRequestTest {
     private static final String ENCOUNTERS_URL = "/projectbuendia/encounters";
 
     private static final long ONE_DAY_IN_MILLIS = 1000 * 60 * 60 * 24;
@@ -62,57 +38,31 @@ public class OrderResourceTest extends MainResourceControllerTest {
     private static final String SAMPLE_INSTRUCTIONS = "Paracetamol 1000mg 4x daily";
     private static final long SAMPLE_START_DATE = 1420602264000L;
     private static final long SAMPLE_END_DATE = SAMPLE_START_DATE + ONE_WEEK_IN_MILLIS;
-    private OrderService orderService;
 
-    /**
-     * {@link BaseModuleContextSensitiveTest} does this initialization, but also pre-loads the
-     * database with a bunch of records. We don't want to load those records,
-     * because we'd then have to augment them with `buendia_[type]_sync_map` records, which would
-     * couple our test integrity to the records in OpenMRS' test data. For this reason, we disable
-     * {@link BaseModuleContextSensitiveTest}'s setup by putting the {@link SkipBaseSetup}
-     * annotation on the class, but then we've got to explicitly init the database and authenticate
-     * ourselves.
-     */
-    @Before
-    public void setUp() throws Exception {
-        orderService = Context.getOrderService();
-        if (useInMemoryDatabase()) {
-            initializeInMemoryDatabase();
-            authenticate();
-        }
-        executeDataSet(BASE_TEST_DATA);
-        executeDataSet(ORDER_TEST_DATA);
-        executeDataSet(SINGLE_ORDER_DATA);
+    @Override public String[] getInitialDataFiles() {
+        return new String[] {
+            "org/openmrs/projectbuendia/webservices/rest/base-test-data.xml",
+            "org/openmrs/projectbuendia/webservices/rest/order-test-data.xml",
+            "org/openmrs/projectbuendia/webservices/rest/single-order.xml"
+        };
+    };
+
+    @Override public String getURI() {
+        return "/projectbuendia/orders";
     }
 
-    @Override
-    public String getURI() {
-        return "projectbuendia/orders";
+    @Override public long getAllCount() {
+        return 1; // orders in the dataset file
     }
 
-    @Override
-    public String getUuid() {
-        // From the dataset file.
-        return "aaaaa";
+    @Override public String getUuid() {
+        return "aaaaa"; // from the dataset file
     }
 
-    @Override
-    public long getAllCount() {
-        // From the dataset file.
-        return 1;
-    }
-
-    @Test
-    public void testOrderCreationWithAllDataPopulated() throws Exception {
+    @Test public void testOrderCreationWithAllDataPopulated() throws Exception {
         SimpleObject input = newOrderJson(
-                SAMPLE_PATIENT_UUID,
-                SAMPLE_INSTRUCTIONS,
-                SAMPLE_START_DATE,
-                SAMPLE_END_DATE);
-        MockHttpServletRequest request = newPostRequest(BASE_URL, input);
-        SimpleObject response = deserialize(handle(request));
-
-        String uuid = (String) response.get(OrderResource.UUID);
+            SAMPLE_PATIENT_UUID, SAMPLE_INSTRUCTIONS, SAMPLE_START_DATE, SAMPLE_END_DATE);
+        SimpleObject response = deserialize(handle(newPostRequest(getURI(), input)));
 
         // Check that fields are correctly set in response
         assertEquals(SAMPLE_PATIENT_UUID, response.get(OrderResource.PATIENT_UUID));
@@ -121,6 +71,7 @@ public class OrderResourceTest extends MainResourceControllerTest {
         assertEquals(SAMPLE_END_DATE, response.get(OrderResource.STOP_MILLIS));
 
         // Check that these fields match the object stored.
+        String uuid = (String) response.get(OrderResource.UUID);
         Order stored = orderService.getOrderByUuid(uuid);
         assertEquals(SAMPLE_PATIENT_UUID, stored.getPatient().getUuid());
         assertEquals(SAMPLE_INSTRUCTIONS, stored.getInstructions());
@@ -128,47 +79,23 @@ public class OrderResourceTest extends MainResourceControllerTest {
         assertEquals(SAMPLE_END_DATE, stored.getAutoExpireDate().getTime());
     }
 
-    @Test
-    public void testOrderCreationWithoutPatientThrowsException() throws Exception {
+    @Test public void testOrderCreationWithoutPatientThrowsException() throws Exception {
         SimpleObject input = newOrderJson(
-                null,
-                SAMPLE_INSTRUCTIONS,
-                SAMPLE_START_DATE,
-                SAMPLE_END_DATE);
-        MockHttpServletRequest request = newPostRequest(BASE_URL, input);
-        try {
-            handle(request);
-            fail("Expected handling this request to throw an exception");
-        } catch (Exception ignored) {
-            System.err.println("Exception due to missing patient was expected: " + ignored);
-        }
+            null, SAMPLE_INSTRUCTIONS, SAMPLE_START_DATE, SAMPLE_END_DATE);
+        assertExceptionOnRequest(newPostRequest(getURI(), input), "missing patient");
     }
 
-    @Test
-    public void testOrderCreationWithoutStartDateReturnsThrowsException() throws Exception {
+    @Test public void testOrderCreationWithoutStartDateReturnsThrowsException() throws Exception {
         SimpleObject input = newOrderJson(
-                SAMPLE_PATIENT_UUID,
-                SAMPLE_INSTRUCTIONS,
-                null,
-                SAMPLE_END_DATE);
-        MockHttpServletRequest request = newPostRequest(BASE_URL, input);
-        try {
-            handle(request);
-            fail("Expected handling this request to throw an exception");
-        } catch (Exception ignored) {
-            System.err.println("Exception due to missing start date was expected: " + ignored);
-        }
+            SAMPLE_PATIENT_UUID, SAMPLE_INSTRUCTIONS, null, SAMPLE_END_DATE);
+        assertExceptionOnRequest(newPostRequest(getURI(), input), "missing start date");
     }
 
     @Test
     public void testOrderCreationWithoutEndDateIsAccepted() throws Exception {
         SimpleObject input = newOrderJson(
-                SAMPLE_PATIENT_UUID,
-                SAMPLE_INSTRUCTIONS,
-                SAMPLE_START_DATE,
-                null);
-        MockHttpServletRequest request = newPostRequest(BASE_URL, input);
-        SimpleObject response = deserialize(handle(request));
+            SAMPLE_PATIENT_UUID, SAMPLE_INSTRUCTIONS, SAMPLE_START_DATE, null);
+        SimpleObject response = deserialize(handle(newPostRequest(getURI(), input)));
 
         String uuid = (String) response.get(OrderResource.UUID);
 
@@ -188,13 +115,12 @@ public class OrderResourceTest extends MainResourceControllerTest {
         assertNull(stored.getAutoExpireDate());
     }
 
-    @Test
-    public void testUpdateForOrderOlderThan24HrsIsARevision() throws Exception {
+    @Test public void testUpdateForOrderOlderThan24HrsIsARevision() throws Exception {
         String newInstructions = "Some instructions?";
         Order baseOrder = createExpiredOrderOlderThan24Hrs();
         SimpleObject newDetails = newOrderJson(null, newInstructions, null, null);
         MockHttpServletRequest request =
-                newPostRequest(BASE_URL + "/" + baseOrder.getUuid(), newDetails);
+            newPostRequest(getURI() + "/" + baseOrder.getUuid(), newDetails);
         SimpleObject response = deserialize(handle(request));
 
         String uuid = (String) response.get(OrderResource.UUID);
@@ -216,23 +142,20 @@ public class OrderResourceTest extends MainResourceControllerTest {
         assertEquals(SAMPLE_END_DATE, stored.getAutoExpireDate().getTime());
     }
 
-    @Test
-    public void testUpdateForExecutedOrderIsARevision() throws Exception {
+    @Test public void testUpdateForExecutedOrderIsARevision() throws Exception {
         Order baseOrder = createOrderStartingNow();
         executeOrder(baseOrder);
         long startTime = baseOrder.getScheduledDate().getTime();
-
         long newEndTime = System.currentTimeMillis() + 2 * ONE_WEEK_IN_MILLIS;
 
         SimpleObject newDetails = newOrderJson(null, null, null, newEndTime);
         MockHttpServletRequest request =
-                newPostRequest(BASE_URL + "/" + baseOrder.getUuid(), newDetails);
+            newPostRequest(getURI() + "/" + baseOrder.getUuid(), newDetails);
 
         SimpleObject response = deserialize(handle(request));
 
-        String uuid = (String) response.get(OrderResource.UUID);
-
         // The client should get the same UUID, but in storage, it should be a different order.
+        String uuid = (String) response.get(OrderResource.UUID);
         assertEquals(baseOrder.getUuid(), uuid);
 
         // Check that fields are correctly set in response
@@ -249,43 +172,30 @@ public class OrderResourceTest extends MainResourceControllerTest {
         assertEquals(newEndTime, stored.getAutoExpireDate().getTime());
     }
 
-    @Test
-    public void testDeleteForNewNonExecutedOrderVoids() throws Exception {
-        Order order = createOrderStartingNow();
-        String uuid = order.getUuid();
-        MockHttpServletRequest request =
-                newDeleteRequest(BASE_URL + "/" + uuid);
-        handle(request);
+    @Test public void testDeleteForNewNonExecutedOrderVoids() throws Exception {
+        String uuid = createOrderStartingNow().getUuid();
+        handle(newDeleteRequest(getURI() + "/" + uuid));
         assertTrue("Order is voided", orderService.getOrderByUuid(uuid).isVoided());
     }
 
-    @Test
-    public void testDeleteForExecutedOrderVoids() throws Exception {
+    @Test public void testDeleteForExecutedOrderVoids() throws Exception {
         Order baseOrder = createOrderStartingNow();
         executeOrder(baseOrder);
         String uuid = baseOrder.getUuid();
-        MockHttpServletRequest request =
-                newDeleteRequest(BASE_URL + "/" + uuid);
-        handle(request);
-        OrderService service = orderService;
-        Order order = service.getOrderByUuid(uuid);
+        handle(newDeleteRequest(getURI() + "/" + uuid));
+        Order order = orderService.getOrderByUuid(uuid);
         assertTrue("Order is voided", order.isVoided());
     }
 
-    @Test
-    public void testDeleteForRevisedOrderVoidsAll() throws Exception {
+    @Test public void testDeleteForRevisedOrderVoidsAll() throws Exception {
         Order baseOrder = createOrderStartingNow();
         String baseUuid = baseOrder.getUuid();
 
-        SimpleObject newDetails = newOrderJson(null, "New instructions!", null, null);
-        MockHttpServletRequest request =
-                newPostRequest(BASE_URL + "/" + baseUuid, newDetails);
-
         // Make the update.
-        handle(request);
+        SimpleObject newDetails = newOrderJson(null, "New instructions!", null, null);
+        handle(newPostRequest(getURI() + "/" + baseUuid, newDetails));
+        handle(newDeleteRequest(getURI() + "/" + baseUuid));
 
-        request = newDeleteRequest(BASE_URL + "/" + baseUuid);
-        handle(request);
         // Reload the base order from storage
         baseOrder = orderService.getOrderByUuid(baseUuid);
         assertTrue("Base order is voided", baseOrder.isVoided());
@@ -297,8 +207,8 @@ public class OrderResourceTest extends MainResourceControllerTest {
 
     private Order createExpiredOrderOlderThan24Hrs() throws Exception {
         SimpleObject input = newOrderJson(
-                SAMPLE_PATIENT_UUID, SAMPLE_INSTRUCTIONS, SAMPLE_START_DATE, SAMPLE_END_DATE);
-        SimpleObject response = deserialize(handle(newPostRequest(BASE_URL, input)));
+            SAMPLE_PATIENT_UUID, SAMPLE_INSTRUCTIONS, SAMPLE_START_DATE, SAMPLE_END_DATE);
+        SimpleObject response = deserialize(handle(newPostRequest(getURI(), input)));
         String uuid = (String) response.get(OrderResource.UUID);
         return orderService.getOrderByUuid(uuid);
     }
@@ -306,17 +216,17 @@ public class OrderResourceTest extends MainResourceControllerTest {
     private Order createOrderStartingNow() throws Exception {
         long now = System.currentTimeMillis();
         SimpleObject input = newOrderJson(
-                SAMPLE_PATIENT_UUID, SAMPLE_INSTRUCTIONS, now, now + ONE_WEEK_IN_MILLIS);
-        SimpleObject response = deserialize(handle(newPostRequest(BASE_URL, input)));
+            SAMPLE_PATIENT_UUID, SAMPLE_INSTRUCTIONS, now, now + ONE_WEEK_IN_MILLIS);
+        SimpleObject response = deserialize(handle(newPostRequest(getURI(), input)));
         String uuid = (String) response.get(OrderResource.UUID);
         return orderService.getOrderByUuid(uuid);
     }
 
     private void executeOrder(Order order) throws Exception {
-        SimpleObject input = new SimpleObject()
-                .add("uuid", order.getPatient().getUuid())
-                .add("order_uuids", new String[]{order.getUuid()});
-        handle(newPostRequest(ENCOUNTERS_URL, input));
+        handle(newPostRequest(ENCOUNTERS_URL, new SimpleObject()
+            .add("uuid", order.getPatient().getUuid())
+            .add("order_uuids", new String[] {order.getUuid()})
+        ));
     }
 
     // Other test cases:
@@ -330,8 +240,8 @@ public class OrderResourceTest extends MainResourceControllerTest {
     // - Delete, order has expired
 
     private static SimpleObject newOrderJson(
-            @Nullable String patientUuid, @Nullable String instructions,
-            @Nullable Long startMillis, @Nullable Long stopMillis) {
+        @Nullable String patientUuid, @Nullable String instructions,
+        @Nullable Long startMillis, @Nullable Long stopMillis) {
         SimpleObject order = new SimpleObject();
         if (patientUuid != null) {
             order.add(OrderResource.PATIENT_UUID, patientUuid);

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/PatientResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/PatientResourceTest.java
@@ -14,85 +14,46 @@
 package org.openmrs.projectbuendia.webservices.rest;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Patient;
-import org.openmrs.api.LocationService;
-import org.openmrs.api.PatientService;
-import org.openmrs.api.context.Context;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.module.webservices.rest.SimpleObject;
-import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
-import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceControllerTest;
-import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.openmrs.test.SkipBaseSetup;
 import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
 
-/** Tests for PatientResource. */
+/** REST API tests for PatientResource. */
 @SkipBaseSetup
-public class PatientResourceTest extends MainResourceControllerTest {
-
-    private static final String BASE_TEST_DATA =
-        "org/openmrs/projectbuendia/webservices/rest/base-test-data.xml";
-    private static final String PATIENT_TEST_DATA =
-        "org/openmrs/projectbuendia/webservices/rest/patient-test-data.xml";
-
+public class PatientResourceTest extends BaseApiRequestTest {
     // These constants should match the values in the BASE_TEST_DATA file.
     String PETER_PAN_UUID = "f6f74ed9-5681-482a-9aa5-c3192579fa59";
     String XANADU_UUID = "9356400c-a5a2-4532-8f2b-2361b3446eb8";
 
-    private PatientService patientService;
+    public String[] getInitialDataFiles() {
+        return new String[] {
+            "org/openmrs/projectbuendia/webservices/rest/base-test-data.xml",
+            "org/openmrs/projectbuendia/webservices/rest/patient-test-data.xml"
+        };
+    };
 
-    /**
-     * {@link BaseModuleContextSensitiveTest} does this initialization, but also pre-loads the
-     * database with a bunch of records. We don't want to load those records,
-     * because we'd then have to augment them with `buendia_[type]_sync_map` records, which would
-     * couple our test integrity to the records in OpenMRS' test data. For this reason, we disable
-     * {@link BaseModuleContextSensitiveTest}'s setup by putting the {@link SkipBaseSetup}
-     * annotation on the class, but then we've got to explicitly init the database and authenticate
-     * ourselves.
-     */
-    @Before
-    public void setUp() throws Exception {
-        patientService = Context.getPatientService();
-        if (useInMemoryDatabase()) {
-            initializeInMemoryDatabase();
-            authenticate();
-        }
-        executeDataSet(BASE_TEST_DATA);
-        executeDataSet(PATIENT_TEST_DATA);
-    }
-
-    @Override
     public String getURI() {
-        return "projectbuendia/patients";
+        return "/projectbuendia/patients";
     }
 
-    @Override
-    public String getUuid() {  // for the common tests defined in MainResourceControllerTest
+    public long getAllCount() {
+        return 0; // even though there are two patients, there are no sync timestamps
+    }
+
+    public String getUuid() {
         return PETER_PAN_UUID;
     }
 
-    @Override
-    public long getAllCount() {
-        return 2;
-    }
-
-    @Test @Override
-    public void shouldGetAll() throws Exception {
-        System.err.println("Skipping shouldGetAll(): we don't know why shouldGetAll() finds 0 patients when there should be 2.");
-    }
-
-    @Test
-    public void testGetPatient() throws Exception {
+    @Test public void testGetPatient() throws Exception {
         MockHttpServletRequest request = this.request(RequestMethod.GET, this.getURI() + "/" + PETER_PAN_UUID);
         SimpleObject response = this.deserialize(this.handle(request));
         Assert.assertNotNull(response);
@@ -104,8 +65,7 @@ public class PatientResourceTest extends MainResourceControllerTest {
         assertEquals("ABC123", response.get("id"));
     }
 
-    @Test
-    public void testCreatePatient() throws Exception {
+    @Test public void testCreatePatient() throws Exception {
         SimpleObject input = new SimpleObject();
         input.add("id", "XYZ");
         input.add("given_name", "Mary");
@@ -129,8 +89,7 @@ public class PatientResourceTest extends MainResourceControllerTest {
         assertEquals("XYZ", patient.getPatientIdentifier(identType).getIdentifier());
     }
 
-    @Test
-    public void testMovePatient() throws Exception {
+    @Test public void testMovePatient() throws Exception {
         // Post an edit that sets the location of a patient.
         SimpleObject input = new SimpleObject();
         input.add("assigned_location", XANADU_UUID);

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformResourceTest.java
@@ -17,16 +17,14 @@ import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.assertXmlE
 import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.readResourceAsString;
 
 public class XformResourceTest {
-    @Test
-    public void convertToOdkCollect() throws Exception {
+    @Test public void convertToOdkCollect() throws Exception {
         String input = readResourceAsString(getClass(), "sample-original-form1.xml");
         String expected = readResourceAsString(getClass(), "expected-result-form1.xml");
         String actual = XformResource.convertToOdkCollect(input, "Form title");
         assertXmlEqual(expected, actual);
     }
 
-    @Test
-    public void removeRelationshipNodes() throws Exception {
+    @Test public void removeRelationshipNodes() throws Exception {
         String input = readResourceAsString(getClass(), "relationships-original-form1.xml");
         String expected = readResourceAsString(getClass(), "relationships-result-form1.xml");
         String actual = XformResource.removeRelationshipNodes(input);


### PR DESCRIPTION
This moves commonly duplicated code into a base class.