### PR TITLE
Assign user_ids and provider_ids to other objects correctly

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
@@ -207,6 +207,11 @@ public class Utils {
 
     // ==== OpenMRS ====
 
+    /** Returns the currently authenticated user. */
+    public static User getAuthenticatedUser() {
+        return Context.getUserContext().getAuthenticatedUser();
+    }
+
     /**
      * Adjusts an encounter datetime to ensure that OpenMRS will accept it.
      * The OpenMRS core is not designed for a client-server setup -- it will

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
@@ -13,9 +13,12 @@ package org.openmrs.projectbuendia.webservices.rest;
 
 import org.openmrs.Concept;
 import org.openmrs.Encounter;
+import org.openmrs.EncounterProvider;
+import org.openmrs.EncounterRole;
 import org.openmrs.Obs;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.Patient;
+import org.openmrs.Person;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -86,10 +89,8 @@ public class EncounterResource implements Creatable {
         // the wire format. So instead, there is this comment.
         // TODO: refactor the wire format for getEncounters so it matches the create format.
 
-        if (!post.containsKey("uuid")) {
-            throw new InvalidObjectDataException("Missing \"uuid\" key for patient");
-        }
-        Patient patient = patientService.getPatientByUuid(post.get("uuid").toString());
+        String patientUuid = Utils.getRequiredString(post, "uuid");
+        Patient patient = patientService.getPatientByUuid(patientUuid);
         if (patient == null) {
             throw new InvalidObjectDataException("Patient not found: " + post.get("uuid"));
         }
@@ -108,10 +109,7 @@ public class EncounterResource implements Creatable {
         }
         Encounter encounter = ObservationUtils.addEncounter(
             (List) post.get("observations"), (List) post.get("order_uuids"),
-            patient, encounterTime, "new observation", "ADULTRETURN", null);
-        if (encounter == null) {
-            throw new InvalidObjectDataException("No observations specified");
-        }
+            patient, encounterTime, "ADULTRETURN", (String) post.get("enterer_uuid"), null);
         SimpleObject simpleObject = new SimpleObject();
         populateJsonProperties(encounter, simpleObject);
         return simpleObject;

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
@@ -269,8 +269,7 @@ public class OrderResource implements
             order.setOrderer(getProvider());
         }
         // Will be null if `orderer` is null.
-        User creator = Utils.getUserFromProvider(orderer);
-        order.setEncounter(createEncounter(order.getPatient(), creator, new Date()));
+        order.setEncounter(createEncounter(order.getPatient(), new Date()));
     }
 
     /**
@@ -382,9 +381,9 @@ public class OrderResource implements
         return millis == null ? null : new Date(millis);
     }
 
-    private Encounter createEncounter(Patient patient, User creator, Date encounterDatetime) {
+    private Encounter createEncounter(Patient patient, Date encounterDatetime) {
         Encounter encounter = new Encounter();
-        encounter.setCreator(creator);
+        encounter.setCreator(Utils.getAuthenticatedUser());
         encounter.setEncounterDatetime(encounterDatetime);
         encounter.setPatient(patient);
         encounter.setLocation(Context.getLocationService().getDefaultLocation());

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
@@ -259,6 +259,10 @@ public class OrderResource implements
      * both new orders and revisions.
      */
     private void populateDefaultsForAllOrders(Order order) {
+        // There is no "changed_by" property; an update is achieved by creating
+        // a new order that revises the previous one, so the authenticated user
+        // goes in the "creator" property for both create and update operations.
+        order.setCreator(Utils.getAuthenticatedUser());
         Provider orderer = order.getOrderer();
         // Populate with a default orderer if none is supplied.
         if (orderer == null) {
@@ -355,9 +359,7 @@ public class OrderResource implements
                         throw new IllegalPropertyException(
                                 "Illegal format for " + ORDERER_UUID + ", expected string");
                     }
-                    order.setCreator(Utils.getUserFromProviderUuid((String) value));
-                    order.setOrderer(
-                            providerService.getProviderByUuid((String) value));
+                    order.setOrderer(providerService.getProviderByUuid((String) value));
                 } break;
 
                 default: {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
@@ -109,7 +109,7 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
     private static final String GIVEN_NAME = "given_name";
     private static final String FAMILY_NAME = "family_name";
     private static final String ASSIGNED_LOCATION = "assigned_location";
-    private static final String PARENT_UUID = "parent_uuid";
+    private static final String ENTERER_UUID = "enterer_uuid";
     private static final String VOIDED = "voided";
 
     private static Log log = LogFactory.getLog(PatientResource.class);
@@ -197,9 +197,6 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
             if (location != null) {
                 SimpleObject locationJson = new SimpleObject();
                 locationJson.add(UUID, location.getUuid());
-                if (location.getParentLocation() != null) {
-                    locationJson.add(PARENT_UUID, location.getParentLocation().getUuid());
-                }
                 jsonForm.add(ASSIGNED_LOCATION, locationJson);
             }
         }
@@ -262,9 +259,10 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
 
         }
         // Store any initial observations that are included with the new patient.
