### PR TITLE
Use CrawlerSessionManagerValve to keep API clients from blowing up the Tomcat session cache.

### DIFF
--- a/packages/buendia-tomcat7/data/usr/share/buendia/diversions/etc/tomcat7/server.xml
+++ b/packages/buendia-tomcat7/data/usr/share/buendia/diversions/etc/tomcat7/server.xml
@@ -134,6 +134,14 @@
         <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
         -->
 
+        <!-- CrawlerSessionManagerValve performs session management for clients
+             who won't return jsessionid cookies. Here we treat any client
+             whose user agent doesn't start with "Mozilla" as an API client,
+             which keeps the session cache from expanding at an unfortunate
+             rate and blowing out the heap. -->
+        <Valve className="org.apache.catalina.valves.CrawlerSessionManagerValve"
+            crawlerUserAgents="^(?!Mozilla).*" sessionInactiveInterval="300"/>
+
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->


### PR DESCRIPTION
We discovered, as reported in #225, that Tomcat 7 apparently creates a new session for (nearly?) every API request, and then hangs onto these sessions for a half hour, which can cause heavy usage of the Buendia client to cause `OutOfMemory` errors on the server.

This PR uses the stock `CrawlerSessionManagerValve` that comes with Tomcat 7 to synthesize a session ID for those clients who don't return one in a cookie. It's designed to make Tomcat more resilient to crawler requests, but it works just as well for us too. The consequence is that the JVM heap no longer grows with each API request.

Configuration of CrawlerSessionManagerValve is documented in the [Tomcat API reference](http://tomcat.apache.org/tomcat-7.0-doc/config/valve.html#Crawler_Session_Manager_Valve). Results from manual testing are documented in #225.

The `crawlerUserAgents` regex is chosen to include pretty much anything that isn't a web browser. Manual testing with this setting enabled demonstrates that use of the web UI is unaffected by it (at least, in Chrome, anyway, and probably virtually all other web browsers as well).

See https://stackoverflow.com/a/13495918 for details.

Fixes #225.