### PR TITLE
Update monitoring and dashboard packages to rely on ip, not ifconfig

### DIFF
--- a/packages/buendia-dashboard/control/control.template
+++ b/packages/buendia-dashboard/control/control.template
@@ -2,6 +2,6 @@ Package: ${PACKAGE_NAME}
 Version: ${PACKAGE_VERSION}
 Architecture: all
 Pre-Depends: buendia-utils
-Depends: buendia-setclock, fcgiwrap, nginx-light
+Depends: buendia-setclock, fcgiwrap, nginx-light, buendia-monitoring
 Description: Serves a system status and administration page for Buendia.
 Maintainer: projectbuendia.org

--- a/packages/buendia-monitoring/data/etc/cron.d/buendia-monitoring
+++ b/packages/buendia-monitoring/data/etc/cron.d/buendia-monitoring
@@ -10,4 +10,4 @@ MAILTO=""
 */10 * * * * root buendia-log df
 */10 * * * * root buendia-log free
 */10 * * * * root buendia-log ps -efww
-*/10 * * * * root buendia-log ifconfig
+*/10 * * * * root buendia-log ip a

--- a/packages/buendia-monitoring/data/usr/share/buendia/tests/40-monitoring-logs-safe
+++ b/packages/buendia-monitoring/data/usr/share/buendia/tests/40-monitoring-logs-safe
@@ -1,10 +1,9 @@
 test_10_run_monitoring_cron () {
-    # TODO: fix missing ifconfig log
-    execute_cron_right_now monitoring || true
+    execute_cron_right_now monitoring
 }
 
 test_20_cron_wrote_some_logs () {
-    for file in df du free ps; do
+    for file in df du free ps ip; do
         check=/var/log/buendia/${file}.log 
         echo "Checking for log file: $check"
         [ -e $check ] || exit 1

--- a/packages/buendia-utils/data/usr/bin/buendia-status
+++ b/packages/buendia-utils/data/usr/bin/buendia-status
@@ -65,8 +65,8 @@ if [ -n "$all" ]; then
         echo -e '\n---- du /var/log'
         du /var/log
 
-        echo -e '\n---- ifconfig wlan0'
-        ifconfig wlan0
+        echo -e '\n---- ip a'
+        ip a
 
         echo -e '\n---- ls -l /usr/share/buendia/site'
         ls -l /usr/share/buendia/site


### PR DESCRIPTION
The classic `ifconfig` utility has been replaced in Debian 9 by the `ip` utility. This PR updates the monitoring and dashboard packages to dump diagnostic data from `ip` instead.

Also, the `dashboard` package relies on the `monitoring` package for a number of things, not the least the correct setup of `/var/log/large/requests` et cetera, so this dependency has been made explicit.