+        String entererUuid = (String) json.get(ENTERER_UUID);
         ObservationUtils.addEncounter(
             (List) json.get("observations"), null,
-            patient, patient.getDateCreated(), "New patient", "ADULTINITIAL", null);
+            patient, patient.getDateCreated(), "ADULTINITIAL", entererUuid, null);
         return patientToJson(patient);
     }
 

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
@@ -34,6 +34,7 @@ import org.openmrs.module.webservices.rest.web.resource.api.Retrievable;
 import org.openmrs.module.webservices.rest.web.resource.api.Searchable;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.openmrs.projectbuendia.Utils;
 import org.projectbuendia.openmrs.webservices.rest.RestController;
 
 import java.util.ArrayList;
@@ -213,6 +214,7 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
         userService.saveUser(user, (String) simpleObject.get(PASSWORD));
 
         Provider provider = new Provider();
+        provider.setCreator(Utils.getAuthenticatedUser());
         provider.setPerson(person);
         provider.setName(fullName);
         providerService.saveProvider(provider);

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
@@ -12,14 +12,10 @@
 package org.openmrs.projectbuendia.webservices.rest;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.openmrs.Patient;
 import org.openmrs.Person;
-import org.openmrs.PersonName;
 import org.openmrs.Provider;
 import org.openmrs.User;
-import org.openmrs.api.PersonService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
@@ -85,8 +81,8 @@ import java.util.List;
  * }
  * </pre>
  */
-@Resource(name = RestController.REST_VERSION_1_AND_NAMESPACE + "/users", supportedClass = Provider
-    .class, supportedOpenmrsVersions = "1.10.*,1.11.*")
+@Resource(name = RestController.REST_VERSION_1_AND_NAMESPACE + "/users",
+    supportedClass = Provider.class, supportedOpenmrsVersions = "1.10.*,1.11.*")
 public class UserResource implements Listable, Searchable, Retrievable, Creatable {
     // JSON property names
     private static final String USER_ID = "user_id";
@@ -94,30 +90,21 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
     private static final String FULL_NAME = "full_name";  // Ignored on create.
     private static final String FAMILY_NAME = "family_name";
     private static final String GIVEN_NAME = "given_name";
-    private static final String PASSWORD = "password";
-
-    // Sentinel for unknown values
-    private static final String UNKNOWN = "(UNKNOWN)";
 
     // Defaults for guest account
     private static final String GUEST_FULL_NAME = "Guest User";
     private static final String GUEST_GIVEN_NAME = "Guest";
     private static final String GUEST_FAMILY_NAME = "User";
     private static final String GUEST_USER_NAME = "guest";
-    private static final String GUEST_PASSWORD = "Password123";
 
-    private static final String[] REQUIRED_FIELDS = {USER_NAME, GIVEN_NAME, PASSWORD};
     private static final Object guestAddLock = new Object();
 
-    private static Log log = LogFactory.getLog(UserResource.class);
     static final RequestLogger logger = RequestLogger.LOGGER;
 
-    private final PersonService personService;
     private final ProviderService providerService;
     private final UserService userService;
 
     public UserResource() {
-        personService = Context.getPersonService();
         providerService = Context.getProviderService();
         userService = Context.getUserService();
     }
@@ -164,14 +151,13 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
             guestDetails.put(GIVEN_NAME, GUEST_GIVEN_NAME);
             guestDetails.put(FAMILY_NAME, GUEST_FAMILY_NAME);
             guestDetails.put(USER_NAME, GUEST_USER_NAME);
-            guestDetails.put(PASSWORD, GUEST_PASSWORD);
             synchronized (guestAddLock) {
                 // Fetch again to avoid duplication in case another thread has
                 // added Guest User, but use the UserService for the check to
                 // avoid Hibernate cache issues.
                 User guestUser = userService.getUserByUsername(GUEST_USER_NAME);
                 if (guestUser == null) {
-                    providers.add(createFromSimpleObject(guestDetails));
+                    providers.add(addNewProvider(guestDetails));
                 }
             }
         }
