### PR TITLE
Shorten buendia-wifi-watchdog delay to ensure that Wi-Fi comes up faster

### DIFF
--- a/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
+++ b/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
@@ -30,7 +30,7 @@ fi
 
 # If it's only been a couple of minutes since boot, the server is still coming
 # up; don't expect networking to be up yet.
-min_upsecs=180
+min_upsecs=${NETWORKING_WATCHDOG_MIN_UPTIME:-15}
 upsecs=$(grep -o '[0-9]\+' /proc/uptime | head -1)
 if [ "$upsecs" -lt "$min_upsecs" ]; then
     echo "Not checking wifi: uptime ($upsecs s) has not reached $min_upsecs s yet."


### PR DESCRIPTION
Add `NETWORKING_WATCHDOG_MIN_UPTIME` setting to `buendia-wifi-watchdog`, and default to 15s, as a workaround to shorten latency on wifi initialization on the NUC. This delay was chosen after observing system network configuration on the NUC to not take longer than 7-8s from kernel boot via syslogs from a number of Buendia installations.

Tested fairly extensively on the NUC with Wi-Fi both on static and DHCP-assigned addresses.

Improves the situation with #246 but is perhaps not a permanent fix.