### PR TITLE
Remove dhcpcd usage from buendia-networking

### DIFF
--- a/packages/buendia-networking/control/control.template
+++ b/packages/buendia-networking/control/control.template
@@ -2,6 +2,6 @@ Package: ${PACKAGE_NAME}
 Version: ${PACKAGE_VERSION}
 Architecture: all
 Pre-Depends: buendia-utils
-Depends: cron-daemon, dnsmasq, hostapd, dhcpcd5, wpasupplicant, diffutils
+Depends: cron-daemon, dnsmasq, hostapd, wpasupplicant, diffutils
 Description: Wifi AP and DHCP/DNS service for Buendia
 Maintainer: projectbuendia.org

--- a/packages/buendia-networking/control/control.template
+++ b/packages/buendia-networking/control/control.template
@@ -2,6 +2,6 @@ Package: ${PACKAGE_NAME}
 Version: ${PACKAGE_VERSION}
 Architecture: all
 Pre-Depends: buendia-utils
-Depends: cron-daemon, dnsmasq, hostapd, wpasupplicant, diffutils
+Depends: cron-daemon, dnsmasq, hostapd, wpasupplicant, diffutils, buendia-monitoring
 Description: Wifi AP and DHCP/DNS service for Buendia
 Maintainer: projectbuendia.org

--- a/packages/buendia-networking/control/postinst
+++ b/packages/buendia-networking/control/postinst
@@ -21,7 +21,6 @@ case $1 in
     configure)
         interface_conf=/etc/network/interfaces
         hostapd_conf=/etc/hostapd/hostapd.conf
-        dhcpd_conf=/etc/dhcpcd.conf
 
         # Save a copy of the original configuration files.
         divert() {
@@ -31,7 +30,12 @@ case $1 in
         }
         divert $interface_conf
         divert $hostapd_conf
-        divert $dhcpd_conf
+
+        # Disable dhcpcd if it was already running
+        if systemctl status dhcpcd >/dev/null; then
+            systemctl stop dhcpcd || true
+            systemctl disable dhcpcd || true
+        fi
 
         systemctl daemon-reload
 

--- a/packages/buendia-networking/control/prerm
+++ b/packages/buendia-networking/control/prerm
@@ -38,8 +38,6 @@ case $1 in
         systemctl stop hostapd || true
         service dnsmasq stop
         update-rc.d dnsmasq disable
-        systemctl enable dhcpcd
-        systemctl start dhcpcd || true
         touch /var/run/reboot-required
         ;;
 

--- a/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
+++ b/packages/buendia-networking/data/usr/share/buendia/config.d/10-networking
@@ -109,12 +109,6 @@ configure_wifi () {
 
     echo "Joining existing wifi network '$NETWORKING_SSID'."
 
-    # Enable the wpa_supplicant hook
-    mkdir -p /usr/lib/dhcpcd/dhcpcd-hooks
-    if [[ ! -f /usr/share/dhcpcd/hooks/10-wpa_supplicant ]]; then
-      ln -s /usr/share/dhcpcd/hooks/10-wpa_supplicant /usr/lib/dhcpcd/dhcpcd-hooks/
-    fi
-
     # Tell wpa_supplicant where to get its credentials
     wpa_passphrase "$NETWORKING_SSID" "$NETWORKING_PASSWORD" > /etc/wpa_supplicant/wpa_supplicant.conf
     echo "wpa-conf /etc/wpa_supplicant/wpa_supplicant.conf" >> /etc/network/interfaces


### PR DESCRIPTION
Use of `dhcpcd` was added in 14bfde71 back in June, but it was never implemented in such a way as to replace `dhclient` (which Debian uses by default when implementing `/etc/network/interfaces`).

The vestiges of this change resulted in `dhcpcd` periodically and unexpectedly requesting DHCP leases on interfaces when `buendia-networking` was not configured to do so. This PR removes dhcpcd support from `buendia-networking`.

Tested by rebooting a NUC repeatedly with site settings configured for either DHCP or static IP addresses on the Wi-Fi and ensuring that DHCP leases are only requested when `buendia-networking` is configured for it.

Also included is a minor fix to ensure that `buendia-monitoring` is present since `buendia-wifi-watchdog` is run by `cron` using `buendia-log`.


