### PR TITLE
Use Java options to prevent slow Tomcat startup

### DIFF
--- a/packages/buendia-server/data/usr/share/buendia/config.d/70-server
+++ b/packages/buendia-server/data/usr/share/buendia/config.d/70-server
@@ -12,16 +12,6 @@
 
 set -e; . /usr/share/buendia/utils.sh
 
-# Ensure that /dev/random points to a fast source of entropy.  If it points
-# to the blocking device, Catalina may take 5-10 minutes to start up!
-if [ ! -L /dev/random ]; then
-    if [ -e /dev/random ]; then
-        mv -f /dev/random /dev/blocking-random
-    fi
-fi
-rm -f /dev/random
-ln -sf /dev/urandom /dev/random
-
 # Provide a randomly generated password for the Buendia user, if necessary.
 generated=/usr/share/buendia/site/20-server
 if [ ! -e $generated -o -z "$SERVER_OPENMRS_PASSWORD" ]; then

--- a/packages/buendia-tomcat7/data/usr/share/buendia/diversions/etc/default/tomcat7
+++ b/packages/buendia-tomcat7/data/usr/share/buendia/diversions/etc/default/tomcat7
@@ -1,7 +1,16 @@
 TOMCAT7_USER=tomcat7
 TOMCAT7_GROUP=tomcat7
 
+# NOTE SDE 2019-09-25: the following comment says "Edison" but I see no reason
+# to change it yet
+#
 # JVM parameters tuned for Edison
 # Increasing the memory limit from 128M to 256M reduces swapping overhead.
 # CMSIncrementalMode reduces latency by yielding periodically during GC sweeps.
 JAVA_OPTS="-Djava.awt.headless=true -Xmx256m -XX:+UseConcMarkSweepGC -XX:+CMSIncrementalMode"
+
+# Eliminate slow startup due to Catalina looking for a secure random source, e.g.
+# https://ruleoftech.com/2016/avoiding-jvm-delays-caused-by-random-number-generation
+#
+# Otherwise Catalina may take 5-10 minutes for a cold start.
+CATALINA_OPTS="-Djava.security.egd=file:/dev/./urandom"


### PR DESCRIPTION
We've experienced slow server startup times in the past, due to a [fairly well-known issue](https://ruleoftech.com/2016/avoiding-jvm-delays-caused-by-random-number-generation) with Catalina blocking while looking for randomness.

In 1562e92, we tackled this issue by replacing `/dev/random` with `/dev/urandom`; however, this approach has two disadvantages: One, the PRNG devices are replaced by Debian on boot; two, it addresses a JVM "bug" by making a system-wide change with possible unintended consequences.

This PR addresses the problem a little more directly by explicitly telling the JVM which PRNG to use when starting Catalina. The use of `/dev/./urandom` (_sic_) apparently sidesteps some cleverness internal to the JVM that we evidently _don't_ want.