### PR TITLE
Restore automatically restores any backup if the current database has never been used

### DIFF
--- a/packages/buendia-backup/data/usr/bin/buendia-backup
+++ b/packages/buendia-backup/data/usr/bin/buendia-backup
@@ -41,6 +41,16 @@ if buendia-db-is-empty >/dev/null; then
     exit 0
 fi
 
+# Use the file descriptor to place a runtime lock, to prevent two updates
+# happening simultaneously. When the process exits the file descriptor will be
+# lost (unlike a file). This prevents multiple backups, or backup and restore
+# from happening simultaneously.
+exec 9> /var/run/lock/buendia-backup
+if ! flock -n 9; then
+    echo "Backup or restore already running; not starting."
+    exit 1
+fi
+
 # Keep one backup per day.  (If you need to maintain a backup that is
 # much less than a day old, run buendia-backup multiple times per day.)
 backup_id=$(date +'%Y-%m-%d')

--- a/packages/buendia-backup/data/usr/bin/buendia-backup
+++ b/packages/buendia-backup/data/usr/bin/buendia-backup
@@ -36,8 +36,8 @@ if [ "$root" = "" -o "$1" = "-h" ]; then
 fi
 
 # Check if there's anything to back up. If not, notify and exit early.
-if buendia-db-is-unused >/dev/null; then
-    echo "No patients have been created; skipping backup."
+if buendia-db-is-empty >/dev/null; then
+    echo "The database is still empty; skipping backup."
     exit 0
 fi
 

--- a/packages/buendia-backup/data/usr/bin/buendia-backup
+++ b/packages/buendia-backup/data/usr/bin/buendia-backup
@@ -35,6 +35,12 @@ if [ "$root" = "" -o "$1" = "-h" ]; then
     exit 1
 fi
 
+# Check if there's anything to back up. If not, notify and exit early.
+if buendia-db-is-unused >/dev/null; then
+    echo "No patients have been created; skipping backup."
+    exit 0
+fi
+
 # Keep one backup per day.  (If you need to maintain a backup that is
 # much less than a day old, run buendia-backup multiple times per day.)
 backup_id=$(date +'%Y-%m-%d')

--- a/packages/buendia-backup/data/usr/bin/buendia-db-is-empty
+++ b/packages/buendia-backup/data/usr/bin/buendia-db-is-empty
@@ -21,7 +21,7 @@ patient_count=$(echo "select count(*) from patient" | \
     mysql -s -u$OPENMRS_MYSQL_USER -p$OPENMRS_MYSQL_PASSWORD openmrs)
 
 if [ "$patient_count" -eq 0 ]; then
-    echo "unused"
+    echo "empty"
     exit 0
 fi
 

--- a/packages/buendia-backup/data/usr/bin/buendia-db-is-unused
+++ b/packages/buendia-backup/data/usr/bin/buendia-db-is-unused
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2019 The Project Buendia Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy
+# of the License at: http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distrib-
+# uted under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+# OR CONDITIONS OF ANY KIND, either express or implied.  See the License for
+# specific language governing permissions and limitations under the License.
+
+if [ "$1" = "-h" ]; then
+    echo "$0 returns true iff no patient records have been created"
+    exit 255
+fi
+
+set -e; . /usr/share/buendia/utils.sh
+
+patient_count=$(echo "select count(*) from patient" | \
+    mysql -s -u$OPENMRS_MYSQL_USER -p$OPENMRS_MYSQL_PASSWORD openmrs)
+
+if [ "$patient_count" -eq 0 ]; then
+    echo "unused"
+    exit 0
+fi
+
+echo "in-use"
+exit 1

--- a/packages/buendia-backup/data/usr/bin/buendia-restore
+++ b/packages/buendia-backup/data/usr/bin/buendia-restore
@@ -41,10 +41,11 @@ fi
 # Use the file descriptor to place a runtime lock, to prevent two updates
 # happening simultaneously. When the process exits the file descriptor will
 # be lost (unlike a file). This allows cron to poll every minute while still
-# having a runtime longer than one minute.
-exec 9> /var/run/lock/$name
+# having a runtime longer than one minute, and prevents backup and restore from
+# happening simultaneously.
+exec 9> /var/run/lock/buendia-backup
 if ! flock -n 9; then
-    echo "$name already running; not starting."
+    echo "Backup or restore already running; not starting."
     exit 1
 fi
 # Prepare some empty temporary directories.

--- a/packages/buendia-backup/data/usr/bin/buendia-restore
+++ b/packages/buendia-backup/data/usr/bin/buendia-restore
@@ -33,8 +33,8 @@ if [ "$root" = "" -o "$1" = "-h" ]; then
 fi
 
 # Check if it's safe to restore. If not, notify and exit early.
-if ! buendia-db-is-unused >/dev/null; then
-    echo "Patient records already exist; skipping restore."
+if ! buendia-db-is-empty >/dev/null; then
+    echo "Database is not empty; skipping restore."
     exit 0
 fi
 

--- a/packages/buendia-backup/data/usr/bin/buendia-restore
+++ b/packages/buendia-backup/data/usr/bin/buendia-restore
@@ -16,7 +16,6 @@ export MYSQL_PASSWORD=$OPENMRS_MYSQL_PASSWORD
 root=$1
 name=$(basename $0)
 
