### PR TITLE
Check the hwclock on boot and disable the Buendia API if it has moved backwards since the last shutdown.

### DIFF
--- a/packages/buendia-utils/control/postinst
+++ b/packages/buendia-utils/control/postinst
@@ -19,6 +19,7 @@ case $1 in
             systemctl enable reboot-check.timer
             systemctl start reboot-check.timer
             systemctl enable buendia-reconfigure.service
+            systemctl enable buendia-init.service
         fi
 
         update-rc.d buendia-utils defaults

--- a/packages/buendia-utils/data/lib/systemd/system/buendia-init.service
+++ b/packages/buendia-utils/data/lib/systemd/system/buendia-init.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Buendia-specific system startup and shutdown
+DefaultDependencies=no
+After=systemd-modules-load.service
+
+# Make this unit start as early as possible during system startup.
+Before=sysinit.target
+
+# Make this unit stop as late as possible during system shutdown.
+Conflicts=umount.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/buendia-init start
+RemainAfterExit=yes
+ExecStop=/usr/bin/buendia-init stop
+
+[Install]
+WantedBy=sysinit.target

--- a/packages/buendia-utils/data/usr/bin/buendia-init
+++ b/packages/buendia-utils/data/usr/bin/buendia-init
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+LOG=/var/log/buendia/buendia-init.log
+HWCLOCK_FILE=/var/log/buendia/hwclock.final
+
+# Ensure no dependency on any environment variables, even PATH.
+export PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+action="$1"
+
+# Reports the date and time on the system clock to nanosecond precision.
+function nanodate() {
+    date +'%Y-%m-%d %H:%M:%S.%N'
+}
+
+# Saves the time reported by the hardware clock (for use during shutdown).
+function save_hwclock() {
+    hwclock -u > $HWCLOCK_FILE
+}
+
+# Checks the hardware clock to see if it has moved backwards since the last
+# shutdown, and if so, disables the Buendia API to prevent database corruption.
+#
+# Loss of battery power to the internal hardware clock can cause the clock to
+# reset to a time in the past.  If data is written to the database that is
+# timestamped in the past, it is not only invalid, but can also make Buendia
+# clients unusable.  Hence, in this eventuality, we disable the Buendia API.
+function check_hwclock() {
+    now=$(echo $(/sbin/hwclock -u))
+    final=$(echo $(cat $HWCLOCK_FILE))
+
+    if [[ "$now" < "$final" ]]; then
+        systemctl mask tomcat7
+        buendia-led pink 100  # system has entered an error state
+    else
+        systemctl unmask tomcat7
+    fi
+}
+
+if [ "$action" = "" ]; then
+    echo 'Usage: $0 <action>'
+    echo
+    echo 'This script performs system startup and shutdown steps for a Buendia'
+    echo 'system.  The systemd unit "buendia-init" should be configued to call'
+    echo 'this script as early as possible during system startup with "start"'
+    echo 'as the <action>, and as late as possible during system shutdown with'
+    echo '"stop" as the <action>.'
+    echo
+    echo 'This script is not intended to be run from a shell or a shell script.'
+    exit 1
+fi
+
+if [ "$action" = start ]; then
+    echo "start $(nanodate)" >> $LOG
+    buendia-led yellow 4  # boot has started
+    check_hwclock
+fi
+
+if [ "$action" = stop ]; then
+    echo "stop $(nanodate)" >> $LOG
+    save_hwclock
+    buendia-led red 4  # shutdown has completed
+fi


### PR DESCRIPTION
Closes: #226 

If the internal battery power is lost, it will reset the hardware clock.  To prevent the resulting catastrophic failure (which we experienced once during a demo in Bunia), this PR checks for this condition on boot and disables the Buendia API.  This doesn't automatically fix the problem, but at least we can fail safely and obviously so that a human will be prompted to investigate immediately.