### PR TITLE
Revert PR #230 as authenticating under CrawlerSessionManagerValve opens a security risk

### DIFF
--- a/packages/buendia-tomcat7/data/usr/share/buendia/diversions/etc/tomcat7/server.xml
+++ b/packages/buendia-tomcat7/data/usr/share/buendia/diversions/etc/tomcat7/server.xml
@@ -134,14 +134,6 @@
         <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
         -->
 
-        <!-- CrawlerSessionManagerValve performs session management for clients
-             who won't return jsessionid cookies. Here we treat any client
-             whose user agent doesn't start with "Mozilla" as an API client,
-             which keeps the session cache from expanding at an unfortunate
-             rate and blowing out the heap. -->
-        <Valve className="org.apache.catalina.valves.CrawlerSessionManagerValve"
-            crawlerUserAgents="^(?!Mozilla).*" sessionInactiveInterval="300"/>
-
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->


### PR DESCRIPTION
The IP-address-based Tomcat session reuse enabled by
`CrawlerSessionManagerValve` in #230 unfortunately permits the following scenario:

1. Client A uses HTTP Basic Auth to authenticate to the API.
2. Client A departs from the network.
3. Client B connects to the API within 5 minutes, using the same IP address and user agent string as Client A, but without authenticating.
4. Client B is assigned Client A's session by `CrawlerSessionManagerValve`
and is now using Client A's credentials.

I think we can agree that this is not what we intended. Unfortunately I think it means we need to reopen #225 and come up with a more robust solution.