### PR TITLE
Have the server use a single hostname: `buendia`

### DIFF
--- a/packages/buendia-backup/data/usr/bin/buendia-restore
+++ b/packages/buendia-backup/data/usr/bin/buendia-restore
@@ -124,18 +124,6 @@ fi
 if [ $progress_state -le $PROGRESS_SETTINGS_NEXT ]; then
   # ---- Restore the buendia settings
   echo "Restoring buendia-settings"
-  # Restore the nameserver settings
-  mv /usr/share/buendia/names.d /usr/share/buendia/names.$$.d
-  # TODO(nfortescue): investigate tar then move rather than straight tar
-  # to reduce time directory is empty
-  if tar -xzf $root/buendia.tar.gz -C / usr/share/buendia/names.d; then
-    rm -rf /usr/share/buendia/names.$$.d
-  else # restore the old settings in the event of failure
-    rm -rf /usr/share/buendia/names.d
-    mv /usr/share/buendia/names.$$.d /usr/share/buendia/names.d
-    echo "Failed to extract new settings"
-    exit 1
-  fi
 
   # Restore backed up site settings
   mv /usr/share/buendia/site /usr/share/buendia/site.$$

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/client
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/client
@@ -19,7 +19,7 @@ Content-Type: text/html
 <link rel="stylesheet" href="style.css">
 <h1>Client app</h1>
 
-<p>Latest version: <a href="http://packages:9001/$latest">$latest</a>
+<p>Latest version: <a href="http://buendia:9001/$latest">$latest</a>
 
 <p>All files:
 <ul>
@@ -27,7 +27,7 @@ EOF
 
 for file in $(ls -t *.apk); do
     cat <<EOF
-<li><a href="http://packages:9001/$file">$file</a>
+<li><a href="http://buendia:9001/$file">$file</a>
 EOF
 done
 

--- a/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
+++ b/packages/buendia-dashboard/data/usr/share/buendia/dashboard/index
@@ -44,7 +44,7 @@ Refresh: 10
 
 <p><a href="client">Download client app</a>
 
-<p><a href="//server:9000/openmrs/moduleServlet/buendiadata">Download CSV data</a>
+<p><a href="//buendia:9000/openmrs/moduleServlet/buendiadata">Download CSV data</a>
 
 <p><a href="stats.zip">Download usage stats</a>
 
@@ -53,7 +53,7 @@ Refresh: 10
 
 <p><a href="status">System status</a>
 
-<p><a href="//packages:9001">Package repository</a>
+<p><a href="//buendia:9001">Package repository</a>
 
 <p><a href="reboot">Reboot server</a>
 

--- a/packages/buendia-networking/data/usr/bin/buendia-update-hosts
+++ b/packages/buendia-networking/data/usr/bin/buendia-update-hosts
@@ -26,10 +26,10 @@ unset CLICOLOR
 unset CLICOLOR_FORCE
 unset LSCOLORS
 unset LS_COLORS
-names=$(echo $(hostname) $(cat /usr/share/buendia/names.d/* | sed -e 's/#.*//'))
 
 # Add a line for each of the machine's IP addresses.
 # TODO this matching pattern apparently isn't quite right
+names="buendia buendia.local"
 for ip in $(ip a | grep 'inet ' | cut -d' ' -f6 | cut -d/ -f1 | grep -v '^127\.'); do
     echo "$ip $names  # added by buendia-update-hosts" >> $tmp
 done

--- a/packages/buendia-networking/data/usr/share/buendia/names.d/README
+++ b/packages/buendia-networking/data/usr/share/buendia/names.d/README
@@ -1,5 +1,0 @@
-# Files in this directory list hostnames by which this machine wants to be
-# known.  Each file should contain hostnames in a list, one per line.
-# Blank lines and comments (everything after "#" on a line) are ignored.
-# When NETWORKING_DHCP_DNS_SERVER is 1, this machine will be a DNS server
-# that resolves all of these names to its own IP.

--- a/packages/buendia-ntpserver/data/usr/share/buendia/names.d/ntpserver
+++ b/packages/buendia-ntpserver/data/usr/share/buendia/names.d/ntpserver
@@ -1,6 +1,0 @@
-# Hostname on the local network
-ntp
-ntp.local
-
-# Default NTP server hostname used by Sony Xperia Z2 tablets
-ntp.nict.jp

--- a/packages/buendia-pkgserver/data/usr/share/buendia/names.d/pkgserver
+++ b/packages/buendia-pkgserver/data/usr/share/buendia/names.d/pkgserver
@@ -1,3 +1,0 @@
-# Hostname on the local network
-packages
-packages.local

--- a/packages/buendia-pkgserver/data/usr/share/buendia/site/10-pkgserver
+++ b/packages/buendia-pkgserver/data/usr/share/buendia/site/10-pkgserver
@@ -1,1 +1,1 @@
-PKGSERVER_URL="http://packages:9001/"
+PKGSERVER_URL="http://buendia:9001/"

--- a/packages/buendia-server/data/usr/share/buendia/names.d/server
+++ b/packages/buendia-server/data/usr/share/buendia/names.d/server
@@ -1,3 +1,0 @@
-# Hostname on the local network
-server
-server.local


### PR DESCRIPTION
Earlier versions of buendia allowed packages to specify different hostnames it wanted the host to serve via DNS, e.g. `packages` or `server`, by means of files in `/usr/share/buendia/names.d` which would be read by `buendia-networking` when configuring the network stack. This seems unnecessary and fragile with our current setup.

This PR removes this feature from `buendia-networking` and updates it to provide two hostnames `buendia` and `buendia.local` on the local network when serving DNS.