### PR TITLE
Make REST error output more readable and add a REST client utility

### DIFF
--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/Utils.java
@@ -235,7 +235,7 @@ public class Utils {
         Object value = obj.get(key);
         if (value == null) {
             throw new InvalidObjectDataException(String.format(
-                "Required property \"%s\" is missing", key));
+                "Required property \"%s\" is missing or null", key));
         }
         if (!(value instanceof String)) {
             throw new InvalidObjectDataException(String.format(
@@ -252,7 +252,7 @@ public class Utils {
         Object value = obj.get(key);
         if (value == null) {
             throw new InvalidObjectDataException(String.format(
-                "Required property \"%s\" is missing", key));
+                "Required property \"%s\" is missing or null", key));
         }
         long millis;
         try {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/BaseResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/BaseResource.java
@@ -40,7 +40,7 @@ public abstract class BaseResource<T extends OpenmrsObject>
     private static final RequestLogger logger = RequestLogger.LOGGER;
     private final List<Representation> availableRepresentations;
     
-    protected final String collectionName;
+    protected final String pluralCollectionName;
     protected final ProjectBuendiaService buendiaService;
     protected final ConceptService conceptService;
     protected final EncounterService encounterService;
@@ -50,8 +50,8 @@ public abstract class BaseResource<T extends OpenmrsObject>
     protected final PatientService patientService;
     protected final ProviderService providerService;
 
-    protected BaseResource(String collectionName, Representation... representations) {
-        this.collectionName = collectionName;
+    protected BaseResource(String pluralCollectionName, Representation... representations) {
+        this.pluralCollectionName = pluralCollectionName;
         availableRepresentations = Arrays.asList(representations);
         buendiaService = Context.getService(ProjectBuendiaService.class);
         conceptService = Context.getConceptService();
@@ -144,8 +144,7 @@ public abstract class BaseResource<T extends OpenmrsObject>
         Utils.addVersionHeaders(context);
         try {
             logger.request(context, this, "retrieve");
-            T item = retrieveItem(uuid);
-            if (item == null || DbUtils.isVoidedOrRetired(item)) throw new ObjectNotFoundException();
+            T item = retrieveRequiredItem(uuid);
             return logger.reply(context, this, "retrieve", toJson(item, context));
         } catch (Exception e) {
             logger.error(context, this, "retrieve", e);
@@ -158,8 +157,7 @@ public abstract class BaseResource<T extends OpenmrsObject>
         Utils.addVersionHeaders(context);
         try {
             logger.request(context, this, "update", data);
-            T item = retrieveItem(uuid);
-            if (item == null || DbUtils.isVoidedOrRetired(item)) throw new ObjectNotFoundException();
+            T item = retrieveRequiredItem(uuid);
             T newItem = updateItem(item, data, context);
             return logger.reply(context, this, "update", toJson(newItem, context));
         } catch (Exception e) {
@@ -173,8 +171,7 @@ public abstract class BaseResource<T extends OpenmrsObject>
         Utils.addVersionHeaders(context);
         try {
             logger.request(context, this, "delete", reason);
-            T item = retrieveItem(uuid);
-            if (item == null || DbUtils.isVoidedOrRetired(item)) throw new ObjectNotFoundException();
+            T item = retrieveRequiredItem(uuid);
             deleteItem(item, reason, context);
             logger.reply(context, this, "delete", null);
         } catch (Exception e) {
@@ -183,46 +180,54 @@ public abstract class BaseResource<T extends OpenmrsObject>
         }
     }
 
+    protected T retrieveRequiredItem(String uuid) {
+        T item = retrieveItem(uuid);
+        if (item == null || DbUtils.isVoidedOrRetired(item)) {
+            throw new ItemNotFoundException(pluralCollectionName, uuid);
+        }
+        return item;
+    }
+
     /** Retrieves a list of all items. */
     protected Collection<T> listItems(RequestContext context) {
         throw new UnsupportedOperationException(String.format(
-            "Listing all %s is not implemented", collectionName));
+            "Listing all %s is not implemented", pluralCollectionName));
     }
 
     /** Searches for all items matching the criteria in the RequestContext. */
     protected Collection<T> searchItems(RequestContext context) {
         throw new UnsupportedOperationException(String.format(
-            "Searching for %s is not implemented", collectionName));
+            "Searching for %s is not implemented", pluralCollectionName));
     }
 
     /** Fetches a chunk of items newer than a bookmarked position, returning an updated bookmark. */
     protected SimpleObject syncItems(String bookmark, List<T> items) {
         throw new UnsupportedOperationException(String.format(
-            "Searching for %s is not implemented", collectionName));
+            "Searching for %s is not implemented", pluralCollectionName));
     }
 
     /** Creates an item from the given data and returns it. */
     protected T createItem(SimpleObject data, RequestContext context) {
         throw new UnsupportedOperationException(String.format(
-            "Creating %s is not implemented", collectionName));
+            "Creating %s is not implemented", pluralCollectionName));
     }
 
     /** Retrieves a single item by UUID, returning null if it can't be found. */
     protected T retrieveItem(String uuid) {
         throw new UnsupportedOperationException(String.format(
-            "Retrieving individual %s is not implemented", collectionName));
+            "Retrieving individual %s is not implemented", pluralCollectionName));
     }
 
     /** Updates the given item using the given data. */
     protected T updateItem(T item, SimpleObject data, RequestContext context) {
         throw new UnsupportedOperationException(String.format(
-            "Updating %s is not implemented", collectionName));
+            "Updating %s is not implemented", pluralCollectionName));
     }
 
     /** Deletes (voids or retires) the given item. */
     protected void deleteItem(T item, String reason, RequestContext context) {
         throw new UnsupportedOperationException(String.format(
-            "Deleting %s is not implemented", collectionName));
+            "Deleting %s is not implemented", pluralCollectionName));
     }
 
     /** Converts a single item to JSON (or returns an empty JSON object for null). */

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ChartResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ChartResource.java
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
 import static org.openmrs.projectbuendia.Utils.isEmpty;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/charts",
