### PR TITLE
buendia-update-hosts restarts dnsmasq only when changes are detected.

### DIFF
--- a/packages/buendia-networking/control/control.template
+++ b/packages/buendia-networking/control/control.template
@@ -2,6 +2,6 @@ Package: ${PACKAGE_NAME}
 Version: ${PACKAGE_VERSION}
 Architecture: all
 Pre-Depends: buendia-utils
-Depends: cron-daemon, dnsmasq, hostapd, dhcpcd5, wpasupplicant
+Depends: cron-daemon, dnsmasq, hostapd, dhcpcd5, wpasupplicant, diffutils
 Description: Wifi AP and DHCP/DNS service for Buendia
 Maintainer: projectbuendia.org

--- a/packages/buendia-networking/data/usr/bin/buendia-update-hosts
+++ b/packages/buendia-networking/data/usr/bin/buendia-update-hosts
@@ -41,10 +41,12 @@ for ip in $(ip a | grep 'inet ' | cut -d' ' -f6 | cut -d/ -f1 | grep -v '^127\.'
     echo "$ip $names  # added by buendia-update-hosts" >> $tmp
 done
 
-# Install the new hosts file.
-mv $tmp /etc/hosts
+# Install the new hosts file, if it has changed.
+if ! diff -q $tmp /etc/hosts >/dev/null; then
+    mv $tmp /etc/hosts
 
-# Tell dnsmasq to reload the hosts file, if it's running.
-if [ -e /var/run/dnsmasq/dnsmasq.pid ]; then
-    service dnsmasq restart
+    # Tell dnsmasq to reload the hosts file, if it's running.
+    if [ -e /var/run/dnsmasq/dnsmasq.pid ]; then
+        service dnsmasq restart
+    fi
 fi


### PR DESCRIPTION
Previously buendia-update-hosts would overwrite `/etc/hosts` and restart dnsmasq whenever it was run, which is currently every minute via cron job. Now it uses diff(1) to see if it has made any substantive changes before overwriting the file and restarting the daemon.

Tested manually. Fixes #222.