### PR TITLE
Fix Wi-Fi watchdog behavior on NUC.

### DIFF
--- a/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
+++ b/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
@@ -43,26 +43,30 @@ if bool "$NETWORKING_AP"; then
     exit 1
 fi
 
-if [ -z "$NETWORKING_SSID" ]; then
-    echo "Not checking wifi: NETWORKING_SSID is unset."
+if [ -z "$NETWORKING_WIFI_INTERFACE" -o -z "$NETWORKING_SSID" ]; then
+    echo "Not checking wifi: NETWORKING_WIFI_INTERFACE or NETWORKING_SSID is unset."
     exit 1
 fi
 
-# The "wpa_cli" command tells us the status of the wifi client subsystem.
+# iwconfig will tell us if we're associated to an access point.
 tmpfile=/tmp/$(basename $0).$$
 trap 'rm -rf $tmpfile' EXIT
-wpa_cli status; true >$tmpfile 2>&1
-
+iwconfig $NETWORKING_WIFI_INTERFACE >$tmpfile 2>&1
 cat $tmpfile  # cause the output of wpa_cli status to appear in the log
 
-# If wpa_supplicant is not running at all, wpa_cli status will just contain
-# an error message.  If wpa_supplicant is up but not (yet) connected to an AP,
-# wpa_cli status will say that the state is something other than COMPLETED,
-# such as SCANNING or DISCONNECTED or ASSOCIATING.  In all of these cases, we
-# just want to restart the wifi connection.
-if ! grep -q wpa_state=COMPLETED $tmpfile; then
-    echo "Restarting wifi."
-    # "-f" means to force redoing network setup even though the network
-    # configuration settings haven't changed.
-    buendia-reconfigure -f networking
+# If we are associated to an access point, _and_ we have a broadcast address we
+# can ping, then we assume that the wifi network is up.
+if ! grep -q "Access Point: Not-Associated" $tmpfile; then
+    broadcast_address=$(ip route | grep "^[0-9\.]*/[0-9]* dev $NETWORKING_WIFI_INTERFACE" | cut -d/ -f1)
+    if [ -n "$broadcast_address" ] && ping -q -w1 -c1 -b $broadcast_address >/dev/null; then
+        # Success!
+        exit 0
+    fi
 fi
+
+# If we couldn't find an access point or someone on the local network, then
+# restart the networking stack.
+echo "Restarting wifi."
+# "-f" means to force redoing network setup even though the network
+# configuration settings haven't changed.
+buendia-reconfigure -f networking

--- a/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
+++ b/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
@@ -52,13 +52,13 @@ fi
 tmpfile=/tmp/$(basename $0).$$
 trap 'rm -rf $tmpfile' EXIT
 iwconfig $NETWORKING_WIFI_INTERFACE >$tmpfile 2>&1
-cat $tmpfile  # cause the output of wpa_cli status to appear in the log
 
 # If we are associated to an access point, _and_ we have a broadcast address we
 # can ping, then we assume that the wifi network is up.
 if ! grep -q "Access Point: Not-Associated" $tmpfile; then
     broadcast_address=$(ip route | grep "^[0-9\.]*/[0-9]* dev $NETWORKING_WIFI_INTERFACE" | cut -d/ -f1)
-    if [ -n "$broadcast_address" ] && ping -q -w1 -c1 -b $broadcast_address >/dev/null; then
+    echo "Broadcast address is ${broadcast_address:-not found}" >>$tmpfile
+    if [ -n "$broadcast_address" ] && ping -w1 -c1 -b $broadcast_address >>$tmpfile 2>&1; then
         # Success!
         exit 0
     fi
@@ -66,6 +66,8 @@ fi
 
 # If we couldn't find an access point or someone on the local network, then
 # restart the networking stack.
+echo "Network appears to be down:"
+cat $tmpfile
 echo "Restarting wifi."
 # "-f" means to force redoing network setup even though the network
 # configuration settings haven't changed.


### PR DESCRIPTION
Currently `buendia-wifi-watchdog` uses `wpa_cli status` to check the status of the wireless link; however, for unknown reasons, this command never reports that the Wi-Fi is connected on the NUC, even when it definitely is.

The consequence of this behavior was `buendia-networking` was causing the wireless connection to drop on the NUC for about 7-8 seconds out of every minute.

This PR changes `buendia-wifi-watchdog` under the hood to perform two checks each time it runs:

1. Run `iwconfig` and see if the `NETWORKING_WIFI_INTERFACE` is associated to an access point
2. If so, find the broadcast address for that interface, and ping it to see if any other hosts respond

If either of these checks fails, then `buendia-wifi-watchdog` will reconfigure the networking stack, which should cause the network to come back. I have tested both conditions manually on the NUC and both times the Wi-Fi came back online within 70 seconds as anticipated. Otherwise, when operating normally, the aforementioned network dropouts disappear as expected.