@@ -192,35 +178,19 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
         return list;
     }
 
-    /** Adds a new Provider (with associated User and Person). */
-    private Provider createFromSimpleObject(SimpleObject simpleObject) {
-        checkRequiredFields(simpleObject, REQUIRED_FIELDS);
-
-        // TODO: Localize full name construction
-        String fullName = simpleObject.get(GIVEN_NAME) + " " + simpleObject.get(FAMILY_NAME);
-
-        Person person = new Person();
-        PersonName personName = new PersonName();
-        personName.setGivenName((String) simpleObject.get(GIVEN_NAME));
-        personName.setFamilyName((String) simpleObject.get(FAMILY_NAME));
-        person.addName(personName);
-        person.setGender(UNKNOWN);  // This is required, even though it serves no purpose here.
-        personService.savePerson(person);
-
-        User user = new User();
-        user.setPerson(person);
-        user.setName(fullName);
-        user.setUsername((String) simpleObject.get(USER_NAME));
-        userService.saveUser(user, (String) simpleObject.get(PASSWORD));
+    /** Constructs and saves a new Provider based on the given JSON object. */
+    private Provider addNewProvider(SimpleObject obj) {
+        String givenName = Utils.getRequiredString(obj, GIVEN_NAME);
+        String familyName = Utils.getRequiredString(obj, FAMILY_NAME);
+        String name = (givenName + " " + familyName).trim();
+        if (name.isEmpty()) {
+            throw new InvalidObjectDataException("Both name fields are empty");
+        }
 
         Provider provider = new Provider();
         provider.setCreator(Utils.getAuthenticatedUser());
-        provider.setPerson(person);
-        provider.setName(fullName);
+        provider.setName(name);
         providerService.saveProvider(provider);
-
-        log.info("Created user " + fullName);
-
         return provider;
     }
 
@@ -230,7 +200,6 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
         if (provider != null) {
             jsonForm.add(USER_ID, provider.getUuid());
             jsonForm.add(FULL_NAME, provider.getName());
-
             Person person = provider.getPerson();
             if (person != null) {
                 jsonForm.add(GIVEN_NAME, person.getGivenName());
@@ -270,7 +239,7 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
     }
 
     private Object createInner(SimpleObject simpleObject) throws ResponseException {
-        return providerToJson(createFromSimpleObject(simpleObject));
+        return providerToJson(addNewProvider(simpleObject));
     }
 
     @Override public String getUri(Object instance) {


### PR DESCRIPTION
Previously, we always created a Person and a User for every Provider, and moved back and forth among these three types of objects and three IDs when trying to associate edited or created objects with the user or person who did the editing or creating.  This was awkward and doesn't really fit how OpenMRS intended to store these relationships.

This PR clears that up.  Providers stand on their own, and correspond to the "users" we see on the client.  Providers can be referenced as the `orderer` on an order, or as the provider who took the observations in an encounter via the `encounter_provider` association table.

Users in OpenMRS are entities that have OpenMRS usernames and passwords.  This corresponds to the OpenMRS username and password configured in the client.  The `creator` and `changed_by` fields now contain a user that corresponds to the OpenMRS login, not a user derived by constructing an association with a provider.

This makes relationships simpler and easier to maintain, as the database invariants designed for OpenMRS protect the integrity of these relationships.  This also paves the way to easily clear out all the actions performed during a test using a test account (an OpenMRS test user).