### PR TITLE
Add openmrs_location_setup.

### DIFF
--- a/packages/buendia-server/Makefile
+++ b/packages/buendia-server/Makefile
@@ -7,7 +7,7 @@ TARGET_DIR=$(EXTRA_DATA)/usr/share/buendia/openmrs/modules
 MAIN_MODULE=$(TARGET_DIR)/buendia-server.omod
 OTHER_MODULES=$(TARGET_DIR)/xforms-4.3.5.omod $(TARGET_DIR)/webservices.rest-2.6.omod
 
-$(EXTRA_DATA): $(MAIN_MODULE) $(OTHER_MODULES) $(EXTRA_DATA)/usr/bin/buendia-openmrs-account-setup $(EXTRA_DATA)/usr/bin/buendia-profile-apply $(EXTRA_DATA)/usr/bin/buendia-profile-validate
+$(EXTRA_DATA): $(MAIN_MODULE) $(OTHER_MODULES) $(EXTRA_DATA)/usr/bin/buendia-openmrs-account-setup $(EXTRA_DATA)/usr/bin/buendia-openmrs-location-setup $(EXTRA_DATA)/usr/bin/buendia-openmrs-dump $(EXTRA_DATA)/usr/bin/buendia-openmrs-load $(EXTRA_DATA)/usr/bin/buendia-profile-apply $(EXTRA_DATA)/usr/bin/buendia-profile-validate
 
 $(MAIN_MODULE_BUILD):
 	../../tools/openmrs_build
@@ -23,6 +23,21 @@ $(OTHER_MODULES):
 $(EXTRA_DATA)/usr/bin/buendia-openmrs-account-setup:
 	mkdir -p $$(dirname $@)
 	cp -p $(TOOLS)/openmrs_account_setup $@
+	chmod 755 $@
+
+$(EXTRA_DATA)/usr/bin/buendia-openmrs-dump:
+	mkdir -p $$(dirname $@)
+	cp -p $(TOOLS)/openmrs_dump $@
+	chmod 755 $@
+
+$(EXTRA_DATA)/usr/bin/buendia-openmrs-location-setup:
+	mkdir -p $$(dirname $@)
+	cp -p $(TOOLS)/openmrs_location_setup $@
+	chmod 755 $@
+
+$(EXTRA_DATA)/usr/bin/buendia-openmrs-load:
+	mkdir -p $$(dirname $@)
+	cp -p $(TOOLS)/openmrs_load $@
 	chmod 755 $@
 
 $(EXTRA_DATA)/usr/bin/buendia-profile-apply:

--- a/tools/openmrs_account_setup
+++ b/tools/openmrs_account_setup
@@ -39,7 +39,7 @@ if [ -z "$MYSQL_USER" ]; then
     exit 1
 fi
 
-MYSQL="mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -N openmrs"
+MYSQL="mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -s -N openmrs"
 
 function randhex() {
     xxd -l $(($1 / 2)) -p /dev/urandom | tr -d '\n'

--- a/tools/openmrs_location_setup
+++ b/tools/openmrs_location_setup
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2015 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+# Sets up the OpenMRS account used for Buendia API requests.
+
+set -e
+if [ "$1" == "-h" ]; then
+    echo "Usage: $0"
+    echo
+    echo "Sets up a small default location hierarchy for testing."
+    echo
+    echo 'Requires a MySQL user that has been granted database access with'
+    echo '    GRANT USAGE ON <database-name>.* to <user>@<host>'
+    echo 'Specify the user and password with $MYSQL_USER and $MYSQL_PASSWORD.'
+    echo
+    exit 1
+fi
+
+eval $(buendia-settings 2>/dev/null)
+
+MYSQL_USER=${MYSQL_USER-$OPENMRS_MYSQL_USER}
+MYSQL_PASSWORD=${MYSQL_PASSWORD-$OPENMRS_MYSQL_PASSWORD}
+
+if [ -z "$MYSQL_USER" ]; then
+    echo '$MYSQL_USER is not set; please set $MYSQL_USER and $MYSQL_PASSWORD.'
+    exit 1
+fi
+
+MYSQL="mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -s -N openmrs"
+USER_ID=$($MYSQL <<< "
+    select user_id from users where username = 'buendia_admin';
+" 2>/dev/null)
+
+function randhex() {
+    xxd -l $(($1 / 2)) -p /dev/urandom | tr -d '\n'
+}
+
+function uuidgen() {
+    randhex 32 | sed -e 's/\(........\)\(....\)\(....\)\(....\)\(............\)/\1-\2-\3-\4-\5/'
+}
+
+function add_location() {
+    name="$1"
+    parent_id="$2"
+    uuid=$(uuidgen)
+    $MYSQL <<< "
+        insert into location
+            (name, parent_location, creator, date_created, uuid)
+        values
+            ('$name', $parent_id, '$USER_ID', now(), '$uuid');
+    " >/dev/null;
+    $MYSQL <<< "
+        select location_id from location where uuid = '$uuid';
+    "
+}
+
+$MYSQL <<< "
+    update location set retired = 1;
+";
+
+etc=$(add_location "[1] Bunia ETC" null)
+triage=$(add_location "[2] Triage" $etc)
+suspected=$(add_location "[3] Suspected" $etc)
+confirmed=$(add_location "[4] Confirmed" $etc)
+discharged=$(add_location "[5] Discharged" null)


### PR DESCRIPTION
This script automatically sets up a few simple locations.  With the addition of this script, deployment for smoke testing can now be automated with `buendia-openmrs-load`, `buendia-openmrs-account-setup`, `buendia-openmrs-location-setup`, and `buendia-profile-apply`.