### PR TITLE
Fix errors in buendia-backup when certain config paths don't exist yet.

### DIFF
--- a/packages/buendia-backup/data/usr/bin/buendia-backup
+++ b/packages/buendia-backup/data/usr/bin/buendia-backup
@@ -122,13 +122,10 @@ sleep 1  # ensure that keep has the uniquely lowest timestamp in the directory
 
 echo
 echo "Saving Buendia configuration..."
-tar cfz "$new_dir/buendia.tar.gz" \
-  --exclude '*.omod' \
-  /usr/share/buendia/counts \
-  /usr/share/buendia/distilled \
-  /usr/share/buendia/openmrs \
-  /usr/share/buendia/profiles \
-  /usr/share/buendia/site
+# Back up only those configuration directories which already exist; don't worry
+# about any which might be missing.
+config_paths=$(ls -d /usr/share/buendia/{counts,distilled,openmrs,profiles,site} || true)
+tar cfz "$new_dir/buendia.tar.gz" --exclude '*.omod' $config_paths
 ls -l "$new_dir/buendia.tar.gz"
 
 # ---- Back up the MySQL database.


### PR DESCRIPTION
`buendia-backup` assumes that certain directories exist when the Buendia configuration is backed up, and fails with an error if not. However, if those directories don't exist, there's nothing to back up per se -- this is definitely not a fatal error and shouldn't be treated as such.

This small change to `buendia-backup` addresses this situation and fixes #207.