### PR TITLE
Add automatic forced database upgrades when migration fails.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,13 +198,13 @@ jobs:
             - "99:7c:11:11:e7:7b:e8:de:c4:0c:4e:6d:1d:cc:2e:1a"
 
       - deploy:
-          name: Deploy to staging host
+          name: Run buendia-update on staging
           command: |
             ssh-keyscan $STAGING_HOST >> $HOME/.ssh/known_hosts
-            ssh $SSH_USER@$STAGING_HOST "sudo apt-get update; sudo apt-get -y -f install; sudo apt-get -y upgrade; sudo apt-get -y -f install"
+            ssh $SSH_USER@$STAGING_HOST "sudo buendia-update"
 
       - deploy:
-          name: Run all integration tests
+          name: Run all integration tests on staging
           command: ssh $SSH_USER@$STAGING_HOST "sudo buendia-run-tests --unsafe"
 
   purge-unstable-repo:

--- a/packages/buendia-site-cloud-demo/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-cloud-demo/data/usr/share/buendia/site/40-site
@@ -16,7 +16,5 @@ MONITORING_LIMITS='
 100000 /usr/share/buendia/packages
 '
 
-# Enable automatic upgrades and forced upgrades, so that we always have the
-# latest code running.
+# Enable automatic upgrades!
 UPDATE_AUTOUPDATE=1
-UPDATE_DESTRUCTIVE_MIGRATION=1

--- a/packages/buendia-site-cloud-demo/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-cloud-demo/data/usr/share/buendia/site/40-site
@@ -16,4 +16,7 @@ MONITORING_LIMITS='
 100000 /usr/share/buendia/packages
 '
 
+# Enable automatic upgrades and forced updates, so that we always have the
+# latest code running.
 UPDATE_AUTOUPDATE=1
+UPDATE_FORCED_UPGRADE=1

--- a/packages/buendia-site-cloud-demo/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-cloud-demo/data/usr/share/buendia/site/40-site
@@ -16,7 +16,7 @@ MONITORING_LIMITS='
 100000 /usr/share/buendia/packages
 '
 
-# Enable automatic upgrades and forced updates, so that we always have the
+# Enable automatic upgrades and forced upgrades, so that we always have the
 # latest code running.
 UPDATE_AUTOUPDATE=1
-UPDATE_FORCED_UPGRADE=1
+UPDATE_FORCE_UPGRADE=1

--- a/packages/buendia-site-cloud-demo/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-cloud-demo/data/usr/share/buendia/site/40-site
@@ -19,4 +19,4 @@ MONITORING_LIMITS='
 # Enable automatic upgrades and forced upgrades, so that we always have the
 # latest code running.
 UPDATE_AUTOUPDATE=1
-UPDATE_FORCE_UPGRADE=1
+UPDATE_DESTRUCTIVE_MIGRATION=1

--- a/packages/buendia-site-test-integration/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-test-integration/data/usr/share/buendia/site/40-site
@@ -22,7 +22,7 @@ UPDATE_AUTOUPDATE=0
 
 # Enable forced upgrades so that we always have the latest code running,
 # regardless of whatever was in the database.
-UPDATE_FORCED_UPGRADE=1
+UPDATE_FORCE_UPGRADE=1
 
 # Enable unsafe testing for this site by default.
 UTILS_RUN_UNSAFE_TESTS=1

--- a/packages/buendia-site-test-integration/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-test-integration/data/usr/share/buendia/site/40-site
@@ -22,7 +22,7 @@ UPDATE_AUTOUPDATE=0
 
 # Enable forced upgrades so that we always have the latest code running,
 # regardless of whatever was in the database.
-UPDATE_FORCE_UPGRADE=1
+UPDATE_DESTRUCTIVE_MIGRATION=1
 
 # Enable unsafe testing for this site by default.
 UTILS_RUN_UNSAFE_TESTS=1

--- a/packages/buendia-site-test-integration/data/usr/share/buendia/site/40-site
+++ b/packages/buendia-site-test-integration/data/usr/share/buendia/site/40-site
@@ -20,5 +20,9 @@ MONITORING_LIMITS='
 # risking collision
 UPDATE_AUTOUPDATE=0
 
+# Enable forced upgrades so that we always have the latest code running,
+# regardless of whatever was in the database.
+UPDATE_FORCED_UPGRADE=1
+
 # Enable unsafe testing for this site by default.
 UTILS_RUN_UNSAFE_TESTS=1

--- a/packages/buendia-update/data/usr/bin/buendia-update
+++ b/packages/buendia-update/data/usr/bin/buendia-update
@@ -27,10 +27,6 @@ if ! flock -n 9; then
     exit 1
 fi
 
-# Checking for updates: red on
-buendia-led red on
-trap 'buendia-led red off; buendia-led yellow off' EXIT
-
 export DEBIAN_FRONTEND=noninteractive
 echo "--- Starting: $0 $@"
 buendia-status
