### PR TITLE
Move pkgserver sources.list to pkgserver.

### DIFF
--- a/packages/buendia-pkgserver/data/etc/apt/sources.list.d/buendia-pkgserver.list
+++ b/packages/buendia-pkgserver/data/etc/apt/sources.list.d/buendia-pkgserver.list
@@ -1,0 +1,1 @@
+deb [trusted=yes] http://localhost:9001 stable main

--- a/packages/buendia-site-demo/data/etc/apt/sources.list.d/buendia.list
+++ b/packages/buendia-site-demo/data/etc/apt/sources.list.d/buendia.list
@@ -1,2 +1,0 @@
-deb [arch=all] http://localhost:9001 stable main
-deb [arch=i386] http://localhost:9001 stable main

--- a/packages/buendia-site-dev/data/etc/apt/sources.list.d/buendia.list
+++ b/packages/buendia-site-dev/data/etc/apt/sources.list.d/buendia.list
@@ -1,3 +1,0 @@
-# Development sites pull the latest packages built from the dev branch.
-deb [arch=all] http://dev.projectbuendia.org:9001 stable main
-deb [arch=i386] http://dev.projectbuendia.org:9001 stable main

--- a/packages/buendia-site-lon/data/etc/apt/sources.list.d/buendia.list
+++ b/packages/buendia-site-lon/data/etc/apt/sources.list.d/buendia.list
@@ -1,2 +1,0 @@
-deb [arch=all] http://localhost:9001 stable main
-deb [arch=i386] http://localhost:9001 stable main

--- a/packages/buendia-site-msf-chad-bokoro/data/etc/apt/sources.list.d/buendia.list
+++ b/packages/buendia-site-msf-chad-bokoro/data/etc/apt/sources.list.d/buendia.list
@@ -1,2 +1,0 @@
-deb [arch=all] http://localhost:9001 stable main
-deb [arch=i386] http://localhost:9001 stable main

--- a/packages/buendia-site-msf-geneva/data/etc/apt/sources.list.d/buendia.list
+++ b/packages/buendia-site-msf-geneva/data/etc/apt/sources.list.d/buendia.list
@@ -1,2 +1,0 @@
-deb [arch=all] http://localhost:9001 stable main
-deb [arch=i386] http://localhost:9001 stable main

--- a/packages/buendia-site-msf-ks/data/etc/apt/sources.list.d/buendia.list
+++ b/packages/buendia-site-msf-ks/data/etc/apt/sources.list.d/buendia.list
@@ -1,2 +1,0 @@
-deb [arch=all] http://localhost:9001 stable main
-deb [arch=i386] http://localhost:9001 stable main

--- a/packages/buendia-site-msf-mg/data/etc/apt/sources.list.d/buendia.list
+++ b/packages/buendia-site-msf-mg/data/etc/apt/sources.list.d/buendia.list
@@ -1,2 +1,0 @@
-deb [arch=all] http://localhost:9001 stable main
-deb [arch=i386] http://localhost:9001 stable main

--- a/packages/buendia-site-test/data/etc/apt/sources.list.d/buendia.list
+++ b/packages/buendia-site-test/data/etc/apt/sources.list.d/buendia.list
@@ -1,2 +1,0 @@
-deb [arch=all] http://localhost:9001 stable main
-deb [arch=i386] http://localhost:9001 stable main

--- a/packages/tests/check-filenames
+++ b/packages/tests/check-filenames
@@ -18,7 +18,7 @@ PACKAGE_NAME=$(basename $(pwd))
 
 for dir in $(find data -name '*.d'); do
     case $dir:$PACKAGE_NAME in
-        data/etc/apt/sources.list.d:*) name=buendia.list ;;
+        data/etc/apt/sources.list.d:*) name=buendia*.list ;;
         data/etc/udev/rules.d:*) continue ;;
         data/usr/share/buendia/*:buendia-site-*) name=site ;;
         data/usr/share/buendia/config.d:*) name="??-${PACKAGE_NAME#buendia-}" ;;


### PR DESCRIPTION
Having an apt source pointing to `localhost:9001` just causes useless errors unless pkgserver is installed. Instead, let's have `buendia-pkgserver` provide its own sources.list, and add `buendia-pkgserver` as a dependency back to those site packages that need it.