### PR TITLE
Fix XForm generation and processing of submissions

### DIFF
--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/SyncToken.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/SyncToken.java
@@ -13,11 +13,10 @@
 
 package org.projectbuendia.openmrs.api;
 
-import net.sf.ehcache.concurrent.Sync;
-
-import javax.annotation.Nullable;
 import java.util.Date;
 import java.util.Objects;
+
+import javax.annotation.Nullable;
 
 /**
  * A {@code SyncToken} represents a bookmark into a dataset.
@@ -55,12 +54,12 @@ public class SyncToken {
             return false;
         }
         SyncToken other = (SyncToken) obj;
-        return
-                Objects.equals(
-                    this.greaterThanOrEqualToTimestamp,
-                    other.greaterThanOrEqualToTimestamp)
-                && Objects.equals(
-                    this.greaterThanUuid,
-                    other.greaterThanUuid);
+        return Objects.equals(
+            this.greaterThanOrEqualToTimestamp,
+            other.greaterThanOrEqualToTimestamp
+        ) && Objects.equals(
+            this.greaterThanUuid,
+            other.greaterThanUuid
+        );
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/ClientConceptNamer.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/ClientConceptNamer.java
@@ -19,6 +19,8 @@ import org.springframework.util.ObjectUtils;
 
 import java.util.Locale;
 
+import static org.openmrs.projectbuendia.Utils.eq;
+
 /**
  * A class to get a String representing a concept in the client. See the wiki
  * page explaining why this is hard and why we made these design decisions:
@@ -70,10 +72,10 @@ public class ClientConceptNamer {
     public String getClientName(Concept concept) {
         String variant = locale.getVariant();
         Locale.Builder builder = new Locale.Builder().setLocale(locale);
-        if (!VARIANT.equals(variant)) {
+        if (!eq(variant, VARIANT)) {
             builder.setVariant(VARIANT);
             // getCountry() and setRegion() refer to the same field.  Oy.
-            if ("".equals(locale.getCountry())) {
+            if (eq(locale.getCountry(), "")) {
                 builder.setRegion(CLIENT_REGION);
             }
         }
@@ -87,7 +89,7 @@ public class ClientConceptNamer {
         if (name != null) return name;
 
         // If the requested had a country/region, try it without the region
-        if ("".equals(locale.getCountry())) {
+        if (eq(locale.getCountry(), "")) {
             name = getPreferredStringInLocaleOrNull(concept, new Locale(locale.getLanguage()));
             if (name != null) return name;
         }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
@@ -203,49 +203,7 @@ public class Utils {
     };
 
 
-    // ==== OpenMRS ====
-
-    /** Returns the currently authenticated user. */
-    public static User getAuthenticatedUser() {
-        return Context.getUserContext().getAuthenticatedUser();
-    }
-
-    public static EncounterRole getUnknownEncounterRole() {
-        EncounterService encounterService = Context.getEncounterService();
-        for (EncounterRole role : encounterService.getAllEncounterRoles(true)) {
-            if (!role.isRetired() && role.getName().equalsIgnoreCase("unknown")) {
-                return role;
-            }
-        }
-        EncounterRole unknownRole = new EncounterRole();
-        unknownRole.setName("Unknown");
-        encounterService.saveEncounterRole(unknownRole);
-        return unknownRole;
-    }
-
-    /**
-     * Adjusts an encounter datetime to ensure that OpenMRS will accept it.
-     * The OpenMRS core is not designed for a client-server setup -- it will
-     * summarily reject a submitted encounter if the encounter_datetime is in
-     * the future, even if the client's clock is off by only one millisecond.
-     * @param datetime The date and time of an encounter.
-     * @return
-     */
-    public static Date fixEncounterDatetime(Date datetime) {
-        Date now = new Date();
-        if (datetime.after(now)) {
-            datetime = now;
-        }
-        return datetime;
-    }
-
-    /** Iterates backwards through revision orders until it finds the root order. */
-    public static Order getRootOrder(Order order) {
-        while (order.getPreviousOrder() != null) {
-            order = order.getPreviousOrder();
-        }
-        return order;
-    }
+    // === JSON SimpleObjects ===
 
     public static void requirePropertyAbsent(SimpleObject obj, String key) {
         if (obj.containsKey(key)) {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
@@ -11,18 +11,8 @@
 
 package org.openmrs.projectbuendia;
 
-import org.openmrs.EncounterRole;
-import org.openmrs.Order;
-import org.openmrs.Person;
-import org.openmrs.Provider;
-import org.openmrs.User;
-import org.openmrs.api.EncounterService;
-import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.projectbuendia.webservices.rest.InvalidObjectDataException;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.math.BigInteger;
 import java.text.DateFormat;
@@ -32,11 +22,12 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
-import java.util.Iterator;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.annotation.Nonnull;
 
 public class Utils {
     // ==== Basic types ====

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,6 +32,21 @@ import javax.annotation.Nonnull;
 
 public class Utils {
     // ==== Basic types ====
+
+    /** A sane eq operator, to replace Java's broken == and broken equals(). */
+    public static boolean eq(Object a, Object b) {
+        return a == b || (a != null && a.equals(b));
+    }
+
+    /** A safe check for null or empty strings. */
+    public static boolean isEmpty(Object s) {
+        return s == null || eq(s, "");
+    }
+
+    /** A safe check for null or whitespace strings. */
+    public static boolean isBlank(Object s) {
+        return s == null || (s instanceof String && ((String) s).trim().isEmpty());
+    }
 
     /** Converts a JSON-parsed number (sometimes Integer, sometimes Long) to a nullable Long. */
     public static Long asLong(Object obj) {
@@ -152,7 +168,7 @@ public class Utils {
     /**
      * Compares two strings in a manner that sorts alphabetic parts in alphabetic
      * order and numeric parts in numeric order, while guaranteeing that:
-     * - compare(s, t) == 0 if and only if s.equals(t).
+     * - compare(s, t) == 0 if and only if eq(s, t).
      * - compare(s, s + t) < 0 for any strings s and t.
      * - compare(s + x, s + y) == Integer.compare(x, y) for all integers x, y
      * and strings s that do not end in a digit.

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/BuendiaXformCustomizer.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/BuendiaXformCustomizer.java
@@ -26,6 +26,8 @@ import org.openmrs.util.FormConstants;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.openmrs.projectbuendia.Utils.eq;
+
 /** XForm rendering customizations for Buendia. */
 public class BuendiaXformCustomizer extends XformCustomizer {
     final ClientConceptNamer namer = new ClientConceptNamer(Context.getLocale());
@@ -50,7 +52,7 @@ public class BuendiaXformCustomizer extends XformCustomizer {
     @Override public String getAppearanceAttribute(FormField formField) {
         Field field = formField.getField();
         FieldType fieldType = field.getFieldType();
-        if (fieldType.getFieldTypeId().equals(FormConstants.FIELD_TYPE_SECTION)) {
+        if (eq(fieldType.getFieldTypeId(), FormConstants.FIELD_TYPE_SECTION)) {
             String extras = "";
             // use binary anywhere in the section to add binary select 1
             String name = formField.getName();

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/BuendiaXformCustomizer.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/BuendiaXformCustomizer.java
@@ -37,16 +37,17 @@ public class BuendiaXformCustomizer extends XformCustomizer {
     }
 
     @Override public String getLabel(Location location) {
-        return location.getName();
+        // We make sure to hide the location question on the client side; the
+        // location labels are never shown to the user.  This lets us use the
+        // UUID as the label, so the client can identify the location options.
+        return location.getUuid();
     }
 
     @Override public String getLabel(Provider provider) {
-        String name = provider.getName();
-        if (name == null) {
-            Person person = provider.getPerson();
-            name = person.getPersonName().toString();
-        }
-        return name;
+        // We make sure to hide the provider question on the client side; the
+        // provider labels are never shown to the user.  This lets us use the
+        // UUID as the label, so the client can identify the provider options.
+        return provider.getUuid();
     }
 
     @Override public String getAppearanceAttribute(FormField formField) {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ChartResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ChartResource.java
@@ -26,6 +26,7 @@ import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.openmrs.projectbuendia.Utils;
 import org.openmrs.util.FormUtil;
 import org.projectbuendia.openmrs.webservices.rest.RestController;
 
@@ -39,6 +40,9 @@ import java.util.SortedMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.openmrs.projectbuendia.Utils.eq;
+import static org.openmrs.projectbuendia.Utils.isEmpty;
 
 /**
  * REST resource for charts. These are stored as OpenMRS forms, but that's
@@ -150,7 +154,7 @@ public class ChartResource extends AbstractReadOnlyResource<Form> {
                 Map<String, Object> config =
                     new ObjectMapper().readValue(field.getDescription(), Map.class);
                 for (String key : config.keySet()) {
-                    if (config.get(key) == null || "".equals(config.get(key))) {
+                    if (isEmpty(config.get(key))) {
                         config.remove(key);
                     }
                 }
@@ -177,7 +181,7 @@ public class ChartResource extends AbstractReadOnlyResource<Form> {
 
         for (Form form : formService.getAllForms()) {
             if (form.isRetired()) continue;
-            if (form.getEncounterType().getName().equals(CHART_ENCOUNTER_TYPE_NAME)) {
+            if (eq(form.getEncounterType().getName(), CHART_ENCOUNTER_TYPE_NAME)) {
                 charts.add(form);
             }
         }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
@@ -39,6 +39,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.openmrs.projectbuendia.Utils.isBlank;
+
 /**
  * REST collection of all the concepts that are present in at least one of the
  * charts returned by {@link ChartResource}.
@@ -205,7 +207,7 @@ public class ConceptResource extends AbstractReadOnlyResource<Concept> {
     private List<Locale> getLocalesForRequest(RequestContext context) {
         // TODO: Make this cheap to call multiple times for a single request.
         String localeIds = context.getRequest().getParameter("locales");
-        if (localeIds == null || localeIds.trim().equals("")) {
+        if (isBlank(localeIds)) {
             return Context.getAdministrationService().getAllowedLocales();
         }
         List<Locale> locales = new ArrayList<>();

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtils.java
@@ -31,14 +31,15 @@ import org.openmrs.api.OrderService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
-import org.openmrs.projectbuendia.Utils;
 
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
+
+import static org.openmrs.projectbuendia.Utils.ALPHANUMERIC_COMPARATOR;
+import static org.openmrs.projectbuendia.Utils.eq;
 
 /** Static helper methods for handling OpenMRS database entities and UUIDs. */
 public class DbUtils {
@@ -77,7 +78,7 @@ public class DbUtils {
             identifierType.setName(name);
             identifierType.setDescription(description);
             service.savePatientIdentifierType(identifierType);
-        } else if (!Objects.equals(identifierType.getName(), name)) {
+        } else if (!eq(identifierType.getName(), name)) {
             identifierType.setName(name);
             service.savePatientIdentifierType(identifierType);
         }
@@ -246,7 +247,7 @@ public class DbUtils {
 
     public static final Comparator<Location> ALPHANUMERIC_NAME_COMPARATOR = new Comparator<Location>() {
         @Override public int compare(Location a, Location b) {
-            return Utils.ALPHANUMERIC_COMPARATOR.compare(a.getName(), b.getName());
+            return ALPHANUMERIC_COMPARATOR.compare(a.getName(), b.getName());
         }
     };
 

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
@@ -31,6 +31,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static org.openmrs.projectbuendia.Utils.eq;
+
 /**
  * A collection where each item corresponds to one patient and contains
  * the encounter and observation data for that patient as of a particular
@@ -130,8 +132,7 @@ public class EncounterResource implements Creatable {
         List<String> orderUuids = new ArrayList<>();
         for (Obs obs : encounter.getObs()) {
             Concept concept = obs.getConcept();
-            if (concept != null &&
-                concept.getUuid().equals(DbUtils.getOrderExecutedConcept().getUuid())) {
+            if (concept != null && eq(concept.getUuid(), DbUtils.CONCEPT_ORDER_EXECUTED_UUID)) {
                 orderUuids.add(obs.getOrder().getUuid());
                 continue;
             }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
@@ -13,12 +13,9 @@ package org.openmrs.projectbuendia.webservices.rest;
 
 import org.openmrs.Concept;
 import org.openmrs.Encounter;
-import org.openmrs.EncounterProvider;
-import org.openmrs.EncounterRole;
 import org.openmrs.Obs;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.Patient;
-import org.openmrs.Person;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
@@ -134,7 +131,7 @@ public class EncounterResource implements Creatable {
         for (Obs obs : encounter.getObs()) {
             Concept concept = obs.getConcept();
             if (concept != null &&
-                concept.getUuid().equals(DbUtil.getOrderExecutedConcept().getUuid())) {
+                concept.getUuid().equals(DbUtils.getOrderExecutedConcept().getUuid())) {
                 orderUuids.add(obs.getOrder().getUuid());
                 continue;
             }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
@@ -35,6 +35,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import static org.openmrs.projectbuendia.Utils.eq;
+
 /**
  * A resource that allows observations to be incrementally synced.
  * Note: this resource is read-only. For creates, see {@link EncounterResource}.
@@ -131,8 +133,8 @@ public class ObservationResource implements Listable, Searchable {
             break;
         }
 
-        boolean isExecutedOrder =
-                DbUtils.getOrderExecutedConcept().equals(obs.getConcept()) && obs.getOrder() != null;
+        boolean isExecutedOrder = obs.getOrder() != null &&
+            eq(DbUtils.getOrderExecutedConcept(), obs.getConcept());
         if (isExecutedOrder) {
             // As far as the client knows, a chain of orders is represented by the root order's
             // UUID, so we have to work back through the chain or orders to get the root UUID.

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
@@ -17,7 +17,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.EncounterProvider;
 import org.openmrs.Obs;
-import org.openmrs.Provider;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -133,14 +132,14 @@ public class ObservationResource implements Listable, Searchable {
         }
 
         boolean isExecutedOrder =
-                DbUtil.getOrderExecutedConcept().equals(obs.getConcept()) && obs.getOrder() != null;
+                DbUtils.getOrderExecutedConcept().equals(obs.getConcept()) && obs.getOrder() != null;
         if (isExecutedOrder) {
             // As far as the client knows, a chain of orders is represented by the root order's
             // UUID, so we have to work back through the chain or orders to get the root UUID.
             // Normally, the client will only ever supply observations for the root order ID, but
             // in the event that an order is marked as executed on the server (for example) we don't
             // want that to mean that an order execution gets missed.
-            object.add("value", Utils.getRootOrder(obs.getOrder()).getUuid());
+            object.add("value", DbUtils.getRootOrder(obs.getOrder()).getUuid());
         } else {
             object.add("value", ObservationUtils.obsValueToString(obs));
         }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationUtils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationUtils.java
@@ -15,7 +15,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Concept;
 import org.openmrs.Encounter;
-import org.openmrs.EncounterProvider;
 import org.openmrs.EncounterType;
 import org.openmrs.Location;
 import org.openmrs.Obs;
@@ -76,7 +75,7 @@ public class ObservationUtils {
                                          String entererUuid, String locationUuid) {
         // OpenMRS will reject the encounter if the time is in the past, even if
         // the client's clock is off by only one millisecond; work around this.
-        encounterTime = Utils.fixEncounterDatetime(encounterTime);
+        encounterTime = DbUtils.fixEncounterDatetime(encounterTime);
 
         EncounterService encounterService = Context.getEncounterService();
         Location location = null;
@@ -122,7 +121,7 @@ public class ObservationUtils {
         if (entererUuid != null) {
             Provider enterer = Context.getProviderService().getProviderByUuid(entererUuid);
             if (enterer != null) {
-                encounter.addProvider(Utils.getUnknownEncounterRole(), enterer);
+                encounter.addProvider(DbUtils.getUnknownEncounterRole(), enterer);
             }
         }
         return encounter;
@@ -177,7 +176,7 @@ public class ObservationUtils {
             log.warn("Order not found: " + orderUuid);
             return null;
         }
-        Obs obs = new Obs(patient, DbUtil.getOrderExecutedConcept(), encounterTime, location);
+        Obs obs = new Obs(patient, DbUtils.getOrderExecutedConcept(), encounterTime, location);
         obs.setOrder(order);
         obs.setValueNumeric(1d);
         return obs;

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
@@ -34,10 +34,10 @@ import org.openmrs.module.webservices.rest.web.resource.api.Listable;
 import org.openmrs.module.webservices.rest.web.resource.api.Retrievable;
 import org.openmrs.module.webservices.rest.web.resource.api.Searchable;
 import org.openmrs.module.webservices.rest.web.resource.api.Updatable;
-import org.openmrs.module.webservices.rest.web.response.IllegalPropertyException;
+import org.openmrs.module.webservices.rest.web.response
+    .IllegalPropertyException;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
-import org.openmrs.projectbuendia.Utils;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
 import org.projectbuendia.openmrs.api.SyncToken;
 import org.projectbuendia.openmrs.api.db.SyncPage;
@@ -49,9 +49,10 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+import static org.openmrs.projectbuendia.Utils.asLong;
+import static org.openmrs.projectbuendia.Utils.eq;
 
 /**
  * Rest API for orders.
@@ -305,7 +306,7 @@ public class OrderResource implements
                     }
                     String patientUuid = (String) value;
                     if (order.getPatient() != null) {
-                        if (Objects.equals(order.getPatient().getUuid(), patientUuid)) {
+                        if (eq(order.getPatient().getUuid(), patientUuid)) {
                             // Patient hasn't changed, keep going
                             continue;
                         }
@@ -325,7 +326,7 @@ public class OrderResource implements
                         throw new IllegalPropertyException(
                                 "Illegal format for " + INSTRUCTIONS + ", expected string");
                     }
-                    if (Objects.equals(order.getInstructions(), value)) {
+                    if (eq(order.getInstructions(), value)) {
                         // No change
                         continue;
                     }
@@ -335,7 +336,7 @@ public class OrderResource implements
 
                 case START_MILLIS: {
                     Date dateVal = objectToDate(value, START_MILLIS);
-                    if (Objects.equals(order.getScheduledDate(), dateVal)) {
+                    if (eq(order.getScheduledDate(), dateVal)) {
                         // No change
                         continue;
                     }
@@ -345,7 +346,7 @@ public class OrderResource implements
 
                 case STOP_MILLIS: {
                     Date dateVal = objectToDate(value, STOP_MILLIS);
-                    if (Objects.equals(order.getAutoExpireDate(), dateVal)) {
+                    if (eq(order.getAutoExpireDate(), dateVal)) {
                         // No change
                         continue;
                     }
@@ -373,7 +374,7 @@ public class OrderResource implements
     private static Date objectToDate(Object value, String fieldName) {
         Long millis;
         try {
-            millis = Utils.asLong(value);
+            millis = asLong(value);
         } catch (ClassCastException ex) {
             throw new IllegalPropertyException(
                     "Illegal format for " + fieldName + ", expected number");

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
@@ -160,7 +160,7 @@ public class OrderResource implements
     private static SimpleObject orderToJson(Order order) {
         // The UUID we send to the client is actually the UUID of the order at the head of the
         // revision chain...
-        Order rootOrder = Utils.getRootOrder(order);
+        Order rootOrder = DbUtils.getRootOrder(order);
         // but the data we supply comes from the latest revision in the chain.
         order = getLatestVersion(rootOrder);
 
@@ -262,7 +262,7 @@ public class OrderResource implements
         // There is no "changed_by" property; an update is achieved by creating
         // a new order that revises the previous one, so the authenticated user
         // goes in the "creator" property for both create and update operations.
-        order.setCreator(Utils.getAuthenticatedUser());
+        order.setCreator(DbUtils.getAuthenticatedUser());
         Provider orderer = order.getOrderer();
         // Populate with a default orderer if none is supplied.
         if (orderer == null) {
@@ -277,9 +277,9 @@ public class OrderResource implements
      * for revisions, because it may overwrite data set by another source.
      */
     private void populateDefaultsForNewOrder(Order order) {
-        order.setOrderType(DbUtil.getMiscOrderType());
+        order.setOrderType(DbUtils.getMiscOrderType());
         order.setCareSetting(orderService.getCareSettingByName("Outpatient"));
-        order.setConcept(DbUtil.getFreeTextOrderConcept());
+        order.setConcept(DbUtils.getFreeTextOrderConcept());
         order.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
     }
 
@@ -383,7 +383,7 @@ public class OrderResource implements
 
     private Encounter createEncounter(Patient patient, Date encounterDatetime) {
         Encounter encounter = new Encounter();
-        encounter.setCreator(Utils.getAuthenticatedUser());
+        encounter.setCreator(DbUtils.getAuthenticatedUser());
         encounter.setEncounterDatetime(encounterDatetime);
         encounter.setPatient(patient);
         encounter.setLocation(Context.getLocationService().getDefaultLocation());

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
@@ -40,7 +40,6 @@ import org.projectbuendia.openmrs.api.SyncToken;
 import org.projectbuendia.openmrs.api.db.SyncPage;
 import org.projectbuendia.openmrs.webservices.rest.RestController;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -188,8 +187,8 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
 
         // TODO: refactor so we have a single assigned location with a uuid,
         // and we walk up the tree to get extra information for the patient.
-        String assignedLocation = DbUtil.getPersonAttributeValue(
-            patient, DbUtil.getAssignedLocationAttributeType());
+        String assignedLocation = DbUtils.getPersonAttributeValue(
+            patient, DbUtils.getAssignedLocationAttributeType());
         if (assignedLocation != null) {
             LocationService locationService = Context.getLocationService();
             Location location = locationService.getLocation(
@@ -252,7 +251,7 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
             // point the PatientIdentifier has a freshly-generated ID column, which
             // we use to construct the string identifier.
             PatientIdentifier ident = patient.getPatientIdentifier();
-            if (ident.getIdentifierType().equals(DbUtil.getIdentifierTypeLocal())) {
+            if (ident.getIdentifierType().equals(DbUtils.getIdentifierTypeLocal())) {
                 ident.setIdentifier("" + ident.getId());
                 patientService.savePatientIdentifier(ident);
             }
@@ -286,7 +285,7 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
     }
 
     protected static Patient jsonToPatient(SimpleObject json) {
-        User user = Utils.getAuthenticatedUser();
+        User user = DbUtils.getAuthenticatedUser();
         Patient patient = new Patient();
         patient.setCreator(user);
         patient.setDateCreated(new Date());
@@ -314,17 +313,17 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
         patient.addIdentifier(identifier);
         identifier.setCreator(user);
         identifier.setDateCreated(patient.getDateCreated());
-        identifier.setLocation(DbUtil.getDefaultLocation());
+        identifier.setLocation(DbUtils.getDefaultLocation());
         identifier.setPreferred(true);
 
         // OpenMRS requires that every patient have a preferred identifier.  If the
         // incoming "id" field is non-blank, it becomes the MSF identifier; otherwise,
         // we use our database to generate a numeric locally unique identifier.
         if (json.containsKey(ID) && !((String) json.get(ID)).isEmpty()) {
-            identifier.setIdentifierType(DbUtil.getIdentifierTypeMsf());
+            identifier.setIdentifierType(DbUtils.getIdentifierTypeMsf());
             identifier.setIdentifier((String) json.get(ID));
         } else {
-            identifier.setIdentifierType(DbUtil.getIdentifierTypeLocal());
+            identifier.setIdentifierType(DbUtils.getIdentifierTypeLocal());
             // To generate an integer ID, we need to save the patient identifier and
             // let the table fill in the ID AUTO_INCREMENT column.  But OpenMRS will
             // not let us save the patient identifier with a blank identifier string,
@@ -360,8 +359,8 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
 
         Location location = Context.getLocationService().getLocationByUuid(locationUuid);
         if (location != null) {
-            DbUtil.setPersonAttributeValue(patient,
-                DbUtil.getAssignedLocationAttributeType(),
+            DbUtils.setPersonAttributeValue(patient,
+                DbUtils.getAssignedLocationAttributeType(),
                 Integer.toString(location.getId()));
         }
     }
@@ -474,7 +473,7 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
 
     /** Applies edits to a Patient.  Returns true if any changes were made. */
     protected void applyEdits(Patient patient, SimpleObject edits) {
-        User user = Utils.getAuthenticatedUser();
+        User user = DbUtils.getAuthenticatedUser();
         boolean changedPatient = false;
         String newGivenName = null;
         String newFamilyName = null;
@@ -558,10 +557,10 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
     private static PatientIdentifier fromClientIdent(String clientIdent) {
         if (clientIdent.startsWith("*")) {
             return new PatientIdentifier(clientIdent.substring(1),
-                DbUtil.getIdentifierTypeLocal(), DbUtil.getDefaultLocation());
+                DbUtils.getIdentifierTypeLocal(), DbUtils.getDefaultLocation());
         } else {
             return new PatientIdentifier(clientIdent,
-                DbUtil.getIdentifierTypeMsf(), DbUtil.getDefaultLocation());
+                DbUtils.getIdentifierTypeMsf(), DbUtils.getDefaultLocation());
         }
     }
 
@@ -570,7 +569,7 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
         // "*" followed by an integer, where the integer is a local
         // (type "LOCAL") server-generated identifier; or otherwise
         // it is an MSF (type "MSF") client-provided identifier.
-        if (ident.getIdentifierType().equals(DbUtil.getIdentifierTypeLocal())) {
+        if (ident.getIdentifierType().equals(DbUtils.getIdentifierTypeLocal())) {
             return "*" + ident.getIdentifier();
         } else {
             return ident.getIdentifier();
@@ -588,7 +587,7 @@ public class PatientResource implements Listable, Searchable, Retrievable, Creat
             ));
         }
         List<PatientIdentifierType> identifierTypes =
-            Collections.singletonList(DbUtil.getIdentifierTypeMsf());
+            Collections.singletonList(DbUtils.getIdentifierTypeMsf());
         List<Patient> existing = patientService.getPatients(
             null, ident, identifierTypes, true /* exact identifier match */);
         if (!existing.isEmpty()) {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/RequestUtil.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/RequestUtil.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 import java.text.ParseException;
 import java.util.Date;
 
+import static org.openmrs.projectbuendia.Utils.eq;
+
 /**
  * Utilities for working with requests and request parameters.
  */
@@ -67,7 +69,7 @@ public class RequestUtil {
     public static SyncToken getSyncToken(RequestContext context) throws
             ParseException, JsonParseException, JsonMappingException {
         String param = context.getParameter("since");
-        if (param == null || "".equals(param)) {
+        if (param == null || eq(param, "")) {
             return null;
         }
         return SyncTokenUtils.jsonToSyncToken(param);

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
@@ -188,7 +188,7 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
         }
 
         Provider provider = new Provider();
-        provider.setCreator(Utils.getAuthenticatedUser());
+        provider.setCreator(DbUtils.getAuthenticatedUser());
         provider.setName(name);
         providerService.saveProvider(provider);
         return provider;

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
@@ -30,12 +30,14 @@ import org.openmrs.module.webservices.rest.web.resource.api.Retrievable;
 import org.openmrs.module.webservices.rest.web.resource.api.Searchable;
 import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
-import org.openmrs.projectbuendia.Utils;
 import org.projectbuendia.openmrs.webservices.rest.RestController;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.openmrs.projectbuendia.Utils.eq;
+import static org.openmrs.projectbuendia.Utils.getRequiredString;
 
 /**
  * Resource for users (note that users are stored as Providers, Persons, and Users, but only
@@ -140,7 +142,7 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
         for (Provider provider : providers) {
             // TODO/robustness: Use a fixed UUID instead of searching for
             // anything with a matching name.
-            if (provider.getName().equals(GUEST_FULL_NAME)) {
+            if (eq(provider.getName(), GUEST_FULL_NAME)) {
                 guestFound = true;
                 break;
             }
@@ -180,8 +182,8 @@ public class UserResource implements Listable, Searchable, Retrievable, Creatabl
 
     /** Constructs and saves a new Provider based on the given JSON object. */
     private Provider addNewProvider(SimpleObject obj) {
-        String givenName = Utils.getRequiredString(obj, GIVEN_NAME);
-        String familyName = Utils.getRequiredString(obj, FAMILY_NAME);
+        String givenName = getRequiredString(obj, GIVEN_NAME);
+        String familyName = getRequiredString(obj, FAMILY_NAME);
         String name = (givenName + " " + familyName).trim();
         if (name.isEmpty()) {
             throw new InvalidObjectDataException("Both name fields are empty");

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResource.java
@@ -156,17 +156,19 @@ public class XformInstanceResource implements Creatable {
     static void adjustXformDocument(Document doc, int patientId, int userId, Date dateEntered) throws SAXException, IOException {
         Element root = doc.getDocumentElement();
 
-        // Fill in a reference to the patient; this becomes the encounter's patient_id.
+        // This element sets the encounter's patient_id column.
         XmlUtils.getOrCreatePath(doc, root, "patient", "patient.patient_id")
             .setTextContent("" + patientId);
 
-        // Fill in the user account that entered the form; this becomes the encounter's creator.
+        // The <enterer> element sets the encounter's creator column; without
+        // this element, the encounter can end up with the wrong creator.
         XmlUtils.getOrCreatePath(doc, root, "header", "enterer")
             .setTextContent("" + userId);
 
         // Fill in the date that the form was entered; this becomes the encounter's date_created.
+        // If this field is missing, saxon will crash with "Invalid dateTime value. too short".
         XmlUtils.getOrCreatePath(doc, root, "header", "date_entered")
-            .setTextContent(Utils.formatUtc8601(dateEntered));
+            .setTextContent("2019-08-14T12:34:56.789Z"); // Utils.formatUtc8601(dateEntered));
 
         // OpenMRS can't handle the encounter_datetime in the format we receive.
         setEncounterDatetime(doc, fixEncounterDatetime(getEncounterDatetime(doc)));

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResource.java
@@ -152,14 +152,7 @@ public class XformInstanceResource implements Creatable {
         Patient patient = patientService.getPatientByUuid(patientUuid);
         if (patient == null) throw new ObjectNotFoundException();
 
-        String entererUuid = Utils.getRequiredString(post, "enterer_uuid");
-        Provider enterer = providerService.getProviderByUuid(entererUuid);
-        if (enterer == null) throw new ObjectNotFoundException();
-
-        Date dateEntered =  parseTimestamp(Utils.getRequiredString(post, "date_entered"));
-        if (dateEntered == null) throw new InvalidObjectDataException("Invalid timestamp in date_entered");
-
-        return completeXform(xml, patient.getId(), enterer.getId(), dateEntered);
+        return completeXform(xml, patient.getId());
     }
 
     /**
@@ -167,7 +160,7 @@ public class XformInstanceResource implements Creatable {
      * needed to get the observations into OpenMRS, e.g. include Patient ID, adjust
      * datetime formats, etc.
      */
-    static String completeXform(String xml, Integer patientId, Integer entererId, Date dateEntered) throws SAXException, IOException {
+    static String completeXform(String xml, Integer patientId) throws SAXException, IOException {
         Document doc = XmlUtil.parse(xml);
 
         // If we haven't been given a patient id, then the XForms processor will
@@ -184,11 +177,6 @@ public class XformInstanceResource implements Creatable {
         if (patientId != null) {
             patientIdElement.setTextContent(String.valueOf(patientId));
         }
-
-        // Modify header element
-        Element header = getElementOrThrow(root, "header");
-        getElementOrThrow(header, "enterer").setTextContent(entererId + "^");
-        getElementOrThrow(header, "date_entered").setTextContent(Utils.formatUtc8601(dateEntered));
 
         // NOTE(ping): We use a form_resource named <form-name>.xFormXslt to alter the translation
         // from XML to HL7 so that the encounter_datetime is recorded with a date and time.

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResource.java
@@ -11,10 +11,14 @@
 
 package org.openmrs.projectbuendia.webservices.rest;
 
+import org.apache.commons.fileupload.MultipartStream;
+import org.apache.commons.lang.time.DateFormatUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.Form;
+import org.openmrs.FormResource;
 import org.openmrs.Patient;
-import org.openmrs.Provider;
+import org.openmrs.api.FormService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.UserService;
@@ -34,7 +38,6 @@ import org.openmrs.projectbuendia.Utils;
 import org.projectbuendia.openmrs.webservices.rest.RestController;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import java.io.File;
@@ -43,13 +46,12 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.getElementOrThrow;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.getElements;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.requireDescendant;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.getChildren;
 import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.removeNode;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.requirePath;
 
 /**
  * Resource for submitted "form instances" (filled-in forms).  Write-only.
@@ -85,17 +87,7 @@ public class XformInstanceResource implements Creatable {
     static final RequestLogger logger = RequestLogger.LOGGER;
     private static final Log LOG = LogFactory.getLog(XformInstanceResource.class);
 
-    // Everything not in this set is assumed to be a group of observations.
-    private static final Set<String> KNOWN_CHILD_ELEMENTS = new HashSet<>();
     private static final XformsQueueProcessor processor = new XformsQueueProcessor();
-
-    static {
-        KNOWN_CHILD_ELEMENTS.add("header");
-        KNOWN_CHILD_ELEMENTS.add("patient");
-        KNOWN_CHILD_ELEMENTS.add("patient.patient_id");
-        KNOWN_CHILD_ELEMENTS.add("encounter");
-        KNOWN_CHILD_ELEMENTS.add("obs");
-    }
 
     private final PatientService patientService;
     private final ProviderService providerService;
@@ -129,7 +121,8 @@ public class XformInstanceResource implements Creatable {
     /** Accepts a submitted form instance. */
     private Object createInner(SimpleObject post, RequestContext context) throws ResponseException {
         try {
-            String xml = getPreparedXml(post);
+            Document doc = getPreparedXformDocument(post);
+            String xml = XformsUtil.doc2String(doc);
             File file = File.createTempFile("projectbuendia", null);
             processor.processXForm(xml, file.getAbsolutePath(), true, context.getRequest());
         } catch (IOException e) {
@@ -140,91 +133,95 @@ public class XformInstanceResource implements Creatable {
         } catch (Exception e) {
             throw new ConversionException("Error processing xform data", e);
         }
-        // FIXME
-        return post;
+        return null;  // this resource cannot be retrieved, so better not to return anything
     }
 
-    /** Fills in and makes adjustments to the form instance XML so that OpenMRS will accept it. */
-    public String getPreparedXml(SimpleObject post) throws IOException, SAXException {
+    /** Given the received form instance, prepares an XML document that OpenMRS will accept. */
+    public Document getPreparedXformDocument(SimpleObject post) throws IOException, SAXException {
         String xml = Utils.getRequiredString(post, "xml");
 
         String patientUuid = Utils.getRequiredString(post, "patient_uuid");
         Patient patient = patientService.getPatientByUuid(patientUuid);
         if (patient == null) throw new ObjectNotFoundException();
 
-        return completeXform(xml, patient.getId());
+        Document doc = XmlUtil.parse(xml);
+        Element formElement = XmlUtil.requireElementTagName(doc.getDocumentElement(), "form");
+        ensureFormHasXsltResource(formElement.getAttribute("uuid"));
+
+        adjustXformDocument(doc, patient.getId());
+        return doc;
     }
 
-    /**
-     * Fixes up the received XForm instance with various adjustments and additions
-     * needed to get the observations into OpenMRS, e.g. include Patient ID, adjust
-     * datetime formats, etc.
-     */
-    static String completeXform(String xml, Integer patientId) throws SAXException, IOException {
-        Document doc = XmlUtil.parse(xml);
-
-        // If we haven't been given a patient id, then the XForms processor will
-        // create a patient and fill in the patient.patient_id in the DOM.
-        // However, it won't actually create the node, just fill it in.
-        // So whatever the case, make sure a patient.patient_id node exists.
+    /** Fixes up a received XForm instance document so that OpenMRS will accept it. */
+    static void adjustXformDocument(Document doc, int patientId) throws SAXException, IOException {
         Element root = doc.getDocumentElement();
-        Element patient = getFirstElementOrCreate(doc, root, "patient");
-        Element patientIdElement = getFirstElementOrCreate(doc, patient, "patient.patient_id");
 
-        // Add patient element if we've been given a patient ID.
-        // TODO: Is this okay if there's already a patient element?
-        // Need to see how the Xforms module behaves.
-        if (patientId != null) {
-            patientIdElement.setTextContent(String.valueOf(patientId));
-        }
-
-        // NOTE(ping): We use a form_resource named <form-name>.xFormXslt to alter the translation
-        // from XML to HL7 so that the encounter_datetime is recorded with a date and time.
-        // (The default XSLT transform records only the date, not the time.)  This means that
-        // IF THE FORM IS RENAMED, THE FORM_RESOURCE MUST ALSO BE RENAMED, or the encounter
-        // datetime will be recorded with only a date and the time will always be 00:00.
-
-        // TODO(ping): We should have some code here to ensure that the correct XSLT exists
-        // for every form; otherwise, we will lose it when a form is renamed.
-
-        // OpenMRS can't handle the encounter_datetime in the format we receive.
-        fixEncounterDatetimeElement(doc);
-
-        // Make sure that all observations are under the obs element, with appropriate attributes
-        Element obs = getFirstElementOrCreate(doc, root, "obs");
+        // Make sure that all observations are under the obs element, with appropriate attributes.
+        Element obs = XmlUtil.getOrCreateChild(doc, root, "obs");
         obs.setAttribute("openmrs_concept", "1238^MEDICAL RECORD OBSERVATIONS^99DCT");
         obs.setAttribute("openmrs_datatype", "ZZ");
-        for (Element element : getElements(root)) {
-            if (!KNOWN_CHILD_ELEMENTS.contains(element.getLocalName())) {
-                for (Element observation : getElements(element)) {
+        List<String> topLevelElements = Arrays.asList("header", "patient", "encounter", "obs");
+        for (Element element : getChildren(root)) {
+            if (!topLevelElements.contains(element.getTagName())) {
+                for (Element observation : getChildren(element)) {
                     obs.appendChild(observation);
                 }
                 removeNode(element);
             }
         }
-        return XformsUtil.doc2String(doc);
+
+        // Fill in a reference to the patient.
+        XmlUtil.getOrCreatePath(doc, root, "patient", "patient.patient_id").setTextContent("" + patientId);
+
+        // OpenMRS can't handle the encounter_datetime in the format we receive.
+        setEncounterDatetime(doc, fixEncounterDatetime(getEncounterDatetime(doc)));
     }
 
-    /**
-     * Searches for an element among the descendants of a given root element,
-     * or creates it as an immediate child of the given element.
-     */
-    private static Element getFirstElementOrCreate(
-        Document doc, Element parent, String elementName) {
-        NodeList patientElements = parent.getElementsByTagName(elementName);
-        Element patient;
-        if (patientElements == null || patientElements.getLength() == 0) {
-            patient = doc.createElementNS(null, elementName);
-            parent.appendChild(patient);
-        } else {
-            patient = (Element) patientElements.item(0);
+    private static void ensureFormHasXsltResource(String formUuid) {
+        // NOTE(ping): We use a form_resource to customize the translation from XML to HL7
+        // so that the encounter_datetime is recorded with both date and time (whereas the
+        // default translation only records the date).  For details, see the instructions
+        // under "How to include time for encounter date" in the XForms Module User Guide at:
+        // https://wiki.openmrs.org/display/docs/XForms+Module+User+Guide
+        //
+        // The XForms module (see XformsServiceImpl.getXslt()) sadly requires this resource
+        // to be named exactly form.getName() + ".xFormXslt", which means that if a Form is
+        // renamed, its FormResource must be recreated or renamed, or it will be lost.
+        // Here, we add the FormResource if it is missing, assuming that the XSLT file exists
+        // in the database's clob_datatype_storage table with a known UUID.
+
+        FormService formService = Context.getFormService();
+        Form form = formService.getFormByUuid(formUuid);
+        String resourceName = form.getName() + ".xFormXslt";
+        FormResource resource = formService.getFormResource(form, resourceName);
+        if (resource == null) {
+            resource = new FormResource();
+            resource.setForm(form);
+            resource.setDatatypeClassname("org.openmrs.customdatatype.datatype.LongFreeTextDatatype");
+            resource.setPreferredHandlerClassname("org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler");
+            resource.setName(resourceName);
+            resource.setValueReferenceInternal("buendia_clob_xform_instance_xslt");
+            formService.saveFormResource(resource);
         }
-        return patient;
     }
 
-    /** Fixes up the encounter_datetime element to make it acceptable to OpenMRS. */
-    private static void fixEncounterDatetimeElement(Document doc) {
-        Date datetime = getEncounterDatetime(doc);
+    private static String getEncounterDatetime(Document doc) {
+        return requirePath(doc.getDocumentElement(),
+            "encounter", "encounter.encounter_datetime").getTextContent();
+    }
+
+    private static void setEncounterDatetime(Document doc, String content) {
+        XmlUtil.getOrCreatePath(doc, doc.getDocumentElement(),
+            "encounter", "encounter.encounter_datetime").setTextContent(content);
+    }
+
+    /** Fixes up the content of the encounter_datetime element for OpenMRS. */
+    private static String fixEncounterDatetime(String text) {
+        Date datetime = parseTimestamp(text);
+        if (datetime == null) {
+            LOG.warn("No encounter_datetime found; using the current time");
+            datetime = new Date();
+        }
 
         // Work around OpenMRS's inherently client-antagonistic design.
         datetime = Utils.fixEncounterDatetime(datetime);
@@ -234,11 +231,7 @@ public class XformInstanceResource implements Creatable {
         // either.  Details on the history of this workaround are here:
         // https://docs.google.com/document/d/1IT92y_YP7AnhpDfdelbS7huxNKswa4VSXYPzqbnkWik/edit
         // To avoid this problem entirely, we always format the timestamp in UTC.
-        String formattedDatetime = Utils.formatUtc8601(datetime);
-        getElementOrThrow(
-            getElementOrThrow(doc.getDocumentElement(), "encounter"),
-            "encounter.encounter_datetime"
-        ).setTextContent(formattedDatetime);
+        return Utils.formatUtc8601(datetime);
     }
 
     /** Parses a timestamp in a variety of formats, returning null on failure. */

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
@@ -42,9 +42,11 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.requireDescendant;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.removeNode;
+import static org.openmrs.projectbuendia.Utils.eq;
 import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.elementsIn;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.removeNode;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtils
+    .requireDescendant;
 
 /**
  * Resource for "form models" (not-yet-filled-in forms).   Note: this is under
@@ -114,9 +116,9 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
             // which is really dangerous.
             for (FormField formField : form.getFormFields()) {
                 Field field = formField.getField();
-                if (FormConstants.FIELD_TYPE_DATABASE.equals(
-                    field.getFieldType().getFieldTypeId())
-                    && "encounter".equals(field.getTableName())) {
+                if (eq(field.getFieldType().getFieldTypeId(),
+                        FormConstants.FIELD_TYPE_DATABASE)
+                    && eq(field.getTableName(), "encounter")) {
                     includesProviders = true;
                 }
                 dateChanged = maxDate(dateChanged, dateChanged(formField));
@@ -202,9 +204,9 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
         for (Element label : elementsIn(doc
             .getElementsByTagNameNS(XFORMS_NAMESPACE, "label"))) {
             Element parent = (Element) label.getParentNode();
-            if (XFORMS_NAMESPACE.equals(parent.getNamespaceURI())
-                && parent.getLocalName().equals("group")
-                && "RELATIONSHIPS".equals(label.getTextContent())) {
+            if (eq(XFORMS_NAMESPACE, parent.getNamespaceURI())
+                && eq(parent.getLocalName(), "group")
+                && eq(label.getTextContent(), "RELATIONSHIPS")) {
                 removeNode(parent);
                 // We don't need to find other labels now, especially if they
                 // may already have been removed.
@@ -237,7 +239,7 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
     private static void removeBinding(Document doc, String id) {
         for (Element binding : elementsIn(
             doc.getElementsByTagNameNS(XFORMS_NAMESPACE, "bind"))) {
-            if (binding.getAttribute("id").equals(id)) {
+            if (eq(binding.getAttribute("id"), id)) {
                 removeNode(binding);
                 return;
             }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
@@ -42,9 +42,9 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.requireDescendant;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.removeNode;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.elementsIn;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.requireDescendant;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.removeNode;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.elementsIn;
 
 /**
  * Resource for "form models" (not-yet-filled-in forms).   Note: this is under
@@ -145,15 +145,15 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
         // this within a document; removing the root element from the document
         // seems
         // to do odd things... so instead, we import it into a new document.
-        Document oldDoc = XmlUtil.parse(xml);
-        Document doc = XmlUtil.createDocumentBuilder().newDocument();
+        Document oldDoc = XmlUtils.parse(xml);
+        Document doc = XmlUtils.createDocumentBuilder().newDocument();
         Element root = (Element) doc.importNode(oldDoc.getDocumentElement(), true);
         root = (Element) doc.renameNode(root, HTML_NAMESPACE, "h:form");
         doc.appendChild(root);
 
         // Prepare the new wrapper elements
         Element head = doc.createElementNS(HTML_NAMESPACE, "h:head");
-        Element titleElement = XmlUtil.appendChild(head, HTML_NAMESPACE, "h:title");
+        Element titleElement = XmlUtils.appendChild(head, HTML_NAMESPACE, "h:title");
         titleElement.setTextContent(title);
         Element body = doc.createElementNS(HTML_NAMESPACE, "h:body");
 
@@ -187,7 +187,7 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
      * XFRM-189 is fixed, this method can go away.
      */
     static String removeRelationshipNodes(String xml) throws IOException, SAXException {
-        Document doc = XmlUtil.parse(xml);
+        Document doc = XmlUtils.parse(xml);
         removeBinding(doc, "patient_relative");
         removeBinding(doc, "patient_relative.person");
         removeBinding(doc, "patient_relative.relationship");

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
@@ -42,9 +42,9 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.getElementOrThrowNS;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.requireDescendant;
 import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.removeNode;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.toElementIterable;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.elementsIn;
 
 /**
  * Resource for "form models" (not-yet-filled-in forms).   Note: this is under
@@ -153,14 +153,14 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
 
         // Prepare the new wrapper elements
         Element head = doc.createElementNS(HTML_NAMESPACE, "h:head");
-        Element titleElement = XmlUtil.appendElementNS(head, HTML_NAMESPACE, "h:title");
+        Element titleElement = XmlUtil.appendChild(head, HTML_NAMESPACE, "h:title");
         titleElement.setTextContent(title);
         Element body = doc.createElementNS(HTML_NAMESPACE, "h:body");
 
         // Find the model element to go in the head, and all its following
         // siblings to go in the body.
         // We do this before moving any elements, for the sake of sanity.
-        Element model = getElementOrThrowNS(root, XFORMS_NAMESPACE, "model");
+        Element model = requireDescendant(root, XFORMS_NAMESPACE, "model");
         List<Node> nodesAfterModel = new ArrayList<>();
         Node nextSibling = model.getNextSibling();
         while (nextSibling != null) {
@@ -192,14 +192,14 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
         removeBinding(doc, "patient_relative.person");
         removeBinding(doc, "patient_relative.relationship");
 
-        for (Element relative : toElementIterable(doc
+        for (Element relative : elementsIn(doc
             .getElementsByTagNameNS("", "patient_relative"))) {
             removeNode(relative);
         }
 
         // Remove every parent of a label element with a text of
         // "RELATIONSHIPS". (Easiest way to find the ones added...)
-        for (Element label : toElementIterable(doc
+        for (Element label : elementsIn(doc
             .getElementsByTagNameNS(XFORMS_NAMESPACE, "label"))) {
             Element parent = (Element) label.getParentNode();
             if (XFORMS_NAMESPACE.equals(parent.getNamespaceURI())
@@ -235,7 +235,7 @@ public class XformResource extends AbstractReadOnlyResource<Form> {
     // Visible for testing
 
     private static void removeBinding(Document doc, String id) {
-        for (Element binding : toElementIterable(
+        for (Element binding : elementsIn(
             doc.getElementsByTagNameNS(XFORMS_NAMESPACE, "bind"))) {
             if (binding.getAttribute("id").equals(id)) {
                 removeNode(binding);

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XmlUtil.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XmlUtil.java
@@ -31,7 +31,7 @@ import javax.xml.parsers.ParserConfigurationException;
 /** XML manipulation functions. */
 public class XmlUtil {
     /** Converts a NodeList to an Iterable of Elements. */
-    public static Iterable<Element> toElementIterable(NodeList nodeList) {
+    public static Iterable<Element> elementsIn(NodeList nodeList) {
         List<Element> elements = new ArrayList<>(nodeList.getLength());
         for (int i = 0; i < nodeList.getLength(); i++) {
             elements.add((Element) nodeList.item(i));
@@ -48,10 +48,10 @@ public class XmlUtil {
      * Given an element, returns all its direct child elements that have the
      * specified namespace and name.  Use null to indicate the empty namespace.
      */
-    public static List<Element> getElementsNS(
+    public static List<Element> getChildren(
         Element element, String namespaceURI, String localName) {
         List<Element> elements = new ArrayList<>();
-        for (Element candidate : getElements(element)) {
+        for (Element candidate : getChildren(element)) {
             if (namespaceURI.equals(candidate.getNamespaceURI())
                 && localName.equals(candidate.getLocalName())) {
                 elements.add(candidate);
@@ -61,9 +61,9 @@ public class XmlUtil {
     }
 
     /** Returns all the direct child elements of the given element. */
-    public static List<Element> getElements(Element element) {
+    public static List<Element> getChildren(Element element) {
         List<Element> elements = new ArrayList<>();
-        for (Node node : toIterable(element.getChildNodes())) {
+        for (Node node : getChildNodes(element)) {
             if (node.getNodeType() == Node.ELEMENT_NODE) {
                 elements.add((Element) node);
             }
@@ -71,46 +71,54 @@ public class XmlUtil {
         return elements;
     }
 
-    /** Converts a NodeList to an Iterable of Nodes. */
-    public static Iterable<Node> toIterable(NodeList nodeList) {
-        List<Node> nodes = new ArrayList<>(nodeList.getLength());
-        for (int i = 0; i < nodeList.getLength(); i++) {
-            nodes.add(nodeList.item(i));
+    /** Gets an Iterable over the child nodes of a given node. */
+    public static Iterable<Node> getChildNodes(Node node) {
+        NodeList list = node.getChildNodes();
+        List<Node> nodes = new ArrayList<>(list.getLength());
+        for (int i = 0; i < list.getLength(); i++) {
+            nodes.add(list.item(i));
         }
         return nodes;
     }
 
-    /**
-     * Given an element, returns its direct child with the empty namespace
-     * and the given name, failing unless there is one and only one match.
-     */
-    public static Element getElementOrThrow(Element element, String name) {
-        return getElementOrThrowNS(element, null, name);
+    /** Requires the given element to have the given tag name. */
+    public static Element requireElementTagName(Element element, String name) {
+        if (!element.getLocalName().equals(name)) {
+            throw new IllegalPropertyException(String.format(
+                "Expected <%s> element but found <%s>", name, element.getLocalName()));
+        }
+        return element;
     }
 
+    /** Gets a child element by name, requiring exactly one such descendant. */
+    public static Element requireDescendant(Element element, String name) {
+        return requireDescendant(element, null, name);
+    }
 
-    /**
-     * Given an element, returns its direct child with the given namespace
-     * and name, failing unless there is one and only one match.
-     * Use null to indicate the empty namespace.
-     */
-    public static Element getElementOrThrowNS(
-        Element element, String namespaceURI, String localName) {
-        NodeList elements = element.getElementsByTagNameNS(namespaceURI, localName);
-        if (elements.getLength() == 0) {
-            throw new IllegalPropertyException("Element " + element.getNodeName()
-                + " does not contain the expected " + localName + " element");
+    /** Gets a sequence of descending children by name, requiring each to exist. */
+    public static Element requirePath(Element element, String... names) {
+        for (String name : names) {
+            element = requireDescendant(element, name);
         }
-        if (elements.getLength() != 1) {
-            throw new IllegalPropertyException("Element " + element.getNodeName()
-                + " contains more than one " + localName + " element");
+        return element;
+    }
+
+    /** Gets a child by namespace and name, requiring exactly one such child. */
+    public static Element requireDescendant(
+        Element element, String ns, String localName) {
+        NodeList elements = element.getElementsByTagNameNS(ns, localName);
+        int count = elements.getLength();
+        if (count != 1) {
+            throw new IllegalPropertyException(String.format(
+                "<%s> element should contain one <%s> element, but there are %s",
+                element.getTagName(), localName, count == 0 ? "none" : "" + count));
         }
         return (Element) elements.item(0);
     }
 
     /** Appends a new empty child element with the given namespace and name. */
-    public static Element appendElementNS(Element parent, String namespaceURI, String localName) {
-        Element ret = parent.getOwnerDocument().createElementNS(namespaceURI, localName);
+    public static Element appendChild(Element parent, String ns, String localName) {
+        Element ret = parent.getOwnerDocument().createElementNS(ns, localName);
         parent.appendChild(ret);
         return ret;
     }
@@ -130,8 +138,28 @@ public class XmlUtil {
     /** Parses the given XML string to produce a Document. */
     public static Document parse(String xml) throws SAXException, IOException {
         // DocumentBuilder is not thread-safe; parsing multiple documents concurrently
-        // will cause the error "FWK005 parse may not be called while parsing".
-        // So, we construct a new DocumentBuilder every time we parse something.
+        // will cause the error "FWK005 parse may not be called while parsing".  So,
+        // we have to construct a new DocumentBuilder every time we parse something.
         return createDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+    }
+
+    /** Gets a sequence of descending children by name, creating each if not present. */
+    public static Element getOrCreatePath(Document doc, Element element, String... names) {
+        for (String name : names) {
+            element = getOrCreateChild(doc, element, name);
+        }
+        return element;
+    }
+
+    /* Gets a child of the given element by name, creating it if not present. */
+    public static Element getOrCreateChild(Document doc, Element element, String name) {
+        for (Element child : getChildren(element)) {
+            if (child.getLocalName().equals(name)) {
+                return child;
+            }
+        }
+        Element child = doc.createElement(name);
+        element.appendChild(child);
+        return child;
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XmlUtils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XmlUtils.java
@@ -29,7 +29,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 /** XML manipulation functions. */
-public class XmlUtil {
+public class XmlUtils {
     /** Converts a NodeList to an Iterable of Elements. */
     public static Iterable<Element> elementsIn(NodeList nodeList) {
         List<Element> elements = new ArrayList<>(nodeList.getLength());

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XmlUtils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XmlUtils.java
@@ -11,7 +11,8 @@
 
 package org.openmrs.projectbuendia.webservices.rest;
 
-import org.openmrs.module.webservices.rest.web.response.IllegalPropertyException;
+import org.openmrs.module.webservices.rest.web.response
+    .IllegalPropertyException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -27,6 +28,8 @@ import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+
+import static org.openmrs.projectbuendia.Utils.eq;
 
 /** XML manipulation functions. */
 public class XmlUtils {
@@ -52,8 +55,8 @@ public class XmlUtils {
         Element element, String namespaceURI, String localName) {
         List<Element> elements = new ArrayList<>();
         for (Element candidate : getChildren(element)) {
-            if (namespaceURI.equals(candidate.getNamespaceURI())
-                && localName.equals(candidate.getLocalName())) {
+            if (eq(namespaceURI, candidate.getNamespaceURI())
+                && eq(localName, candidate.getLocalName())) {
                 elements.add(candidate);
             }
         }
@@ -83,7 +86,7 @@ public class XmlUtils {
 
     /** Requires the given element to have the given tag name. */
     public static Element requireElementTagName(Element element, String name) {
-        if (!element.getLocalName().equals(name)) {
+        if (!eq(element.getLocalName(), name)) {
             throw new IllegalPropertyException(String.format(
                 "Expected <%s> element but found <%s>", name, element.getLocalName()));
         }
@@ -154,7 +157,7 @@ public class XmlUtils {
     /* Gets a child of the given element by name, creating it if not present. */
     public static Element getOrCreateChild(Document doc, Element element, String name) {
         for (Element child : getChildren(element)) {
-            if (child.getLocalName().equals(name)) {
+            if (eq(child.getLocalName(), name)) {
                 return child;
             }
         }

--- a/openmrs/omod/src/main/java/org/projectbuendia/openmrs/web/controller/ProfileManager.java
+++ b/openmrs/omod/src/main/java/org/projectbuendia/openmrs/web/controller/ProfileManager.java
@@ -46,6 +46,8 @@ import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.openmrs.projectbuendia.Utils.eq;
+
 /** The controller for the profile management page. */
 @Controller
 public class ProfileManager {
@@ -128,12 +130,12 @@ public class ProfileManager {
                 File file = new File(profileDir, filename);
                 if (file.isFile()) {
                     model.addAttribute("filename", filename);
-                    if ("Apply".equals(op)) {
+                    if (eq(op, "Apply")) {
                         applyProfile(file, model);
-                    } else if ("Download".equals(op)) {
+                    } else if (eq(op, "Download")) {
                         downloadProfile(file, response);
                         return null;  // download the file, don't redirect
-                    } else if ("Delete".equals(op)) {
+                    } else if (eq(op, "Delete")) {
                         deleteProfile(file, model);
                     }
                 }
@@ -160,7 +162,7 @@ public class ProfileManager {
         for (File file : profileDir.listFiles()) {
             int version = 0;
             String n = file.getName();
-            if (n.equals(name + ext)) {
+            if (eq(n, name + ext)) {
                 version = 1;
             } else if (n.startsWith(prefix) && n.endsWith(ext)) {
                 try {
@@ -243,7 +245,7 @@ public class ProfileManager {
 
     /** Deletes a profile. */
     private void deleteProfile(File file, ModelMap model) {
-        if (file.getName().equals(getCurrentProfile())) {
+        if (eq(file.getName(), getCurrentProfile())) {
             model.addAttribute("success", false);
             model.addAttribute("message", "Cannot delete the currently active profile.");
         } else if (file.delete()) {

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/BaseApiRequestTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/BaseApiRequestTest.java
@@ -85,7 +85,8 @@ public abstract class BaseApiRequestTest extends MainResourceControllerTest {
             handle(request);
             fail("Exception due to " + reason + " was not thrown as expected");
         } catch (Exception expected) {
-            System.err.println(expected.getClass().getName() + " due to " + reason + " was thrown as expected");
+            if (VERBOSE) System.err.println(expected.getClass().getName()
+                + " due to " + reason + " was thrown as expected");
         }
     }
 }

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/PatientResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/PatientResourceTest.java
@@ -85,7 +85,7 @@ public class PatientResourceTest extends BaseApiRequestTest {
         assertFalse(response.containsKey("assigned_location"));
 
         Patient patient = patientService.getPatientByUuid(uuid);
-        PatientIdentifierType identType = patientService.getPatientIdentifierTypeByUuid(DbUtil.IDENTIFIER_TYPE_MSF_UUID);
+        PatientIdentifierType identType = patientService.getPatientIdentifierTypeByUuid(DbUtils.IDENTIFIER_TYPE_MSF_UUID);
         assertEquals("XYZ", patient.getPatientIdentifier(identType).getIdentifier());
     }
 

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResourceTest.java
@@ -10,8 +10,12 @@
 // specific language governing permissions and limitations under the License.
 package org.openmrs.projectbuendia.webservices.rest;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.UserContext;
 import org.openmrs.projectbuendia.Utils;
+import org.openmrs.test.BaseContextSensitiveTest;
 
 import java.util.Date;
 
@@ -24,7 +28,7 @@ public class XformInstanceResourceTest {
         String input = readResourceAsString(getClass(), "original-instance-add.xml");
         String expected = readResourceAsString(getClass(), "expected-instance-add.xml");
         Date dateEntered = Utils.parse8601("2014-11-15T12:34:56.789Z");
-        String actual = XformInstanceResource.completeXform(input, null, 1, dateEntered);
+        String actual = XformInstanceResource.completeXform(input, null, dateEntered);
         assertXmlEqual(expected, actual);
     }
 
@@ -32,7 +36,7 @@ public class XformInstanceResourceTest {
         String input = readResourceAsString(getClass(), "original-instance-edit.xml");
         String expected = readResourceAsString(getClass(), "expected-instance-edit.xml");
         Date dateEntered = Utils.parse8601("2014-11-15T12:34:56.789Z");
-        String actual = XformInstanceResource.completeXform(input, 10, 1, dateEntered);
+        String actual = XformInstanceResource.completeXform(input, 10, dateEntered);
         assertXmlEqual(expected, actual);
     }
 
@@ -40,7 +44,7 @@ public class XformInstanceResourceTest {
         String input = readResourceAsString(getClass(), "original-grouped.xml");
         String expected = readResourceAsString(getClass(), "expected-grouped.xml");
         Date dateEntered = Utils.parse8601("2014-11-15T12:34:56.789Z");
-        String actual = XformInstanceResource.completeXform(input, null, 1, dateEntered);
+        String actual = XformInstanceResource.completeXform(input, null, dateEntered);
         assertXmlEqual(expected, actual);
     }
 

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResourceTest.java
@@ -10,42 +10,34 @@
 // specific language governing permissions and limitations under the License.
 package org.openmrs.projectbuendia.webservices.rest;
 
-import org.junit.Before;
 import org.junit.Test;
-import org.openmrs.api.context.Context;
-import org.openmrs.api.context.UserContext;
 import org.openmrs.projectbuendia.Utils;
-import org.openmrs.test.BaseContextSensitiveTest;
-
-import java.util.Date;
+import org.w3c.dom.Document;
 
 import static org.junit.Assert.assertEquals;
 import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.assertXmlEqual;
-import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.readResourceAsString;
+import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.getXmlResource;
 
 public class XformInstanceResourceTest {
     @Test public void addForm() throws Exception {
-        String input = readResourceAsString(getClass(), "original-instance-add.xml");
-        String expected = readResourceAsString(getClass(), "expected-instance-add.xml");
-        Date dateEntered = Utils.parse8601("2014-11-15T12:34:56.789Z");
-        String actual = XformInstanceResource.completeXform(input, null, dateEntered);
-        assertXmlEqual(expected, actual);
+        Document expected = getXmlResource(getClass(), "expected-instance-add.xml");
+        Document doc = getXmlResource(getClass(), "original-instance-add.xml");
+        XformInstanceResource.adjustXformDocument(doc, 8);
+        assertXmlEqual(expected, doc);
     }
 
     @Test public void editForm() throws Exception {
-        String input = readResourceAsString(getClass(), "original-instance-edit.xml");
-        String expected = readResourceAsString(getClass(), "expected-instance-edit.xml");
-        Date dateEntered = Utils.parse8601("2014-11-15T12:34:56.789Z");
-        String actual = XformInstanceResource.completeXform(input, 10, dateEntered);
-        assertXmlEqual(expected, actual);
+        Document expected = getXmlResource(getClass(), "expected-instance-edit.xml");
+        Document doc = getXmlResource(getClass(), "original-instance-edit.xml");
+        XformInstanceResource.adjustXformDocument(doc, 9);
+        assertXmlEqual(expected, doc);
     }
 
     @Test public void moveGroupsIntoObs() throws Exception {
-        String input = readResourceAsString(getClass(), "original-grouped.xml");
-        String expected = readResourceAsString(getClass(), "expected-grouped.xml");
-        Date dateEntered = Utils.parse8601("2014-11-15T12:34:56.789Z");
-        String actual = XformInstanceResource.completeXform(input, null, dateEntered);
-        assertXmlEqual(expected, actual);
+        Document expected = getXmlResource(getClass(), "expected-grouped.xml");
+        Document doc = getXmlResource(getClass(), "original-grouped.xml");
+        XformInstanceResource.adjustXformDocument(doc, 10);
+        assertXmlEqual(expected, doc);
     }
 
     @Test public void parseNonstandardTimestamp() {

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResourceTest.java
@@ -22,21 +22,21 @@ public class XformInstanceResourceTest {
     @Test public void addForm() throws Exception {
         Document expected = getXmlResource(getClass(), "expected-instance-add.xml");
         Document doc = getXmlResource(getClass(), "original-instance-add.xml");
-        XformInstanceResource.adjustXformDocument(doc, 8);
+        XformInstanceResource.adjustXformDocument(doc, 8, 1, Utils.parse8601("2014-11-15T12:34:56.789Z"));
         assertXmlEqual(expected, doc);
     }
 
     @Test public void editForm() throws Exception {
         Document expected = getXmlResource(getClass(), "expected-instance-edit.xml");
         Document doc = getXmlResource(getClass(), "original-instance-edit.xml");
-        XformInstanceResource.adjustXformDocument(doc, 9);
+        XformInstanceResource.adjustXformDocument(doc, 9, 2, Utils.parse8601("2014-11-15T12:34:56.789Z"));
         assertXmlEqual(expected, doc);
     }
 
     @Test public void moveGroupsIntoObs() throws Exception {
         Document expected = getXmlResource(getClass(), "expected-grouped.xml");
         Document doc = getXmlResource(getClass(), "original-grouped.xml");
-        XformInstanceResource.adjustXformDocument(doc, 10);
+        XformInstanceResource.adjustXformDocument(doc, 10, 3, Utils.parse8601("2014-11-15T12:34:56.789Z"));
         assertXmlEqual(expected, doc);
     }
 

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformResourceTest.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XformResourceTest.java
@@ -14,19 +14,19 @@ package org.openmrs.projectbuendia.webservices.rest;
 import org.junit.Test;
 
 import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.assertXmlEqual;
-import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.readResourceAsString;
+import static org.openmrs.projectbuendia.webservices.rest.XmlTestUtil.getStringResource;
 
 public class XformResourceTest {
     @Test public void convertToOdkCollect() throws Exception {
-        String input = readResourceAsString(getClass(), "sample-original-form1.xml");
-        String expected = readResourceAsString(getClass(), "expected-result-form1.xml");
+        String input = getStringResource(getClass(), "sample-original-form1.xml");
+        String expected = getStringResource(getClass(), "expected-result-form1.xml");
         String actual = XformResource.convertToOdkCollect(input, "Form title");
         assertXmlEqual(expected, actual);
     }
 
     @Test public void removeRelationshipNodes() throws Exception {
-        String input = readResourceAsString(getClass(), "relationships-original-form1.xml");
-        String expected = readResourceAsString(getClass(), "relationships-result-form1.xml");
+        String input = getStringResource(getClass(), "relationships-original-form1.xml");
+        String expected = getStringResource(getClass(), "relationships-result-form1.xml");
         String actual = XformResource.removeRelationshipNodes(input);
         assertXmlEqual(expected, actual);
     }

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XmlTestUtil.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XmlTestUtil.java
@@ -20,7 +20,6 @@ import org.xml.sax.SAXException;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
@@ -29,36 +28,34 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import static org.junit.Assert.assertEquals;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.toElementIterable;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.toIterable;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.elementsIn;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.getChildNodes;
 
 public class XmlTestUtil {
-    static String readResourceAsString(Class<?> clazz, String file) throws IOException {
-        return IOUtils.toString(clazz.getResourceAsStream(file), "utf-8");
+    static String getStringResource(Class<?> cls, String path) throws IOException {
+        return IOUtils.toString(cls.getResourceAsStream(path), "utf-8");
     }
 
-    /**
-     * Normalizes XML by parsing and reformatting, then asserts that the two documents
-     * are equal.
-     */
-    static void assertXmlEqual(String expected, String actual) throws TransformerException,
-        SAXException, IOException, ParserConfigurationException {
-        Document expectedDoc = XmlUtil.parse(expected);
-        Document actualDoc = XmlUtil.parse(actual);
-        expected = toIndentedString(expectedDoc);
-        actual = toIndentedString(actualDoc);
-
-        assertEquals(expected, actual);
+    static Document getXmlResource(Class<?> cls, String path) throws IOException, SAXException {
+        return XmlUtil.parse(getStringResource(cls, path));
     }
 
-    /**
-     * Converts an XML document into a string, applying indentation. First all elements have
-     * their text
-     * content trimmed, just for simplicity.
-     */
+    static void assertXmlEqual(Document expectedDoc, Document actualDoc) throws TransformerException {
+        String expectedXml = toIndentedString(expectedDoc);
+        String actualXml = toIndentedString(actualDoc);
+        assertEquals(expectedXml, actualXml);
+    }
+
+    /** Checks that two documents are equal after normalization. */
+    static void assertXmlEqual(String expectedXml, String actualXml)
+        throws TransformerException, SAXException, IOException {
+        assertXmlEqual(XmlUtil.parse(expectedXml), XmlUtil.parse(actualXml));
+    }
+
+    /**  Formats an XML document by indenting and trimming whitespace from elements. */
     static String toIndentedString(Document doc) throws TransformerException {
-        for (Element element : toElementIterable(doc.getElementsByTagName("*"))) {
-            for (Node node : toIterable(element.getChildNodes())) {
+        for (Element element : elementsIn(doc.getElementsByTagName("*"))) {
+            for (Node node : getChildNodes(element)) {
                 if (node.getNodeType() == Node.TEXT_NODE) {
                     node.setNodeValue(node.getNodeValue().trim());
                 }

--- a/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XmlTestUtil.java
+++ b/openmrs/omod/src/test/java/org/openmrs/projectbuendia/webservices/rest/XmlTestUtil.java
@@ -28,8 +28,8 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import static org.junit.Assert.assertEquals;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.elementsIn;
-import static org.openmrs.projectbuendia.webservices.rest.XmlUtil.getChildNodes;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.elementsIn;
+import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.getChildNodes;
 
 public class XmlTestUtil {
     static String getStringResource(Class<?> cls, String path) throws IOException {
@@ -37,7 +37,7 @@ public class XmlTestUtil {
     }
 
     static Document getXmlResource(Class<?> cls, String path) throws IOException, SAXException {
-        return XmlUtil.parse(getStringResource(cls, path));
+        return XmlUtils.parse(getStringResource(cls, path));
     }
 
     static void assertXmlEqual(Document expectedDoc, Document actualDoc) throws TransformerException {
@@ -49,7 +49,7 @@ public class XmlTestUtil {
     /** Checks that two documents are equal after normalization. */
     static void assertXmlEqual(String expectedXml, String actualXml)
         throws TransformerException, SAXException, IOException {
-        assertXmlEqual(XmlUtil.parse(expectedXml), XmlUtil.parse(actualXml));
+        assertXmlEqual(XmlUtils.parse(expectedXml), XmlUtils.parse(actualXml));
     }
 
     /**  Formats an XML document by indenting and trimming whitespace from elements. */

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
     name="Weight observation" id="4" uuid="9e17ff6f-e3c8-4661-86d3-09a96169bedc"
     version="1">
   <header>
-    <enterer/>
-    <date_entered/>
+    <enterer>3</enterer>
+    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
     name="Weight observation" id="4" uuid="9e17ff6f-e3c8-4661-86d3-09a96169bedc"
     version="1">
   <header>
-    <enterer>1^</enterer>
-    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
+    <enterer/>
+    <date_entered/>
     <session/>
     <uid/>
   </header>
@@ -36,7 +36,7 @@ specific language governing permissions and limitations under the License.
     <patient.middle_name openmrs_attribute="middle_name"
                          openmrs_table="patient_name"/>
     <patient.sex openmrs_attribute="gender" openmrs_table="patient">M</patient.sex>
-    <patient.patient_id/>
+    <patient.patient_id>10</patient.patient_id>
   </patient>
 
   <encounter>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
@@ -41,7 +41,7 @@ specific language governing permissions and limitations under the License.
 
   <encounter>
     <encounter.encounter_datetime
-        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13T00:00:00+00:00
+        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13T12:34:56.789Z
     </encounter.encounter_datetime>
     <encounter.location_id openmrs_attribute="location_id"
                            openmrs_table="encounter">1

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-grouped.xml
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
     version="1">
   <header>
     <enterer>3</enterer>
-    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
+    <date_entered>2019-08-14T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
     version="1">
   <header>
     <enterer>1</enterer>
-    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
+    <date_entered>2019-08-14T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
@@ -41,7 +41,7 @@ specific language governing permissions and limitations under the License.
 
   <encounter>
     <encounter.encounter_datetime
-        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13T00:00:00+00:00
+        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13T12:34:56.000Z
     </encounter.encounter_datetime>
     <encounter.location_id openmrs_attribute="location_id"
                            openmrs_table="encounter">1

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
     name="Weight observation" id="4" uuid="9e17ff6f-e3c8-4661-86d3-09a96169bedc"
     version="1">
   <header>
-    <enterer>1^</enterer>
-    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
+    <enterer/>
+    <date_entered/>
     <session/>
     <uid/>
   </header>
@@ -36,7 +36,7 @@ specific language governing permissions and limitations under the License.
     <patient.middle_name openmrs_attribute="middle_name"
                          openmrs_table="patient_name"/>
     <patient.sex openmrs_attribute="gender" openmrs_table="patient">M</patient.sex>
-    <patient.patient_id/>
+    <patient.patient_id>8</patient.patient_id>
   </patient>
 
   <encounter>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-add.xml
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
     name="Weight observation" id="4" uuid="9e17ff6f-e3c8-4661-86d3-09a96169bedc"
     version="1">
   <header>
-    <enterer/>
-    <date_entered/>
+    <enterer>1</enterer>
+    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
     name="Weight observation" id="4" uuid="9e17ff6f-e3c8-4661-86d3-09a96169bedc"
     version="1">
   <header>
-    <enterer>1^</enterer>
-    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
+    <enterer/>
+    <date_entered/>
     <session/>
     <uid/>
   </header>
@@ -44,6 +44,6 @@ specific language governing permissions and limitations under the License.
     </weight_kg>
   </obs>
   <patient>
-    <patient.patient_id>10</patient.patient_id>
+    <patient.patient_id>9</patient.patient_id>
   </patient>
 </form>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
@@ -21,7 +21,7 @@ specific language governing permissions and limitations under the License.
   </header>
   <encounter>
     <encounter.encounter_datetime
-        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13T00:00:00+00:00
+        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13T12:34:56.000Z
     </encounter.encounter_datetime>
     <encounter.location_id openmrs_attribute="location_id"
                            openmrs_table="encounter">1

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
@@ -15,7 +15,7 @@ specific language governing permissions and limitations under the License.
     version="1">
   <header>
     <enterer>2</enterer>
-    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
+    <date_entered>2019-08-14T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/expected-instance-edit.xml
@@ -14,8 +14,8 @@ specific language governing permissions and limitations under the License.
     name="Weight observation" id="4" uuid="9e17ff6f-e3c8-4661-86d3-09a96169bedc"
     version="1">
   <header>
-    <enterer/>
-    <date_entered/>
+    <enterer>2</enterer>
+    <date_entered>2014-11-15T12:34:56.789Z</date_entered>
     <session/>
     <uid/>
   </header>

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/original-grouped.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/original-grouped.xml
@@ -40,7 +40,7 @@ specific language governing permissions and limitations under the License.
 
   <encounter>
     <encounter.encounter_datetime
-        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13
+        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13T12:34:56.789Z
     </encounter.encounter_datetime>
     <encounter.location_id openmrs_attribute="location_id"
                            openmrs_table="encounter">1

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/original-instance-add.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/original-instance-add.xml
@@ -40,7 +40,7 @@ specific language governing permissions and limitations under the License.
 
   <encounter>
     <encounter.encounter_datetime
-        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13
+        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13T12:34:56Z
     </encounter.encounter_datetime>
     <encounter.location_id openmrs_attribute="location_id"
                            openmrs_table="encounter">1

--- a/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/original-instance-edit.xml
+++ b/openmrs/omod/src/test/resources/org/openmrs/projectbuendia/webservices/rest/original-instance-edit.xml
@@ -21,7 +21,7 @@ specific language governing permissions and limitations under the License.
   </header>
   <encounter>
     <encounter.encounter_datetime
-        openmrs_attribute="encounter_datetime" openmrs_table="encounter">2014-11-13
+        openmrs_attribute="encounter_datetime" openmrs_table="encounter">20141113T123456Z
     </encounter.encounter_datetime>
     <encounter.location_id openmrs_attribute="location_id"
                            openmrs_table="encounter">1

--- a/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilder.java
+++ b/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilder.java
@@ -14,6 +14,7 @@ import org.kxml2.io.KXmlParser;
 import org.kxml2.io.KXmlSerializer;
 import org.kxml2.kdom.Document;
 import org.kxml2.kdom.Element;
+import org.kxml2.kdom.Node;
 import org.openmrs.Concept;
 import org.openmrs.ConceptMap;
 import org.openmrs.ConceptReferenceTerm;
@@ -71,6 +72,7 @@ import static org.openmrs.module.xforms.XformBuilder.NODE_XFORMS_VALUE;
 import static org.openmrs.module.xforms.XformBuilder.VALUE_TRUE;
 import static org.openmrs.module.xforms.XformBuilder.XPATH_VALUE_FALSE;
 import static org.openmrs.module.xforms.XformBuilder.XPATH_VALUE_TRUE;
+import static org.openmrs.projectbuendia.Utils.eq;
 
 //TODO This class is too big. May need breaking into smaller ones.
 
@@ -146,7 +148,7 @@ public final class BuendiaXformBuilder {
             String name = child.getName();
 
             /* TODO(jonskeet): If we care, move this into buildUiNode.
-            if (name.equals("patient_relationship")) {
+            if (Utils.eq(name, "patient_relationship")) {
                 RelationshipBuilder.build(modelElement, bodyNode, child);
                 continue;
             }
@@ -155,11 +157,9 @@ public final class BuendiaXformBuilder {
             //If the node has an openmrs_concept attribute but is not a top-level node,
             //Or has the openmrs_attribute and openmrs_table attributes.
             if ((child.getAttributeValue(null, ATTRIBUTE_OPENMRS_CONCEPT) != null && level > 1
-            /*!child.getName().equals(NODE_OBS)*/)
-                || (child.getAttributeValue(null, ATTRIBUTE_OPENMRS_ATTRIBUTE) != null && child
-                .getAttributeValue(
-                    null,
-                    ATTRIBUTE_OPENMRS_TABLE) != null)) {
+            /*!Utils.eq(child.getName(), NODE_OBS)*/)
+                || (child.getAttributeValue(null, ATTRIBUTE_OPENMRS_ATTRIBUTE) != null
+                    && child.getAttributeValue(null, ATTRIBUTE_OPENMRS_TABLE) != null)) {
                 if (!name.equalsIgnoreCase(NODE_PROBLEM_LIST)) {
                     Element bindNode = createBindNode(
                         modelElement, child, bindings, problemList, problemListItems);
@@ -354,8 +354,11 @@ public final class BuendiaXformBuilder {
 
         bindNode.setAttribute(null, ATTRIBUTE_NODESET, nodeset);
 
-        if (!((Element) ((Element) node.getParent()).getParent())
-            .getName().equals(NODE_PROBLEM_LIST)) {
+        if (!eq(
+            ((Element)
+                ((Element) node.getParent())
+                    .getParent()
+            ).getName(), NODE_PROBLEM_LIST)) {
             modelElement.addChild(Element.ELEMENT, bindNode);
         }
 

--- a/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilderEx.java
+++ b/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilderEx.java
@@ -89,6 +89,7 @@ import static org.openmrs.module.xforms.XformBuilder.PREFIX_XML_INSTANCES;
 import static org.openmrs.module.xforms.XformBuilder.PREFIX_XML_SCHEMA;
 import static org.openmrs.module.xforms.XformBuilder.PREFIX_XML_SCHEMA2;
 import static org.openmrs.module.xforms.XformBuilder.XPATH_VALUE_TRUE;
+import static org.openmrs.projectbuendia.Utils.eq;
 
 /**
  * This is a clone of the Xforms module XformBuilderEx class, allowing us to tinker with the view
@@ -275,7 +276,7 @@ public class BuendiaXformBuilderEx {
                     formField.getParent() != null &&
                     (formField.getParent().getField().getName().contains("PROBLEM LIST"))) {
                     fieldUiNode = addProblemList(name, concept, formField, parentUiNode);
-                } else if (name.equals("problem_list")) {
+                } else if (eq(name, "problem_list")) {
                     // TODO(jonskeet): Work out what we should do here. There won't be any
                     // bindings for this.
                     // The child nodes will be covered by the case above, when we recurse down.
@@ -327,7 +328,7 @@ public class BuendiaXformBuilderEx {
                             break;
                         default:
                             // TODO(jonskeet): Remove this hack when we understand better...
-                            if (field.getName().equals("OBS")) {
+                            if (eq(field.getName(), "OBS")) {
                                 fieldUiNode = createGroupNode(formField, parentUiNode);
                             } else {
                                 // Don't understand this concept
@@ -368,7 +369,7 @@ public class BuendiaXformBuilderEx {
 
         Element controlNode = appendElement(bodyNode, NAMESPACE_XFORMS, controlName);
         controlNode.setAttribute(null, ATTRIBUTE_BIND, bindName);
-        if (DATA_TYPE_TEXT.equals(dataType)) {
+        if (eq(DATA_TYPE_TEXT, dataType)) {
             Integer rows = customizer.getRows(concept);
             if (rows != null) {
                 controlNode.setAttribute(null, ATTRIBUTE_ROWS, rows.toString());
@@ -572,23 +573,22 @@ public class BuendiaXformBuilderEx {
 
         // TODO: Set the data type on the bind node? It may already be done.
 
-        // Handle encounter provider / location: these are multiple choice questions, and we
-        // populate
-        // the options.
+        // Handle encounter provider / location: these are multiple choice questions,
+        // and we populate the options.
         Field field = formField.getField();
-        if ("patient".equals(field.getTableName())) {
-            if ("gender".equals(field.getAttributeName())) {
+        if (eq(field.getTableName(), "patient")) {
+            if (eq(field.getAttributeName(), "gender")) {
                 controlNode.setName(CONTROL_SELECT1);
                 populateGenders(controlNode);
-            } else if ("birthdate".equals(field.getAttributeName())) {
+            } else if (eq(field.getAttributeName(), "birthdate")) {
                 controlNode.setAttribute(null, ATTRIBUTE_APPEARANCE,
                     "minimal|show_years|show_months");
             }
-        } else if ("encounter".equals(field.getTableName())) {
-            if ("location_id".equals(field.getAttributeName())) {
+        } else if (eq(field.getTableName(), "encounter")) {
+            if (eq(field.getAttributeName(), "location_id")) {
                 controlNode.setName(CONTROL_SELECT1);
                 populateLocations(controlNode);
-            } else if ("provider_id".equals(field.getAttributeName())) {
+            } else if (eq(field.getAttributeName(), "provider_id")) {
                 controlNode.setName(CONTROL_SELECT1);
                 populateProviders(controlNode);
             }

--- a/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilderEx.java
+++ b/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/BuendiaXformBuilderEx.java
@@ -609,8 +609,7 @@ public class BuendiaXformBuilderEx {
     private void populateProviders(Element controlNode) {
         includesProviders = true;
         for (Provider provider : Context.getProviderService().getAllProviders()) {
-            Integer providerId = provider.getId();
-            addSelectOption(controlNode, customizer.getLabel(provider), providerId.toString());
+            addSelectOption(controlNode, customizer.getLabel(provider), "" + provider.getId());
         }
     }
 
@@ -618,9 +617,8 @@ public class BuendiaXformBuilderEx {
     private void populateLocations(Element controlNode) {
         includesLocations = true;
         List<Location> locations = customizer.getEncounterLocations();
-        for (Location loc : locations) {
-            Integer id = loc.getLocationId();
-            addSelectOption(controlNode, customizer.getLabel(loc), id.toString());
+        for (Location location : locations) {
+            addSelectOption(controlNode, customizer.getLabel(location), "" + location.getId());
         }
     }
 }

--- a/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/XformCustomizer.java
+++ b/third_party/openmrs-module-xforms/api/src/main/java/org/openmrs/module/xforms/buendia/XformCustomizer.java
@@ -32,17 +32,17 @@ public class XformCustomizer {
     }
 
     public String getLabel(Location loc) {
-        // We make sure to hide the location question on the client side; the
-        // location labels are never shown to the user.  This lets us use the
-        // UUID as the label, so the client can identify the location options.
-        return loc.getUuid();
+        return loc.getName() + " [" + loc.getLocationId() + "]";
     }
 
     public String getLabel(Provider provider) {
-        // We make sure to hide the provider question on the client side; the
-        // provider labels are never shown to the user.  This lets us use the
-        // UUID as the label, so the client can identify the provider options.
-        return provider.getUuid();
+        String name = provider.getName();
+        if (name == null) {
+            Person person = provider.getPerson();
+            name = person.getPersonName().toString();
+        }
+        String identifier = provider.getIdentifier();
+        return name + " [" + identifier + "]";
     }
 
     public String getGroupLabel(FormField formField) {

--- a/tools/profile_apply
+++ b/tools/profile_apply
@@ -13,14 +13,6 @@ import warnings
 CHART_UUID = 'buendia_chart'
 LOCALE = 'en_GB_client'
 
-# This is a modified copy of the "OpenMRS FormEntry Form HL7 Translation" XSLT
-# file, with encounter_datetime changed from a "hl7Date" to an "hl7Timestamp".
-# To record the date and time (not just the date) of submitted observations,
-# we have to add this as a form resource to every form.
-XSLT_UUID = 'c39fc8bc-f188-4479-8b1a-c1d28f1b7dcf'
-XSLT_DATATYPE = 'org.openmrs.customdatatype.datatype.LongFreeTextDatatype'
-XSLT_HANDLER = 'org.openmrs.web.attribute.handler.LongFreeTextTextareaHandler'
-
 class Database:
     def __init__(self, database, user, password):
         self.db = MySQLdb.connect(db=database, user=user, passwd=password)
@@ -407,16 +399,7 @@ def apply(tabs):
         uuid = create_uuid_from_form_name(title)
         form_id = put_form(uuid, title, adult_return)
         apply_form(rows, form_id)
-        init_form_xslt(form_id)
         db.execute('update form set published = 1 where form_id = %s', form_id)
-
-    def init_form_xslt(form_id):
-        """Adds our custom XSLT as a form resource to a specified form."""
-        name = db.get('name', 'form', form_id=form_id) + '.xFormXslt'
-        resource_id = get_or_insert('form_resource',
-            form_id=form_id, name=name, value_reference=XSLT_UUID)
-        odb.update('form_resource', resource_id, datatype=XSLT_DATATYPE,
-                   preferred_handler=XSLT_HANDLER)
 
     def apply_form(rows, form_id):
         """


### PR DESCRIPTION
This PR corrects many issues we have had with XForms:
  - Previously, submissions were not being assigned the correct provider; now they are.
  - Previously, submissions were not being assigned the correct user (creator); now they are.
  - Previously, there was a risk of times being interpreted incorrectly due to time zones; now all timestamps are in UTC to avoid the possibility of confusion.
  - Previously, XSLT resources were not managed together with forms; now the server ensures they are present and correctly associated with their forms, and not by the `profile_apply` script.
  - Previously, there were many risks from using Java's broken equality operators (`==` and `equals()`); these have now been replaced by the safe and correct operator, `Utils.eq`.