@@ -54,11 +50,42 @@ if [ -n "$1" ]; then
 else
     packages=$(echo $(sed -e 's/#.*//' /usr/share/buendia/packages.list.d/*))
 fi
+
+# Attempt database migration first, if requested
+if echo $packages | grep buendia-server; then
+    echo "--- Attempting database migration"
+    apt-get -V -y --allow-unauthenticated install buendia-db-migrate
+
+    from_version=$(dpkg-query --showformat='${Version}' --show buendia-server)
+    to_version=$(dpkg-query --showformat='${Version}' --show buendia-db-migrate)
+    buendia-db-migrate $from_version $to_version
+    migration_failed=$?
+
+    if bool $migration_failed && bool "$UPDATE_FORCE_UPGRADE"; then
+        echo "--- Migration failed; performing forced upgrade"
+        if [ -x /usr/bin/buendia-openmrs-dump ]; then
+            echo "--- Dumping database v${from_version}"
+            buendia-openmrs-dump openmrs /var/backups/buendia/buendia-db-${from_version}.zip
+        fi
+
+        echo "--- Remove old database"
+        apt-get purge -y buendia-db
+        rm /etc/buendia-db-init-installed
+
+        echo "--- Create new database"
+        apt-get install -V -y buendia-db-init buendia-server
+        buendia-openmrs-account-setup $SERVER_OPENMRS_USER $SERVER_OPENMRS_PASSWORD
+        buendia-openmrs-location-setup
+
+        latest_profile=$(ls -t /usr/share/buendia/profiles/* | head -1)
+        if [ -x /usr/bin/buendia-profile-apply -a -n "$latest_profile" ]; then
+            buendia-profile-apply $latest_profile
+        fi
+    fi
+fi
+
 echo
 echo "--- Updating packages: $packages"
-# Applying updates: red and yellow
-buendia-led red on
-buendia-led yellow on
 
 apt-get -V -y --allow-unauthenticated install $packages
 install_status=$?

--- a/packages/buendia-update/data/usr/bin/buendia-update
+++ b/packages/buendia-update/data/usr/bin/buendia-update
@@ -62,7 +62,7 @@ if echo $packages | grep buendia-server; then
     migration_failed=$?
 
     if bool $migration_failed; then
-        if ! bool "$UPDATE_FORCE_UPGRADE"; then
+        if ! bool "$UPDATE_DESTRUCTIVE_MIGRATION"; then
             echo "--- MIGRATION FAILED FROM v${from_version} to v{$to_version}; EXITING"
             exit $migration_failed
         fi

--- a/packages/buendia-update/data/usr/bin/buendia-update
+++ b/packages/buendia-update/data/usr/bin/buendia-update
@@ -61,7 +61,12 @@ if echo $packages | grep buendia-server; then
     buendia-db-migrate $from_version $to_version
     migration_failed=$?
 
-    if bool $migration_failed && bool "$UPDATE_FORCE_UPGRADE"; then
+    if bool $migration_failed; then
+        if ! bool "$UPDATE_FORCE_UPGRADE"; then
+            echo "--- MIGRATION FAILED FROM v${from_version} to v{$to_version}; EXITING"
+            exit $migration_failed
+        fi
+
         echo "--- Migration failed; performing forced upgrade"
         if [ -x /usr/bin/buendia-openmrs-dump ]; then
             echo "--- Dumping database v${from_version}"

--- a/packages/buendia-update/data/usr/share/buendia/site/10-update
+++ b/packages/buendia-update/data/usr/share/buendia/site/10-update
@@ -3,4 +3,4 @@ UPDATE_AUTOUPDATE=1
 
 # Don't automatically force database upgrades as this *will* destroy the
 # contents of your database when a migration is impossible!
-UPDATE_FORCE_UPGRADE=0
+UPDATE_DESTRUCTIVE_MIGRATION=0

--- a/packages/buendia-update/data/usr/share/buendia/site/10-update
+++ b/packages/buendia-update/data/usr/share/buendia/site/10-update
@@ -1,1 +1,6 @@
+# Automatically update all packages by default.
 UPDATE_AUTOUPDATE=1
+
+# Don't automatically force database upgrades as this *will* destroy the
+# contents of your database when a migration is impossible!
+UPDATE_FORCE_UPGRADE=0


### PR DESCRIPTION
Per @zestyping's [outline](https://buendia.slack.com/archives/C02T5LNMC/p1568690670015500), this PR adds a step to `buendia-update` which completely refreshes the database on demand, if migration to the latest version is not possible.

This feature is enabled with the `UPDATE_FORCE_UPGRADE` site setting and it **will destroy whatever is in the database** after backing up to `/var/backups/buendia`. Therefore this setting should be used _only_ on demo or testing sites where the contents of the database are not valuable.

This setting is enabled by default in the `buendia-site-cloud-demo` and `buendia-site-test-integration` sites.

This PR also includes a change to CI to use `buendia-update` to upgrade packages on the staging site.