### PR TITLE
Add buendia-site-reference package

### DIFF
--- a/packages/buendia-networking/data/usr/share/buendia/site/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/site/10-networking
@@ -1,22 +1,22 @@
 # 0 to join an existing wifi network; 1 to become an AP and create a network.
-NETWORKING_AP=0
+# NETWORKING_AP=0
 
 # Default network interfaces on the Intel NUC
-NETWORKING_WIFI_INTERFACE=wlp2s0
-NETWORKING_ETHERNET_INTERFACE=enp3s0
+# NETWORKING_WIFI_INTERFACE=wlp2s0
+# NETWORKING_ETHERNET_INTERFACE=enp3s0
 
 # SSID and WPA password for the network to join or create.
-NETWORKING_SSID=buendia
+# NETWORKING_SSID=buendia
 # Default password must be at least 8 characters for the client
-NETWORKING_PASSWORD=password
+# NETWORKING_PASSWORD=password
 
 # 0 to rely on externally provided DHCP and DNS services; 1 to authoritatively
 # provide DHCP and DNS service for the network.
-NETWORKING_DHCP_DNS_SERVER=0
+# NETWORKING_DHCP_DNS_SERVER=0
 
 # Set to provide DHCP (if NETWORKING_DHCP_DNS_SERVER is set); otherwise none is provided.
-NETWORKING_DHCP_RANGE=10.0.0.100,10.0.0.199,12h
+# NETWORKING_DHCP_RANGE=10.0.0.100,10.0.0.199,12h
 
 # This host's wireless IP address. If unset, then DHCP is used to get an
 # address on the wireless interface.
-NETWORKING_IP_ADDRESS=10.0.0.50
+# NETWORKING_IP_ADDRESS=10.0.0.50

--- a/packages/buendia-site-reference/Makefile
+++ b/packages/buendia-site-reference/Makefile
@@ -1,0 +1,3 @@
+include ../Makefile.inc
+
+$(EXTRA_DATA): $(EXTRA_DATA)/usr/share/buendia/site/id

--- a/packages/buendia-site-reference/control/control.template
+++ b/packages/buendia-site-reference/control/control.template
@@ -1,0 +1,8 @@
+Package: ${PACKAGE_NAME}
+Version: ${PACKAGE_VERSION}
+Architecture: all
+Pre-Depends: buendia-utils
+Provides: buendia-site
+Conflicts: buendia-site
+Description: Site config: Reference deployment
+Maintainer: projectbuendia.org

--- a/packages/buendia-site-reference/control/control.template
+++ b/packages/buendia-site-reference/control/control.template
@@ -6,3 +6,4 @@ Provides: buendia-site
 Conflicts: buendia-site
 Description: Site config: Reference deployment
 Maintainer: projectbuendia.org
+Depends: buendia-networking, buendia-dashboard, buendia-pkgserver, buendia-update, buendia-backup, buendia-monitoring, buendia-sshd

--- a/packages/buendia-site-reference/control/postinst
+++ b/packages/buendia-site-reference/control/postinst
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright 2015 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+set -e; . /usr/share/buendia/utils.sh
+
+case $1 in
+    configure|abort-upgrade|abort-remove|abort-deconfigure)
+        buendia-reconfigure
+        ;;
+
+    *) exit 1
+esac

--- a/packages/buendia-site-reference/data/usr/share/buendia/packages.list.d/site
+++ b/packages/buendia-site-reference/data/usr/share/buendia/packages.list.d/site
@@ -1,7 +1,9 @@
 buendia-backup
 buendia-dashboard
+buendia-monitoring
 buendia-networking
 buendia-pkgserver
 buendia-server
 buendia-site-reference
 buendia-sshd
+buendia-update

--- a/packages/buendia-site-reference/data/usr/share/buendia/packages.list.d/site
+++ b/packages/buendia-site-reference/data/usr/share/buendia/packages.list.d/site
@@ -1,0 +1,7 @@
+buendia-backup
+buendia-dashboard
+buendia-networking
+buendia-pkgserver
+buendia-server
+buendia-site-reference
+buendia-sshd

--- a/packages/buendia-site-reference/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-reference/data/usr/share/buendia/site/40-site
@@ -1,4 +1,4 @@
-# Site configuration for integration testing on an Edison.
+# Site configuration for reference deployments
 
 SERVER_OPENMRS_USER=buendia
 SERVER_OPENMRS_PASSWORD=buendia
@@ -22,7 +22,7 @@ NETWORKING_ETHERNET_INTERFACE=enp3s0
 
 # Join the existing "buendia" network as provided by the Nanostation
 NETWORKING_SSID=buendia
-NETWORKING_PASSWORD=buendia
+NETWORKING_PASSWORD=plumpynut
 
 # Get a static address on the network and provide DNS but not DHCP.
 NETWORKING_IP_ADDRESS=10.0.0.2

--- a/packages/buendia-site-reference/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-reference/data/usr/share/buendia/site/40-site
@@ -1,0 +1,33 @@
+# Site configuration for integration testing on an Edison.
+
+SERVER_OPENMRS_USER=buendia
+SERVER_OPENMRS_PASSWORD=buendia
+
+MONITORING_LIMITS='
+100000 /var/log/large/requests
+200000 /var/log
+
+300000 /var/cache
+
+50000 /var/backups/buendia/packages
+50000 /var/backups/buendia/backup*
+100000 /var/backups/buendia
+
+100000 /usr/share/buendia/packages
+'
+
+# Default network interfaces on the Intel NUC
+NETWORKING_WIFI_INTERFACE=wlp2s0
+NETWORKING_ETHERNET_INTERFACE=enp3s0
+
+# Join the existing "buendia" network as provided by the Nanostation
+NETWORKING_SSID=buendia
+NETWORKING_PASSWORD=buendia
+
+# Get a static address on the network and provide DNS but not DHCP.
+NETWORKING_IP_ADDRESS=10.0.0.2
+NETWORKING_DHCP_DNS_SERVER=1
+NETWORKING_DHCP_RANGE=
+
+# Keep the NUC up to date.
+UPDATE_AUTOUPDATE=1

--- a/tools/iso/preseed.cfg
+++ b/tools/iso/preseed.cfg
@@ -1409,7 +1409,7 @@ d-i apt-setup/local0/repository string [trusted=yes] https://projectbuendia.gith
 d-i apt-setup/local0/comment string Buendia Packages
 
 # Add any packages you want installed in the final installer stage here:
-d-i pkgsel/include string buendia-server buendia-site-test buendia-networking buendia-dashboard buendia-pkgserver buendia-update buendia-backup buendia-monitoring
+d-i pkgsel/include string buendia-server buendia-site-reference buendia-networking buendia-dashboard buendia-pkgserver buendia-update buendia-backup buendia-monitoring
 
 # Placing an executable command in /usr/lib/pre-pkgsel.d ensures that the
 # command is run after the chroot is set up but before any packages are


### PR DESCRIPTION
The reference deployment consists of a NanoStation M2 on 10.0.0.1/24, providing DHCP with the DNS server set to 10.0.0.2. The wifi SSID is `buendia`.

This package configures the NUC to take 10.0.0.2/24 on its wifi interface, and provide DNS on that address.

The Wi-Fi password should be set manually by adding a `NETWORKING_PASSWORD` parameter to `/usr/share/buendia/site/75-networking` or similar.