### PR TITLE
Robustness improvements to buendia-wifi-watchdog

### DIFF
--- a/packages/buendia-networking/control/control.template
+++ b/packages/buendia-networking/control/control.template
@@ -2,6 +2,6 @@ Package: ${PACKAGE_NAME}
 Version: ${PACKAGE_VERSION}
 Architecture: all
 Pre-Depends: buendia-utils
-Depends: cron-daemon, dnsmasq, hostapd, wpasupplicant, diffutils, buendia-monitoring
+Depends: cron-daemon, dnsmasq, hostapd, wpasupplicant, wireless-tools, diffutils, buendia-monitoring
 Description: Wifi AP and DHCP/DNS service for Buendia
 Maintainer: projectbuendia.org

--- a/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
+++ b/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
@@ -51,17 +51,15 @@ fi
 # The "wpa_cli" command tells us the status of the wifi client subsystem.
 tmpfile=/tmp/$(basename $0).$$
 trap 'rm -rf $tmpfile' EXIT
-echo wpa_cli -i $NETWORKING_WIFI_INTERFACE status
-wpa_cli -i $NETWORKING_WIFI_INTERFACE status >$tmpfile 2>&1 || true
+echo iwconfig $NETWORKING_WIFI_INTERFACE
+iwconfig $NETWORKING_WIFI_INTERFACE >$tmpfile 2>&1 || true
 
 cat $tmpfile  # cause the output of wpa_cli status to appear in the log
 
-# If wpa_supplicant is not running at all, wpa_cli status will just contain
-# an error message.  If wpa_supplicant is up but not (yet) connected to an AP,
-# wpa_cli status will say that the state is something other than COMPLETED,
-# such as SCANNING or DISCONNECTED or ASSOCIATING.  In all of these cases, we
-# just want to restart the wifi connection.
-if ! grep -q wpa_state=COMPLETED $tmpfile; then
+# If the wifi interface is associated to an access point, then iwconfig will
+# return the MAC address of the access point. If we can't see it, then let's
+# try reconfiguring the network to get us associated.
+if ! grep -Eq "Access Point: [0-9A-F]{2}:" $tmpfile; then
     echo "Restarting wifi."
     # "-f" means to force redoing network setup even though the network
     # configuration settings haven't changed.

--- a/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
+++ b/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
@@ -48,18 +48,22 @@ if [ -z "$NETWORKING_SSID" ]; then
     exit 1
 fi
 
-# The "wpa_cli" command tells us the status of the wifi client subsystem.
 tmpfile=/tmp/$(basename $0).$$
 trap 'rm -rf $tmpfile' EXIT
-echo iwconfig $NETWORKING_WIFI_INTERFACE
-iwconfig $NETWORKING_WIFI_INTERFACE >$tmpfile 2>&1 || true
-
-cat $tmpfile  # cause the output of wpa_cli status to appear in the log
+# Use tee to ensure that the output goes both to $tmpfile and the cron log
+(
+    echo iwconfig $NETWORKING_WIFI_INTERFACE
+    iwconfig $NETWORKING_WIFI_INTERFACE
+    echo ip a show dev $NETWORKING_WIFI_INTERFACE
+    ip address show dev $NETWORKING_WIFI_INTERFACE 
+) 2>&1 | tee $tmpfile || true
 
 # If the wifi interface is associated to an access point, then iwconfig will
-# return the MAC address of the access point. If we can't see it, then let's
-# try reconfiguring the network to get us associated.
-if ! grep -Eq "Access Point: [0-9A-F]{2}:" $tmpfile; then
+# return the MAC address of the access point. If the wifi interface has an IP
+# address, then the ip command will report "state UP". If either condition is
+# false, try reconfiguring the network to get us associated.
+if ! grep -Eq "Access Point: [0-9A-F]{2}:" $tmpfile || \
+   ! grep -q "state UP" $tmpfile; then
     echo "Restarting wifi."
     # "-f" means to force redoing network setup even though the network
     # configuration settings haven't changed.

--- a/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
+++ b/packages/buendia-networking/data/usr/bin/buendia-wifi-watchdog
@@ -37,6 +37,11 @@ if [ "$upsecs" -lt "$min_upsecs" ]; then
     exit 1
 fi
 
+if [ -z "$NETWORKING_WIFI_INTERFACE" ]; then
+    echo "Not checking wifi: no interface defined in site configuration."
+    exit 1
+fi
+
 # The observed problem occurs when the server is a wifi client, not a wifi AP.
 if bool "$NETWORKING_AP"; then
     echo "Not checking wifi: server is an AP creating its own wifi network."


### PR DESCRIPTION
Some improvements to `buendia-wifi-watchdog` made while testing #247 in the hopes of making it more robust:

* skip running if no wifi interface is configured
* use `iwconfig` rather than `wpa_cli` to ensure that what we're looking at is network association, and ensure that `wireless-tools` is required by the package
* use `ip` to check that we actually have an IP address

Tested on the NUC by watching `buendia-wifi-watchdog.log` for several minutes, both with the network unconfigured and subsequently configured, to ensure the desired behavior. Also tested with and without a wifi interface defined. Performed same manual tests across multiple boots for confirmation.