### PR TITLE
Ensure that /var/log/{large/,}requests is world-writeable

### DIFF
--- a/packages/buendia-dashboard/control/postinst
+++ b/packages/buendia-dashboard/control/postinst
@@ -17,6 +17,12 @@ case $1 in
         # Enable the dashboard website
         ln -sf ../sites-available/buendia-dashboard /etc/nginx/sites-enabled
 
+        # Ensure that everyone can write request logs, new and old,
+        # large and small
+        mkdir -p /var/log/large/requests /var/log/large/old \
+                 /var/log/requests /var/log/requests/old
+        chmod 1777 /var/log/requests /var/log/large/requests
+
         # Bring services back up (need to restart here, not merely start)
         service_if_exists nginx restart
         ;;

--- a/packages/buendia-dashboard/data/etc/logrotate.d/buendia-dashboard
+++ b/packages/buendia-dashboard/data/etc/logrotate.d/buendia-dashboard
@@ -16,6 +16,7 @@
     compress
     olddir /var/log/requests/old
     sharedscripts
+    su root root
     postrotate
         # The limit is applied to both the original log directory and this one
         # as a safety measure, so that space usage is controlled even if

--- a/packages/buendia-dashboard/data/usr/share/buendia/tests/40-dashboard-running
+++ b/packages/buendia-dashboard/data/usr/share/buendia/tests/40-dashboard-running
@@ -1,9 +1,5 @@
 test_10_run_dashboard_cron () {
     execute_cron_right_now dashboard
-    # FIXME: ^^ this throws an error when run manually:
-    # $ sudo /usr/sbin/logrotate /etc/logrotate.d/buendia-dashboard
-    # error: /etc/logrotate.d/buendia-dashboard:27 error verifying olddir path /var/log/requests/old: No such file or directory
-    true
 }
 
 test_20_dashboard_says_server_is_running () {


### PR DESCRIPTION
Now `/var/log/large/requests` exists whenever `buendia-dashboard` is installed and furthermore is `chmod 1777` so that Catalina can write to it.

This was driven partly because the integration tests for `buendia-dashboard` were failing because we very wisely made `set -e` the [default for integration tests](https://github.com/projectbuendia/buendia/commit/3b09f23f8). Now we can remove that **FIXME** from the test! :confetti_ball: 

@zestyping I think this is pretty uncontroversial, so I'm going to wait a lil bit and then merge, unless I hear back from you.