### PR TITLE
Run integration tests on staging after every dev build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,10 @@ jobs:
             ssh-keyscan $STAGING_HOST >> $HOME/.ssh/known_hosts
             ssh $SSH_USER@$STAGING_HOST "sudo apt-get update; sudo apt-get -y -f install; sudo apt-get -y upgrade; sudo apt-get -y -f install"
 
+      - deploy:
+          name: Run all integration tests
+          command: ssh $SSH_USER@$STAGING_HOST "sudo buendia-run-tests --unsafe"
+
   purge-unstable-repo:
     working_directory: ~/buendia
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,28 +164,44 @@ jobs:
           # Carry forward the artifacts from the previous build job
           path: /tmp/artifacts
 
-      - deploy:
-          name: Deploy to download.buendia.org
-          command: |
-            if [ "$BUENDIA_BRANCH" = "dev" -o "$BUENDIA_BRANCH" = "master" ]; then
-                ssh-keyscan $DOWNLOAD_HOST >> $HOME/.ssh/known_hosts
-                ssh $SSH_USER@$DOWNLOAD_HOST "cd builds && \
-                      git fetch --force origin gh-pages && \
-                      git reset --hard origin/gh-pages && \
-                      git checkout -q -B gh-pages && \
-                      mkdir /var/www/html/deb.new && \
-                      git archive gh-pages | tar -C/var/www/html/deb.new --strip-components 1 -xf - packages && \
-                      rm -r /var/www/html/deb && \
-                      mv /var/www/html/deb.new /var/www/html/deb"
-            fi
+  deploy-download:
+    docker:
+      - image: projectbuendia/debian-stretch:1.1.0
+
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            # staging.buendia.org deploy key
+            - "99:7c:11:11:e7:7b:e8:de:c4:0c:4e:6d:1d:cc:2e:1a"
 
       - deploy:
-          name: Deploy to staging.buendia.org
+          name: Deploy to download host
           command: |
-            if [ "$BUENDIA_BRANCH" = "dev" -o "$BUENDIA_BRANCH" = "master" ]; then
-                ssh-keyscan $STAGING_HOST >> $HOME/.ssh/known_hosts
-                ssh $SSH_USER@$STAGING_HOST "sudo apt-get update; sudo apt-get -y -f install; sudo apt-get -y upgrade; sudo apt-get -y -f install"
-            fi
+            ssh-keyscan $DOWNLOAD_HOST >> $HOME/.ssh/known_hosts
+            ssh $SSH_USER@$DOWNLOAD_HOST "cd builds && \
+                  git fetch --force origin gh-pages && \
+                  git reset --hard origin/gh-pages && \
+                  git checkout -q -B gh-pages && \
+                  mkdir /var/www/html/deb.new && \
+                  git archive gh-pages | tar -C/var/www/html/deb.new --strip-components 1 -xf - packages && \
+                  rm -r /var/www/html/deb && \
+                  mv /var/www/html/deb.new /var/www/html/deb"
+
+  deploy-staging:
+    docker:
+      - image: projectbuendia/debian-stretch:1.1.0
+
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            # staging.buendia.org deploy key
+            - "99:7c:11:11:e7:7b:e8:de:c4:0c:4e:6d:1d:cc:2e:1a"
+
+      - deploy:
+          name: Deploy to staging host
+          command: |
+            ssh-keyscan $STAGING_HOST >> $HOME/.ssh/known_hosts
+            ssh $SSH_USER@$STAGING_HOST "sudo apt-get update; sudo apt-get -y -f install; sudo apt-get -y upgrade; sudo apt-get -y -f install"
 
   purge-unstable-repo:
     working_directory: ~/buendia
@@ -275,6 +291,12 @@ workflows:
                 - dev
             tags:
               ignore: /.*/
+      - deploy-download:
+          requires:
+              - apt-archive
+      - deploy-staging:
+          requires:
+              - deploy-download
 
   release-build:
     # Ensure that tagged releases get their own CircleCI build:
@@ -292,6 +314,9 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - deploy-download:
+          requires:
+              - apt-archive
 
   clean-apt-archive:
     # Eliminate older unstable packages every night at 2am. This is intended to

--- a/packages/buendia-backup/data/usr/share/buendia/tests/50-backup-locked-safe
+++ b/packages/buendia-backup/data/usr/share/buendia/tests/50-backup-locked-safe
@@ -1,7 +1,7 @@
 test_10_prevent_simultaneous_backup () {
     mount_loopback
     buendia-backup /dev/loop0 &
-    sleep 0.05
+    sleep 0.1
     if buendia-backup /dev/loop0; then
         echo "Simultaneous backup should be prevented"
         return 1

--- a/packages/buendia-backup/data/usr/share/buendia/tests/60-backup-and-restore
+++ b/packages/buendia-backup/data/usr/share/buendia/tests/60-backup-and-restore
@@ -16,7 +16,7 @@ test_30_create_backup () {
 }
 
 test_40_delete_all_patients () {
-    echo "delete from encounter; delete from patient" | execute_openmrs_sql
+    echo "delete from obs; delete from encounter; delete from patient" | execute_openmrs_sql
 }
 
 test_50_confirm_changed_patient_list () {


### PR DESCRIPTION
Now that we have a separate demo server, we can run the integration tests on `staging.buendia.org` on every dev build, so that we get an alert (via the CircleCI Slack integration) if the tests ever fail.

This PR splits out the CircleCI tasks of deploying new packages to the download and staging servers for clarity, and adds a final call to the staging server via SSH to run the tests.

Also included are two small fixes to the `buendia-backup` tests for previously-untested and race conditions.