### PR TITLE
Discard HTTP sessions during RestController.finish()

### DIFF
--- a/openmrs/omod/src/main/java/org/projectbuendia/openmrs/webservices/rest/RestController.java
+++ b/openmrs/omod/src/main/java/org/projectbuendia/openmrs/webservices/rest/RestController.java
@@ -39,6 +39,7 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 /**
  * Controller for the REST resources in this module. This implicitly picks up
@@ -107,7 +108,14 @@ public class RestController extends MainResourceController {
     }
 
     private void finish(HttpServletRequest request, HttpServletResponse response) {
-        // Nothing to do.
+        // Since we don't expect the REST client to return jsession ID cookies
+        // or URL parameters, we invalidate any extant session when finalizing
+        // the response. This way the servlet's session cache doesn't fill up
+        // with unused sessions and eventually grind to a halt.
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
     }
 
     @Override public SimpleObject handleException(Exception e, HttpServletRequest request, HttpServletResponse response) throws Exception {


### PR DESCRIPTION
Since REST clients don't reuse Java servlet HTTP sessions, make sure that we always invalidate the current session (if any), to prevent the session cache from filling up and bogging down the servlet container.

Tested using `tools/stress` and `jmap -histo:live` as described in the [comments to #225](https://github.com/projectbuendia/buendia/issues/225#issuecomment-543907168). The `jmap` output looks good after 11,000 requests, and request response times are nominal.

Has no impact on regular user logins via the web interface. Tested by logging into OpenMRS and then waiting 20 minutes to see if I was still logged in, as expected.

Ran the integration tests manually in Vagrant. All pass.

Fixes #225 hopefully once and for all.