### PR TITLE
Return all concepts in forms as well as charts.

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ChartResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ChartResource.java
@@ -44,7 +44,7 @@ public class ChartResource extends BaseResource<Form> {
         return getChartForms(formService);
     }
 
-    public static List<Form> getChartForms(FormService formService) {
+    public static Collection<Form> getChartForms(FormService formService) {
         List<Form> charts = new ArrayList<>();
         for (Form form : formService.getAllForms()) {
             if (DbUtils.isChartForm(form)) {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
@@ -56,10 +56,14 @@ public class ConceptResource extends BaseResource<Concept> {
 
     @Override protected Collection<Concept> listItems(RequestContext context) {
         // Retrieves all the concepts that the client needs to know about
-        // (the concepts within all the charts served by ChartResource).
+        // (the concepts within all the forms served by XFormResource and
+        // all the charts served by ChartResource).
         Set<Concept> concepts = new HashSet<>();
-        for (Form chart : ChartResource.getChartForms(formService)) {
-            for (FormField formField : chart.getFormFields()) {
+        List<Form> forms = new ArrayList<>();
+        forms.addAll(ChartResource.getChartForms(formService));
+        forms.addAll(XformResource.getXformForms(formService));
+        for (Form form : forms) {
+            for (FormField formField : form.getFormFields()) {
                 Field field = formField.getField();
                 Concept concept = field.getConcept();
                 if (concept != null && !concept.isRetired()) {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtils.java
@@ -268,13 +268,11 @@ public class DbUtils {
         }
     };
 
-    /**
-     * Gets the default root location, where identifiers will be placed.  For consistency
-     * with the client, this is the root with the alphanumerically first (lowest) name.
-     */
+    /** Gets the default root location, where identifiers will be placed. */
     public static Location getDefaultRoot() {
         LocationService locationService = Context.getLocationService();
         List<Location> locations = locationService.getAllLocations(false);
+        // The default location is the root with the alphanumerically first (lowest) name.
         Collections.sort(locations, ALPHANUMERIC_NAME_COMPARATOR);
         for (Location location : locationService.getAllLocations(false)) {
             if (location.getParentLocation() == null) {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
@@ -5,6 +5,7 @@ import org.openmrs.Field;
 import org.openmrs.Form;
 import org.openmrs.FormField;
 import org.openmrs.Provider;
+import org.openmrs.api.FormService;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -46,6 +47,10 @@ public class XformResource extends BaseResource<Form> {
     }
 
     @Override protected Collection<Form> listItems(RequestContext context) {
+        return getXformForms(formService);
+    }
+
+    public static Collection<Form> getXformForms(FormService formService) {
         List<Form> results = new ArrayList<>();
         for (Form form : formService.getAllForms()) {
             if (DbUtils.isPublishedXform(form)) results.add(form);


### PR DESCRIPTION
Previously we only returned information for concepts that exist in the charts.  This didn't include concepts that are used in the form but not explicitly mentioned in the chart, such as pregnancy status; for those concepts, observations would not update immediately on the client but would have to wait until the next sync.  With this fix, pregnancy status updates immediately on the client when the form is submitted.