### PR TITLE
Various improvements to scripts

### DIFF
--- a/packages/buendia-tomcat7/control/postinst
+++ b/packages/buendia-tomcat7/control/postinst
@@ -15,6 +15,7 @@ set -e; . /usr/share/buendia/utils.sh
 buendia-divert $1 /etc/default/tomcat7
 buendia-divert $1 /etc/tomcat7/server.xml
 buendia-divert $1 /etc/tomcat7/tomcat-users.xml
+buendia-divert $1 /etc/tomcat7/context.xml
 
 case $1 in
     configure|abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/buendia-tomcat7/data/usr/share/buendia/diversions/etc/tomcat7/context.xml
+++ b/packages/buendia-tomcat7/data/usr/share/buendia/diversions/etc/tomcat7/context.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+    <!-- Default set of monitored resources -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+
+    <!-- Disable session persistence across Tomcat restarts -->
+    <Manager pathname="" />
+
+</Context>

--- a/tools/clear_server.sql
+++ b/tools/clear_server.sql
@@ -462,12 +462,6 @@ DELETE FROM xforms_person_repeat_attribute WHERE
 
 DELETE FROM person WHERE person_id NOT IN (SELECT person_id FROM keep_users);
 
--- Clear the huge concept word and concept reference tables; we don't need them.
-DELETE FROM concept_word;
-DELETE FROM concept_reference_term_map;
-DELETE FROM concept_reference_map;
-DELETE FROM concept_reference_term;
-
 -- Delete all the custom Buendia concepts.
 SET @max_id := 999999;
 DELETE FROM concept_answer WHERE concept_id > @max_id;

--- a/tools/package_grep
+++ b/tools/package_grep
@@ -10,4 +10,4 @@ if [ -z "$1" ]; then
 fi
 
 cd $tools/../packages
-grep -r "$@" */data | sed -e 's#/control/control.template:#: #'
+grep -r "$@" *


### PR DESCRIPTION
This adds a few sundry fixes:
  - `package_grep` used to not search the `Makefile` for the package; now it does.
  - `clear_server.sql` used to delete the large `concept_reference_map`, `concept_reference_term`, and `concept_word` tables; now it no longer needs to do that because we have a tested, known-working database dump that omits the contents of these tables.
  - When `tomcat7` started up, Catalina would often spew error messages about unrestorable sessions.  We don't need to preserve user sessions across restarts of `tomcat7`, so this change disables that feature.