+    name = RestController.PATH + "/charts",
     supportedClass = Form.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ConceptResource.java
@@ -6,7 +6,6 @@ import org.openmrs.Field;
 import org.openmrs.Form;
 import org.openmrs.FormField;
 import org.openmrs.api.context.Context;
-import org.openmrs.hl7.HL7Constants;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RequestContext;
 import org.openmrs.module.webservices.rest.web.annotation.Resource;
@@ -30,7 +29,7 @@ import javax.annotation.Nullable;
 import static org.openmrs.projectbuendia.Utils.isBlank;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/concepts",
+    name = RestController.PATH + "/concepts",
     supportedClass = Concept.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtils.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/DbUtils.java
@@ -38,8 +38,6 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
 import org.openmrs.hl7.HL7Constants;
-import org.openmrs.module.webservices.rest.web.response
-    .IllegalPropertyException;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -339,19 +337,16 @@ public class DbUtils {
     }
 
     protected static abstract class Getter<T> {
-        String name;
+        String type;
 
-        Getter(Class<T> cls) { name = cls.getSimpleName(); }
+        Getter(Class<T> cls) { type = cls.getSimpleName(); }
 
         protected abstract @Nullable T lookup(String uuid);
 
         public @Nullable T get(@Nullable String uuid) {
             if (uuid == null) return null;
             T entity = lookup(uuid);
-            if (entity == null) {
-                throw new IllegalPropertyException(String.format(
-                    "No %s found with UUID %s", name, uuid));
-            }
+            if (entity == null) throw new UuidNotFoundException(type, uuid);
             return entity;
         }
     }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/EncounterResource.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static org.openmrs.projectbuendia.Utils.eq;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/encounters",
+    name = RestController.PATH + "/encounters",
     supportedClass = Location.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ItemNotFoundException.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ItemNotFoundException.java
@@ -1,0 +1,25 @@
+// Copyright 2015 The Project Buendia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distrib-
+// uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+// specific language governing permissions and limitations under the License.
+
+package org.openmrs.projectbuendia.webservices.rest;
+
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** The requested item in the REST collection was not found. */
+@ResponseStatus(value=HttpStatus.NOT_FOUND)
+public class ItemNotFoundException extends ResponseException {
+    public ItemNotFoundException(String pluralCollectionName, String uuid) {
+        super(String.format("None of the %s in this collection have UUID \"%s\"",
+            pluralCollectionName, uuid));
+    }
+}

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/LocationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/LocationResource.java
@@ -18,7 +18,7 @@ import java.util.Collection;
  * "parent_uuid" key with a value of null.
  */
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/locations",
+    name = RestController.PATH + "/locations",
     supportedClass = Location.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/LocationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/LocationResource.java
