### PR TITLE
Ensure that API methods that rely on ProjectBuendiaService get authenticated

### DIFF
--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/ProjectBuendiaService.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/ProjectBuendiaService.java
@@ -14,7 +14,10 @@ package org.projectbuendia.openmrs.api;
 import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.Patient;
+import org.openmrs.api.APIException;
 import org.openmrs.api.OpenmrsService;
+import org.openmrs.annotation.Authorized;
+import org.openmrs.util.PrivilegeConstants;
 import org.projectbuendia.openmrs.api.db.ProjectBuendiaDAO;
 import org.projectbuendia.openmrs.api.db.SyncPage;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,8 +49,10 @@ public interface ProjectBuendiaService extends OpenmrsService {
      * @param includeVoided if {@code true}, results will include voided observations.
      * @param maxResults the maximum number of results to fetch. If {@code <= 0}, returns all
      */
+    @Authorized(PrivilegeConstants.VIEW_OBS)
     SyncPage<Obs> getObservationsModifiedAtOrAfter(
-        @Nullable Bookmark bookmark, boolean includeVoided, int maxResults);
+        @Nullable Bookmark bookmark, boolean includeVoided, int maxResults)
+        throws APIException;
 
     /**
      * Returns all patients modified on or after the given {@code date}.
@@ -56,8 +61,10 @@ public interface ProjectBuendiaService extends OpenmrsService {
      * @param includeVoided if {@code true}, results will include voided patients.
      * @param maxResults the maximum number of results to fetch. If {@code <= 0}, returns all
      */
+    @Authorized(PrivilegeConstants.VIEW_PATIENTS)
     SyncPage<Patient> getPatientsModifiedAtOrAfter(
-        @Nullable Bookmark bookmark, boolean includeVoided, int maxResults);
+        @Nullable Bookmark bookmark, boolean includeVoided, int maxResults)
+        throws APIException;
 
     /**
      * Returns all orders modified on or after the given {@code date}.
@@ -68,7 +75,9 @@ public interface ProjectBuendiaService extends OpenmrsService {
      * @param allowedOrderTypes only order types specified in this whitelist will be fetched. If
      *                          null, all order types are permissible.
      */
+    @Authorized(PrivilegeConstants.VIEW_ORDERS)
     SyncPage<Order> getOrdersModifiedAtOrAfter(
         @Nullable Bookmark bookmark, boolean includeVoided, int maxResults,
-        @Nullable Order.Action[] allowedOrderTypes);
+        @Nullable Order.Action[] allowedOrderTypes)
+        throws APIException;
 }

--- a/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/impl/ProjectBuendiaServiceImpl.java
+++ b/openmrs/api/src/main/java/org/projectbuendia/openmrs/api/impl/ProjectBuendiaServiceImpl.java
@@ -16,6 +16,7 @@ import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.Patient;
+import org.openmrs.api.APIException;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.projectbuendia.openmrs.api.Bookmark;
 import org.projectbuendia.openmrs.api.ProjectBuendiaService;
@@ -42,20 +43,20 @@ public class ProjectBuendiaServiceImpl extends BaseOpenmrsService implements Pro
 
     @Override
     public SyncPage<Obs> getObservationsModifiedAtOrAfter(
-        @Nullable Bookmark bookmark, boolean includeVoided, int maxResults) {
+        @Nullable Bookmark bookmark, boolean includeVoided, int maxResults) throws APIException {
         return dao.getObservationsModifiedAfter(bookmark, includeVoided, maxResults);
     }
 
     @Override
     public SyncPage<Patient> getPatientsModifiedAtOrAfter(
-        @Nullable Bookmark bookmark, boolean includeVoided, int maxResults) {
+        @Nullable Bookmark bookmark, boolean includeVoided, int maxResults) throws APIException {
         return dao.getPatientsModifiedAfter(bookmark, includeVoided, maxResults);
     }
 
     @Override
     public SyncPage<Order> getOrdersModifiedAtOrAfter(
         @Nullable Bookmark bookmark, boolean includeVoided, int maxResults,
-        @Nullable Order.Action[] allowedOrderTypes) {
+        @Nullable Order.Action[] allowedOrderTypes) throws APIException {
         return dao.getOrdersModifiedAtOrAfter(
             bookmark, includeVoided, maxResults, allowedOrderTypes);
     }

--- a/packages/buendia-server/data/usr/share/buendia/tests/30-server-auth-safe
+++ b/packages/buendia-server/data/usr/share/buendia/tests/30-server-auth-safe
@@ -1,0 +1,22 @@
+endpoint_requires_auth () {
+    curl -s -o /dev/null -w "%{http_code}" \
+        http://localhost:9000/openmrs/ws/rest/buendia/$1 \
+        | grep 401
+}
+
+# This is an expected behavior of OpenMRS
+
+test_10_patients_requires_auth () {
+    endpoint_requires_auth patients
+}
+
+# The next two tests confirm that issue #223 has been fixed
+# https://github.com/projectbuendia/buendia/issues/223
+
+test_20_orders_requires_auth () {
+    endpoint_requires_auth orders
+}
+
+test_30_observations_requires_auth () {
+    endpoint_requires_auth observations
+}


### PR DESCRIPTION
Fixes #223 by adding `@Authorized` annotations to `ProjectBuendiaService`, following the example of `org.openmrs.api.PatientService` in [OpenMRS 1.10.x](https://github.com/openmrs/openmrs-core/blob/1.10.x/api/src/main/java/org/openmrs/api/PatientService.java#L148-L150).

Includes integration tests to confirm working functionality. These tests pass for me in Vagrant.