### PR TITLE
Fix dashboard auth test that was broken by PR #231

### DIFF
--- a/packages/buendia-dashboard/data/usr/share/buendia/tests/40-dashboard-running-safe
+++ b/packages/buendia-dashboard/data/usr/share/buendia/tests/40-dashboard-running-safe
@@ -12,12 +12,12 @@ test_20_dashboard_says_server_is_running () {
 }
 
 test_30_status_is_password_protected () {
-    curl -s -o /dev/null -w "%{http_code}" http://localhost:9999/status \
+    curl -s -o /dev/null -w "%{http_code}" http://localhost:9999/admin/status \
         | grep 401
 }
 
 test_30_status_works_with_credentials () {
     curl -s -o /dev/null -w "%{http_code}" \
-        http://$SERVER_OPENMRS_USER:$SERVER_OPENMRS_PASSWORD@localhost:9999/status \
+        http://$SERVER_OPENMRS_USER:$SERVER_OPENMRS_PASSWORD@localhost:9999/admin/status \
         | grep 200
 }


### PR DESCRIPTION
The changes to the dashboard URLs introduced in #231 broke the dashboard integration tests, and hence our CI pipeline. This PR fixes the tests to match the new functionality.

I take the fact that we didn't act on this information promptly as an indication that we should revisit the integration tests and pipeline to see what we need to make them useful to us as developers.

Merging because changes are purely test related. Tagging @zestyping FYI