@@ -10,6 +10,13 @@ import org.projectbuendia.openmrs.webservices.rest.RestController;
 
 import java.util.Collection;
 
+/**
+ * REST collection for locations.  In the JSON representation, every
+ * location has a parent that can be null, and the "parent_uuid" key
+ * is always present though its value may be null.  The parent can
+ * be set to null during an update operation by including the
+ * "parent_uuid" key with a value of null.
+ */
 @Resource(
     name = RestController.REST_VERSION_1_AND_NAMESPACE + "/locations",
     supportedClass = Location.class,
@@ -26,16 +33,9 @@ public class LocationResource extends BaseResource<Location> {
 
     @Override protected Location createItem(SimpleObject data, RequestContext context) {
         Location location = new Location();
-        String parentUuid = Utils.getOptionalString(data, "parent_uuid");
-        if (parentUuid != null) {
-            Location parent = locationService.getLocationByUuid(parentUuid);
-            if (parent == null) {
-                throw new InvalidObjectDataException(String.format(
-                    "No parent location found with UUID %s", parentUuid));
-            }
-            location.setParentLocation(parent);
-        }
         location.setName(Utils.getRequiredString(data, "name"));
+        String parentUuid = Utils.getOptionalString(data, "parent_uuid");
+        location.setParentLocation(DbUtils.locationsByUuid.get(parentUuid));
         return locationService.saveLocation(location);
     }
 
@@ -44,31 +44,35 @@ public class LocationResource extends BaseResource<Location> {
     }
 
     @Override protected Location updateItem(Location location, SimpleObject data, RequestContext context) {
-        if (data.get("name") != null) {
+        if (data.containsKey("name")) {
             location.setName(Utils.getRequiredString(data, "name"));
+        }
+        if (data.containsKey("parent_uuid")) {
+            String parentUuid = Utils.getOptionalString(data, "parent_uuid");  // nullable
+            location.setParentLocation(DbUtils.locationsByUuid.get(parentUuid));  // nullable
         }
         return locationService.saveLocation(location);
     }
 
     @Override protected void deleteItem(Location location, String reason, RequestContext context) {
-        deleteLocationRecursively(location, reason);
+        retireLocationRecursively(location, reason);
     }
 
-    private void deleteLocationRecursively(Location location, String reason) {
-        // This may delete locations that are assigned to existing patients.
+    private void retireLocationRecursively(Location location, String reason) {
+        // This may retire locations that are assigned to existing patients.
         // The location is stored just as a string attribute on the patient,
         // so this will not break any database constraints; it just means
         // those patients will end up with an unknown location UUID.
         for (Location child : location.getChildLocations()) {
-            deleteLocationRecursively(child, reason);
+            retireLocationRecursively(child, reason);
         }
         locationService.retireLocation(location, reason);
     }
 
     @Override protected void populateJson(SimpleObject json, Location location, RequestContext context) {
-        Location parent = location.getParentLocation();
-        if (parent != null) json.add("parent_uuid", parent.getUuid());
         json.add("name", location.getName());
         json.add("names", new SimpleObject().add("en", location.getName())); // backward compatibility
+        Location parent = location.getParentLocation();
+        json.add("parent_uuid", parent != null ? parent.getUuid() : null);
     }
 }

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/ObservationResource.java
@@ -22,7 +22,7 @@ import java.util.List;
 import static org.openmrs.projectbuendia.Utils.eq;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/observations",
+    name = RestController.PATH + "/observations",
     supportedClass = Obs.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/OrderResource.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import static org.openmrs.projectbuendia.Utils.eq;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/orders",
+    name = RestController.PATH + "/orders",
     supportedClass = Order.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/PatientResource.java
@@ -33,7 +33,7 @@ import static org.openmrs.projectbuendia.Utils.formatUtcDate;
 import static org.openmrs.projectbuendia.Utils.parseLocalDate;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/patients",
+    name = RestController.PATH + "/patients",
     supportedClass = Patient.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UserResource.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 import static org.openmrs.projectbuendia.Utils.getRequiredString;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/users",
+    name = RestController.PATH + "/users",
     supportedClass = Provider.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UuidNotFoundException.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/UuidNotFoundException.java
@@ -1,0 +1,24 @@
+// Copyright 2015 The Project Buendia Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at: http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distrib-
+// uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+// OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+// specific language governing permissions and limitations under the License.
+
+package org.openmrs.projectbuendia.webservices.rest;
+
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** The request data contained an invalid UUID. */
+@ResponseStatus(value=HttpStatus.BAD_REQUEST)
+public class UuidNotFoundException extends ResponseException {
+    public UuidNotFoundException(String type, String uuid) {
+        super(String.format("No %s exists with UUID \"%s\"", type, uuid));
+    }
+}

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformInstanceResource.java
@@ -15,7 +15,6 @@ import org.openmrs.module.webservices.rest.web.annotation.Resource;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.response.ConversionException;
 import org.openmrs.module.webservices.rest.web.response.GenericRestException;
-import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.openmrs.module.xforms.XformsQueueProcessor;
 import org.openmrs.module.xforms.util.XformsUtil;
@@ -38,7 +37,7 @@ import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.removeNode;
 import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.requirePath;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/xforminstances",
+    name = RestController.PATH + "/xforminstances",
     supportedClass = Void.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )
@@ -72,8 +71,7 @@ public class XformInstanceResource extends BaseResource<OpenmrsObject> {
         String xml = Utils.getRequiredString(post, "xml");
 
         String patientUuid = Utils.getRequiredString(post, "patient_uuid");
-        Patient patient = patientService.getPatientByUuid(patientUuid);
-        if (patient == null) throw new ObjectNotFoundException();
+        Patient patient = DbUtils.patientsByUuid.get(patientUuid);
 
         Document doc = XmlUtils.parse(xml);
         Element formElement = XmlUtils.requireElementTagName(doc.getDocumentElement(), "form");
@@ -136,7 +134,7 @@ public class XformInstanceResource extends BaseResource<OpenmrsObject> {
         // in the database's clob_datatype_storage table with a known UUID.
 
         FormService formService = Context.getFormService();
-        Form form = formService.getFormByUuid(formUuid);
+        Form form = DbUtils.formsByUuid.get(formUuid);
         String resourceName = form.getName() + ".xFormXslt";
         FormResource resource = formService.getFormResource(form, resourceName);
         if (resource == null) {

--- a/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
+++ b/openmrs/omod/src/main/java/org/openmrs/projectbuendia/webservices/rest/XformResource.java
@@ -34,7 +34,7 @@ import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.removeNode;
 import static org.openmrs.projectbuendia.webservices.rest.XmlUtils.requireDescendant;
 
 @Resource(
-    name = RestController.REST_VERSION_1_AND_NAMESPACE + "/xforms",
+    name = RestController.PATH + "/xforms",
     supportedClass = Form.class,
     supportedOpenmrsVersions = "1.10.*,1.11.*"
 )
@@ -65,7 +65,7 @@ public class XformResource extends BaseResource<Form> {
 
     /**
      * Adds the following fields to the {@link SimpleObject}:
-     *   - name: display name of the form
+     *   - name: display type of the form
      *   - date_created: the date the form was created, as ms since epoch
      *   - version: the version number of the form (e.g. 0.2.1)
      *   - date_changed: the date the form was last modified, as ms since epoch;

--- a/openmrs/omod/src/main/java/org/projectbuendia/openmrs/webservices/rest/RestController.java
+++ b/openmrs/omod/src/main/java/org/projectbuendia/openmrs/webservices/rest/RestController.java
@@ -13,31 +13,71 @@ package org.projectbuendia.openmrs.webservices.rest;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.APIAuthenticationException;
+import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.RestUtil;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.MainResourceController;
+import org.openmrs.projectbuendia.Utils;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Controller for the REST resources in this module. This implicitly picks up
  * all the resources with the Resource annotation.
  */
 @Controller
-@RequestMapping("/rest/" + RestController.REST_VERSION_1_AND_NAMESPACE)
+@RequestMapping("/rest/" + RestController.PATH)
 public class RestController extends MainResourceController {
-    public static final String REST_VERSION_1_AND_NAMESPACE =
-        RestConstants.VERSION_1 + "/projectbuendia";
+    public static final String PATH = RestConstants.VERSION_1 + "/projectbuendia";
     private final Log log = LogFactory.getLog(getClass());
 
     public RestController() {
         log.warn("Created ProjectBuendia RestController");
     }
 
-    /**
-     * @see org.openmrs.module.webservices.rest.web.v1_0.controller
-     * .BaseRestController#getNamespace()
-     */
     @Override public String getNamespace() {
-        return REST_VERSION_1_AND_NAMESPACE;
+        return PATH;
+    }
+
+    @Override public SimpleObject handleException(Exception e, HttpServletRequest request, HttpServletResponse response) throws Exception {
+        if (RestUtil.hasCause(e, APIAuthenticationException.class)) {
+            return apiAuthenticationExceptionHandler(e, request, response);
+        }
+
+        ResponseStatus ann = (ResponseStatus) e.getClass().getAnnotation(ResponseStatus.class);
+        int status = ann != null ? ann.value().value() : 500;
+        String description = ann != null ? ann.reason() : null;
+        String message = e.getMessage();
+        response.setStatus(status);
+
+        StackTraceElement top = e.getStackTrace()[0];
+        List<String> frames = new ArrayList<>();
+        int maxLevels = 20;
+        int level = 0;
+        for (StackTraceElement frame : e.getStackTrace()) {
+            frames.add(frame.toString());
+            level++;
+            if (level >= maxLevels) break;
+            if (frame.getClassName().contains(".projectbuendia.")) {
+                maxLevels = level + 1;  // show one more stack level
+            }
+        }
+
+        LinkedHashMap map = new LinkedHashMap();
+        if (!Utils.isEmpty(description)) map.put("description", description);
+        map.put("message", message);
+        map.put("frames", frames);
+        return new SimpleObject().add("error", map);
     }
 }

--- a/tools/rest
+++ b/tools/rest
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import shlex
+import sys
+
+AUTH_HEADER = 'Authorization: Basic YnVlbmRpYTpidWVuZGlh'
+CONTENT_TYPE_HEADER = 'Content-Type: application/json'
+
+args = sys.argv[1:]
+
+try:
+    server, path = args[:2]
+    assert '.' in server
+except:
+    sys.stderr.write('''Usage: %s <server>:<port> <path> [curl options...]
+
+Makes an HTTP request to the Buendia REST API at a given server.
+
+<server> should be the hostname of a Buendia server; the port number
+defaults to 9000 if not specified.
+
+<path> should be a URL path relative to the root of the REST API,
+such as "/patients", "/locations", etc.
+
+Any additional arguments will be passed along as options to the "curl"
+command.  The "-i" option is passed by default so that the HTTP header
+will be printed out.  If a "-d" option is detected, the HTTP method will
+automatically switch to POST and the Content-Type will be set to
+application/json.
+
+The curl command will be shown in yellow and the response headers
+will be shown in cyan.  If the response body is valid JSON, it will be
+pretty-printed with indentation; otherwise, the raw response data will
+be printed in red.
+
+Examples:
+
+    %s demo.buendia.org /locations  # GET all locations
+    %s demo.buendia.org /patients -d'{"id":"123"}'  # POST a patient
+
+''' % (sys.argv[0], sys.argv[0], sys.argv[0]))
+    sys.exit(1)
+
+if ':' not in server:
+    server += ':9000'
+path = path.lstrip('/')
+
+args[:2] = ['http://%s/openmrs/ws/rest/v1/projectbuendia/%s' % (server, path)]
+args = ['curl', '-isS', '-H', AUTH_HEADER] + args
+if any(arg.startswith('-d') for arg in args):
+    args[4:4] = ['-H', CONTENT_TYPE_HEADER, '-X', 'POST']
+
+command = ' '.join(shlex.quote(arg) for arg in args)
+sys.stderr.write('\x1b[33m%s\x1b[0m\n' % command)
+with os.popen(command) as output:
+    while True:
+        line = output.readline()
+        if line.endswith('\n'):
+            line = line[:-1]
+        if not line: break
+        sys.stderr.write('\x1b[36m%s\x1b[0m\n' % line)
+    body = output.read()
+    try:
+        data = json.loads(body)
+        print('\n' + json.dumps(data, indent=2))
+    except:
+        print('\n\x1b[31m' + body + '\x1b[0m')


### PR DESCRIPTION
The new REST client utility, `tools/rest`, can make GET or POST requests to a REST endpoint, and pretty-prints the results to make them easier to read.  This change goes hand-in-hand with a change to the error reporting format that makes errors much easier to understand in the `tools/rest` output.