-
 if [ "$root" = "" -o "$1" = "-h" ]; then
     echo "Usage: $0 <restore-root-path>"
     echo "       $0 <block-device>"
@@ -62,16 +61,16 @@ if [ -b "$root" ]; then
     mkdir -p "$mnt_dir"
     mount "$root" "$mnt_dir"
 
-    root="$mnt_dir/restore"
+    # Find the latest backup directory on the device, or else.
+    backup_dir=$(ls -d $mnt_dir/backup.????-??-?? 2>/dev/null | tail -1)
+    if [ -z "$backup_dir" ]; then
+        echo "No backups found on $root, exiting."
+        exit 1
+    fi
+    root=$backup_dir
 
 elif [ ! -d "$root" ]; then
     echo "$root is neither a block device nor a directory."
-    exit 1
-fi
-
-# If the root directory does not exist, then give up
-if [ ! -e $root ]; then
-    echo "$root does not exist, exiting."
     exit 1
 fi
 

--- a/packages/buendia-backup/data/usr/bin/buendia-restore
+++ b/packages/buendia-backup/data/usr/bin/buendia-restore
@@ -33,6 +33,12 @@ if [ "$root" = "" -o "$1" = "-h" ]; then
     exit 1
 fi
 
+# Check if it's safe to restore. If not, notify and exit early.
+if ! buendia-db-is-unused >/dev/null; then
+    echo "Patient records already exist; skipping restore."
+    exit 0
+fi
+
 # Use the file descriptor to place a runtime lock, to prevent two updates
 # happening simultaneously. When the process exits the file descriptor will
 # be lost (unlike a file). This allows cron to poll every minute while still

--- a/packages/buendia-backup/data/usr/share/buendia/tests/20-backup-skip-safe
+++ b/packages/buendia-backup/data/usr/share/buendia/tests/20-backup-skip-safe
@@ -1,6 +1,6 @@
 # if there aren't any patient records yet, prove that backups don't run
 test_10_no_backups_if_no_patients () {
-    buendia-db-is-unused || return 0
+    buendia-db-is-empty || return 0
     buendia-backup no-backup
     [ ! -d no-backup ]
 }

--- a/packages/buendia-backup/data/usr/share/buendia/tests/20-backup-skip-safe
+++ b/packages/buendia-backup/data/usr/share/buendia/tests/20-backup-skip-safe
@@ -1,0 +1,6 @@
+# if there aren't any patient records yet, prove that backups don't run
+test_10_no_backups_if_no_patients () {
+    buendia-db-is-unused || return 0
+    buendia-backup no-backup
+    [ ! -d no-backup ]
+}

--- a/packages/buendia-backup/data/usr/share/buendia/tests/50-backup-locked-safe
+++ b/packages/buendia-backup/data/usr/share/buendia/tests/50-backup-locked-safe
@@ -1,0 +1,10 @@
+test_10_prevent_simultaneous_backup () {
+    mount_loopback
+    buendia-backup /dev/loop0 &
+    if buendia-backup /dev/loop0; then
+        echo "Simultaneous backup should be prevented"
+        return 1
+    fi
+    kill %1
+    return 0
+}

--- a/packages/buendia-backup/data/usr/share/buendia/tests/60-backup-and-restore
+++ b/packages/buendia-backup/data/usr/share/buendia/tests/60-backup-and-restore
@@ -15,13 +15,8 @@ test_30_create_backup () {
     [ -d loop/backup.$(date +%Y-%m-%d) ]
 }
 
-test_40_create_patient () {
-    USER_ID=$(head -c8 /dev/random | base64)
-    openmrs_post patients/ >create-patient.json <<END
-        {"id": "$USER_ID", "given_name": "Louis", "family_name": "Pasteur", "sex": "M", "birthdate": "1924-08-20"}
-END
-    cat create-patient.json
-    grep '"uuid" *: *"........-....-....-....-............"' create-patient.json
+test_40_delete_all_patients () {
+    echo "delete from encounter; delete from patient" | execute_openmrs_sql
 }
 
 test_50_confirm_changed_patient_list () {

--- a/packages/buendia-backup/data/usr/share/buendia/tests/60-backup-and-restore
+++ b/packages/buendia-backup/data/usr/share/buendia/tests/60-backup-and-restore
@@ -31,7 +31,6 @@ test_50_confirm_changed_patient_list () {
 }
 
 test_60_restore_from_backup () {
-    mv loop/backup.$(date +%Y-%m-%d) loop/restore || return 1
     execute_cron_right_now backup
 }
 


### PR DESCRIPTION
This PR changes the behavior of `buendia-restore` to restore the latest directory from an external block device that matches the format _backup.YYYY-MM-DD_, but only if the current database has no patient entries.

Also the behavior of `buendia-backup` is changed to refrain from creating backups _unless_ the database has patient entries.

For this purpose is included is a utility shell script `buendia-db-is-unused` which returns true if and only if the database contains exactly zero patient records.

The integration tests have been updated to confirm the new behavior.
